### PR TITLE
The ThingsBoard logo should be displayed as a favicon.

### DIFF
--- a/lib/utils/services/notification_service.dart
+++ b/lib/utils/services/notification_service.dart
@@ -90,7 +90,7 @@ class NotificationService {
 
   Future<void> _initFlutterLocalNotificationsPlugin() async {
     const initializationSettingsAndroid =
-        AndroidInitializationSettings('@mipmap/launcher_icon');
+        AndroidInitializationSettings('@mipmap/thingsboard');
 
     const initializationSettingsIOS = DarwinInitializationSettings();
 


### PR DESCRIPTION
![Screenshot_20240222-100541](https://github.com/thingsboard/flutter_thingsboard_pe_app/assets/10604455/701e4a60-878f-42ce-8cbe-25dac21a16f5)
