### PR TITLE
[WIP] feat: multi-select notifications with batch delete and mark as read

### DIFF
--- a/lib/generated/intl/messages_ar.dart
+++ b/lib/generated/intl/messages_ar.dart
@@ -57,40 +57,43 @@ class MessageLookup extends MessageLookupByLibrary {
 
   static String m13(error) => "خطأ في إرسال الرمز: ${error}";
 
-  static String m14(count) => "${count} محدد";
+  static String m14(count) =>
+      "${Intl.plural(count, one: 'فشلت عملية واحدة', other: 'فشلت ${count} عمليات')}";
 
-  static String m15(count) =>
+  static String m15(count) => "${count} محدد";
+
+  static String m16(count) =>
       "${Intl.plural(count, one: 'إشعار', other: 'إشعارات')}";
 
-  static String m16(permissions) =>
+  static String m17(permissions) =>
       "ليس لديك أذونات كافية لـ \"${permissions}\" للمتابعة. يرجى فتح إعدادات التطبيق ومنح الأذونات والضغط على \"حاول مرة أخرى\".";
 
-  static String m17(permissions) =>
+  static String m18(permissions) =>
       "ليس لديك أذونات كافية لـ \"${permissions}\" للمتابعة. يرجى منح الأذونات المطلوبة والضغط على \"حاول مرة أخرى\".";
 
-  static String m18(deviceName) =>
+  static String m19(deviceName) =>
       "أدخل رقم PIN الخاص بـ ${deviceName} لتأكيد إثبات الحيازة";
 
-  static String m19(time) =>
+  static String m20(time) =>
       "إعادة إرسال الرمز في ${Intl.plural(time, one: 'ثانية واحدة', other: '${time} ثواني')}";
 
-  static String m20(name) => "المسار غير محدد: ${name}";
+  static String m21(name) => "المسار غير محدد: ${name}";
 
-  static String m21(count) =>
+  static String m22(count) =>
       "${Intl.plural(count, one: 'البحث عن مستخدم', other: 'البحث عن مستخدمين')}";
 
-  static String m22(contact) =>
+  static String m23(contact) =>
       "تم إرسال رمز أمني إلى هاتفك على الرقم ${contact}.";
 
-  static String m23(name) =>
+  static String m24(name) =>
       "تعذر الاتصال بـ Wi-Fi لأن الجهاز ${name} لم يجد شبكات";
 
-  static String m24(version) => "تحديث إلى ${version}";
+  static String m25(version) => "تحديث إلى ${version}";
 
-  static String m25(deviceName) =>
+  static String m26(deviceName) =>
       "لمتابعة إعداد جهازك ${deviceName}، يرجى تقديم بيانات اعتماد الشبكة الخاصة بك.";
 
-  static String m26(network) => "أدخل كلمة المرور لـ ${network}";
+  static String m27(network) => "أدخل كلمة المرور لـ ${network}";
 
   final messages = _notInlinedMessages(_notInlinedMessages);
   static Map<String, Function> _notInlinedMessages(_) => <String, Function>{
@@ -441,6 +444,7 @@ class MessageLookup extends MessageLookupByLibrary {
     "failedToLoadTheList": MessageLookupByLibrary.simpleMessage(
       "فشل في تحميل القائمة",
     ),
+    "failedToPerformOperation": m14,
     "failedToSaveImage": MessageLookupByLibrary.simpleMessage(
       "فشل في حفظ الصورة",
     ),
@@ -536,7 +540,7 @@ class MessageLookup extends MessageLookupByLibrary {
           "يجب تكوين لوحة المعلومات المحمولة في ملف تعريف الجهاز!",
         ),
     "more": MessageLookupByLibrary.simpleMessage("المزيد"),
-    "nSelected": m14,
+    "nSelected": m15,
     "newPassword": MessageLookupByLibrary.simpleMessage("كلمة المرور الجديدة"),
     "newPassword2": MessageLookupByLibrary.simpleMessage(
       "تأكيد كلمة المرور الجديدة",
@@ -577,12 +581,12 @@ class MessageLookup extends MessageLookupByLibrary {
     "notificationTemplate": MessageLookupByLibrary.simpleMessage(
       "قالب الإشعار",
     ),
-    "notifications": m15,
+    "notifications": m16,
     "oauth2Client": MessageLookupByLibrary.simpleMessage("عميل OAuth2"),
     "openAppSettings": MessageLookupByLibrary.simpleMessage(
       "فتح إعدادات التطبيق",
     ),
-    "openAppSettingsToGrantPermissionMessage": m16,
+    "openAppSettingsToGrantPermissionMessage": m17,
     "openSettingsAndGrantAccessToCameraToContinue":
         MessageLookupByLibrary.simpleMessage(
           "افتح الإعدادات ومنح الوصول للكاميرا للمتابعة",
@@ -617,7 +621,7 @@ class MessageLookup extends MessageLookupByLibrary {
       "تم تغيير كلمة المرور بنجاح",
     ),
     "permissions": MessageLookupByLibrary.simpleMessage("الأذونات"),
-    "permissionsNotEnoughMessage": m17,
+    "permissionsNotEnoughMessage": m18,
     "phone": MessageLookupByLibrary.simpleMessage("الهاتف"),
     "phoneIsInvalid": MessageLookupByLibrary.simpleMessage(
       "رقم الهاتف غير صالح",
@@ -640,7 +644,7 @@ class MessageLookup extends MessageLookupByLibrary {
       "يرجى مسح رمز QR على جهازك",
     ),
     "plusAlarmType": MessageLookupByLibrary.simpleMessage("+ نوع تنبيه"),
-    "popTitle": m18,
+    "popTitle": m19,
     "postalCode": MessageLookupByLibrary.simpleMessage("الرمز البريدي"),
     "privacyPolicy": MessageLookupByLibrary.simpleMessage("سياسة الخصوصية"),
     "profile": MessageLookupByLibrary.simpleMessage("الملف الشخصي"),
@@ -669,7 +673,7 @@ class MessageLookup extends MessageLookupByLibrary {
     ),
     "resend": MessageLookupByLibrary.simpleMessage("إعادة إرسال"),
     "resendCode": MessageLookupByLibrary.simpleMessage("إعادة إرسال الرمز"),
-    "resendCodeWait": m19,
+    "resendCodeWait": m20,
     "reset": MessageLookupByLibrary.simpleMessage("إعادة تعيين"),
     "retry": MessageLookupByLibrary.simpleMessage("إعادة المحاولة"),
     "returnToDashboard": MessageLookupByLibrary.simpleMessage(
@@ -679,7 +683,7 @@ class MessageLookup extends MessageLookupByLibrary {
       "عد إلى التطبيق واضغط على زر جاهز",
     ),
     "role": MessageLookupByLibrary.simpleMessage("دور"),
-    "routeNotDefined": m20,
+    "routeNotDefined": m21,
     "rpc": MessageLookupByLibrary.simpleMessage("RPC"),
     "ruleChain": MessageLookupByLibrary.simpleMessage("سلسلة القواعد"),
     "ruleNode": MessageLookupByLibrary.simpleMessage("عقدة القواعد"),
@@ -688,7 +692,7 @@ class MessageLookup extends MessageLookupByLibrary {
     "schedulerEvent": MessageLookupByLibrary.simpleMessage("حدث المجدول"),
     "search": MessageLookupByLibrary.simpleMessage("بحث"),
     "searchResults": MessageLookupByLibrary.simpleMessage("نتائج البحث"),
-    "searchUsers": m21,
+    "searchUsers": m22,
     "seconds": MessageLookupByLibrary.simpleMessage("ثواني"),
     "security": MessageLookupByLibrary.simpleMessage("الأمان"),
     "selectAll": MessageLookupByLibrary.simpleMessage("تحديد الكل"),
@@ -715,7 +719,7 @@ class MessageLookup extends MessageLookupByLibrary {
     "severity": MessageLookupByLibrary.simpleMessage("الخطورة"),
     "signIn": MessageLookupByLibrary.simpleMessage("تسجيل الدخول"),
     "signUp": MessageLookupByLibrary.simpleMessage("التسجيل"),
-    "smsAuthDescription": m22,
+    "smsAuthDescription": m23,
     "smsAuthPlaceholder": MessageLookupByLibrary.simpleMessage("رمز SMS"),
     "smsSetupSuccessDescription": MessageLookupByLibrary.simpleMessage(
       "في المرة القادمة التي تسجل فيها الدخول، سيُطلب منك إدخال رمز الأمان المرسل إلى رقم الهاتف",
@@ -775,7 +779,7 @@ class MessageLookup extends MessageLookupByLibrary {
     "unableConnectToDevice": MessageLookupByLibrary.simpleMessage(
       "تعذر الاتصال بالجهاز",
     ),
-    "unableConnectToWifiBecauseNetworksWasntFoundByDevice": m23,
+    "unableConnectToWifiBecauseNetworksWasntFoundByDevice": m24,
     "unableToUseCamera": MessageLookupByLibrary.simpleMessage(
       "غير قادر على استخدام الكاميرا",
     ),
@@ -789,7 +793,7 @@ class MessageLookup extends MessageLookupByLibrary {
     ),
     "update": MessageLookupByLibrary.simpleMessage("تحديث"),
     "updateRequired": MessageLookupByLibrary.simpleMessage("تحديث مطلوب"),
-    "updateTo": m24,
+    "updateTo": m25,
     "url": MessageLookupByLibrary.simpleMessage("رابط"),
     "user": MessageLookupByLibrary.simpleMessage("المستخدم"),
     "username": MessageLookupByLibrary.simpleMessage("اسم المستخدم"),
@@ -812,9 +816,9 @@ class MessageLookup extends MessageLookupByLibrary {
     "warning": MessageLookupByLibrary.simpleMessage("تحذير"),
     "widgetType": MessageLookupByLibrary.simpleMessage("نوع الأداة"),
     "widgetsBundle": MessageLookupByLibrary.simpleMessage("حزمة الأدوات"),
-    "wifiHelpMessage": m25,
+    "wifiHelpMessage": m26,
     "wifiPassword": MessageLookupByLibrary.simpleMessage("كلمة مرور Wi-Fi"),
-    "wifiPasswordMessage": m26,
+    "wifiPasswordMessage": m27,
     "yes": MessageLookupByLibrary.simpleMessage("نعم"),
     "yesDeactivate": MessageLookupByLibrary.simpleMessage("نعم، تعطيل"),
     "yesDiscard": MessageLookupByLibrary.simpleMessage("نعم، تجاهل"),

--- a/lib/generated/intl/messages_ar.dart
+++ b/lib/generated/intl/messages_ar.dart
@@ -57,38 +57,40 @@ class MessageLookup extends MessageLookupByLibrary {
 
   static String m13(error) => "خطأ في إرسال الرمز: ${error}";
 
-  static String m14(count) =>
+  static String m14(count) => "${count} محدد";
+
+  static String m15(count) =>
       "${Intl.plural(count, one: 'إشعار', other: 'إشعارات')}";
 
-  static String m15(permissions) =>
+  static String m16(permissions) =>
       "ليس لديك أذونات كافية لـ \"${permissions}\" للمتابعة. يرجى فتح إعدادات التطبيق ومنح الأذونات والضغط على \"حاول مرة أخرى\".";
 
-  static String m16(permissions) =>
+  static String m17(permissions) =>
       "ليس لديك أذونات كافية لـ \"${permissions}\" للمتابعة. يرجى منح الأذونات المطلوبة والضغط على \"حاول مرة أخرى\".";
 
-  static String m17(deviceName) =>
+  static String m18(deviceName) =>
       "أدخل رقم PIN الخاص بـ ${deviceName} لتأكيد إثبات الحيازة";
 
-  static String m18(time) =>
+  static String m19(time) =>
       "إعادة إرسال الرمز في ${Intl.plural(time, one: 'ثانية واحدة', other: '${time} ثواني')}";
 
-  static String m19(name) => "المسار غير محدد: ${name}";
+  static String m20(name) => "المسار غير محدد: ${name}";
 
-  static String m20(count) =>
+  static String m21(count) =>
       "${Intl.plural(count, one: 'البحث عن مستخدم', other: 'البحث عن مستخدمين')}";
 
-  static String m21(contact) =>
+  static String m22(contact) =>
       "تم إرسال رمز أمني إلى هاتفك على الرقم ${contact}.";
 
-  static String m22(name) =>
+  static String m23(name) =>
       "تعذر الاتصال بـ Wi-Fi لأن الجهاز ${name} لم يجد شبكات";
 
-  static String m23(version) => "تحديث إلى ${version}";
+  static String m24(version) => "تحديث إلى ${version}";
 
-  static String m24(deviceName) =>
+  static String m25(deviceName) =>
       "لمتابعة إعداد جهازك ${deviceName}، يرجى تقديم بيانات اعتماد الشبكة الخاصة بك.";
 
-  static String m25(network) => "أدخل كلمة المرور لـ ${network}";
+  static String m26(network) => "أدخل كلمة المرور لـ ${network}";
 
   final messages = _notInlinedMessages(_notInlinedMessages);
   static Map<String, Function> _notInlinedMessages(_) => <String, Function>{
@@ -534,6 +536,7 @@ class MessageLookup extends MessageLookupByLibrary {
           "يجب تكوين لوحة المعلومات المحمولة في ملف تعريف الجهاز!",
         ),
     "more": MessageLookupByLibrary.simpleMessage("المزيد"),
+    "nSelected": m14,
     "newPassword": MessageLookupByLibrary.simpleMessage("كلمة المرور الجديدة"),
     "newPassword2": MessageLookupByLibrary.simpleMessage(
       "تأكيد كلمة المرور الجديدة",
@@ -574,12 +577,12 @@ class MessageLookup extends MessageLookupByLibrary {
     "notificationTemplate": MessageLookupByLibrary.simpleMessage(
       "قالب الإشعار",
     ),
-    "notifications": m14,
+    "notifications": m15,
     "oauth2Client": MessageLookupByLibrary.simpleMessage("عميل OAuth2"),
     "openAppSettings": MessageLookupByLibrary.simpleMessage(
       "فتح إعدادات التطبيق",
     ),
-    "openAppSettingsToGrantPermissionMessage": m15,
+    "openAppSettingsToGrantPermissionMessage": m16,
     "openSettingsAndGrantAccessToCameraToContinue":
         MessageLookupByLibrary.simpleMessage(
           "افتح الإعدادات ومنح الوصول للكاميرا للمتابعة",
@@ -614,7 +617,7 @@ class MessageLookup extends MessageLookupByLibrary {
       "تم تغيير كلمة المرور بنجاح",
     ),
     "permissions": MessageLookupByLibrary.simpleMessage("الأذونات"),
-    "permissionsNotEnoughMessage": m16,
+    "permissionsNotEnoughMessage": m17,
     "phone": MessageLookupByLibrary.simpleMessage("الهاتف"),
     "phoneIsInvalid": MessageLookupByLibrary.simpleMessage(
       "رقم الهاتف غير صالح",
@@ -637,7 +640,7 @@ class MessageLookup extends MessageLookupByLibrary {
       "يرجى مسح رمز QR على جهازك",
     ),
     "plusAlarmType": MessageLookupByLibrary.simpleMessage("+ نوع تنبيه"),
-    "popTitle": m17,
+    "popTitle": m18,
     "postalCode": MessageLookupByLibrary.simpleMessage("الرمز البريدي"),
     "privacyPolicy": MessageLookupByLibrary.simpleMessage("سياسة الخصوصية"),
     "profile": MessageLookupByLibrary.simpleMessage("الملف الشخصي"),
@@ -666,7 +669,7 @@ class MessageLookup extends MessageLookupByLibrary {
     ),
     "resend": MessageLookupByLibrary.simpleMessage("إعادة إرسال"),
     "resendCode": MessageLookupByLibrary.simpleMessage("إعادة إرسال الرمز"),
-    "resendCodeWait": m18,
+    "resendCodeWait": m19,
     "reset": MessageLookupByLibrary.simpleMessage("إعادة تعيين"),
     "retry": MessageLookupByLibrary.simpleMessage("إعادة المحاولة"),
     "returnToDashboard": MessageLookupByLibrary.simpleMessage(
@@ -676,7 +679,7 @@ class MessageLookup extends MessageLookupByLibrary {
       "عد إلى التطبيق واضغط على زر جاهز",
     ),
     "role": MessageLookupByLibrary.simpleMessage("دور"),
-    "routeNotDefined": m19,
+    "routeNotDefined": m20,
     "rpc": MessageLookupByLibrary.simpleMessage("RPC"),
     "ruleChain": MessageLookupByLibrary.simpleMessage("سلسلة القواعد"),
     "ruleNode": MessageLookupByLibrary.simpleMessage("عقدة القواعد"),
@@ -685,9 +688,10 @@ class MessageLookup extends MessageLookupByLibrary {
     "schedulerEvent": MessageLookupByLibrary.simpleMessage("حدث المجدول"),
     "search": MessageLookupByLibrary.simpleMessage("بحث"),
     "searchResults": MessageLookupByLibrary.simpleMessage("نتائج البحث"),
-    "searchUsers": m20,
+    "searchUsers": m21,
     "seconds": MessageLookupByLibrary.simpleMessage("ثواني"),
     "security": MessageLookupByLibrary.simpleMessage("الأمان"),
+    "selectAll": MessageLookupByLibrary.simpleMessage("تحديد الكل"),
     "selectCountry": MessageLookupByLibrary.simpleMessage("اختيار البلد"),
     "selectRegion": MessageLookupByLibrary.simpleMessage("حدد المنطقة"),
     "selectUser": MessageLookupByLibrary.simpleMessage("اختيار المستخدمين"),
@@ -711,7 +715,7 @@ class MessageLookup extends MessageLookupByLibrary {
     "severity": MessageLookupByLibrary.simpleMessage("الخطورة"),
     "signIn": MessageLookupByLibrary.simpleMessage("تسجيل الدخول"),
     "signUp": MessageLookupByLibrary.simpleMessage("التسجيل"),
-    "smsAuthDescription": m21,
+    "smsAuthDescription": m22,
     "smsAuthPlaceholder": MessageLookupByLibrary.simpleMessage("رمز SMS"),
     "smsSetupSuccessDescription": MessageLookupByLibrary.simpleMessage(
       "في المرة القادمة التي تسجل فيها الدخول، سيُطلب منك إدخال رمز الأمان المرسل إلى رقم الهاتف",
@@ -771,7 +775,7 @@ class MessageLookup extends MessageLookupByLibrary {
     "unableConnectToDevice": MessageLookupByLibrary.simpleMessage(
       "تعذر الاتصال بالجهاز",
     ),
-    "unableConnectToWifiBecauseNetworksWasntFoundByDevice": m22,
+    "unableConnectToWifiBecauseNetworksWasntFoundByDevice": m23,
     "unableToUseCamera": MessageLookupByLibrary.simpleMessage(
       "غير قادر على استخدام الكاميرا",
     ),
@@ -785,7 +789,7 @@ class MessageLookup extends MessageLookupByLibrary {
     ),
     "update": MessageLookupByLibrary.simpleMessage("تحديث"),
     "updateRequired": MessageLookupByLibrary.simpleMessage("تحديث مطلوب"),
-    "updateTo": m23,
+    "updateTo": m24,
     "url": MessageLookupByLibrary.simpleMessage("رابط"),
     "user": MessageLookupByLibrary.simpleMessage("المستخدم"),
     "username": MessageLookupByLibrary.simpleMessage("اسم المستخدم"),
@@ -808,9 +812,9 @@ class MessageLookup extends MessageLookupByLibrary {
     "warning": MessageLookupByLibrary.simpleMessage("تحذير"),
     "widgetType": MessageLookupByLibrary.simpleMessage("نوع الأداة"),
     "widgetsBundle": MessageLookupByLibrary.simpleMessage("حزمة الأدوات"),
-    "wifiHelpMessage": m24,
+    "wifiHelpMessage": m25,
     "wifiPassword": MessageLookupByLibrary.simpleMessage("كلمة مرور Wi-Fi"),
-    "wifiPasswordMessage": m25,
+    "wifiPasswordMessage": m26,
     "yes": MessageLookupByLibrary.simpleMessage("نعم"),
     "yesDeactivate": MessageLookupByLibrary.simpleMessage("نعم، تعطيل"),
     "yesDiscard": MessageLookupByLibrary.simpleMessage("نعم، تجاهل"),

--- a/lib/generated/intl/messages_ar.dart
+++ b/lib/generated/intl/messages_ar.dart
@@ -46,54 +46,60 @@ class MessageLookup extends MessageLookupByLibrary {
       "${Intl.plural(count, one: 'لوحة معلومات', other: 'لوحات معلومات')}";
 
   static String m9(count) =>
+      "${Intl.plural(count, one: 'حذف إشعار واحد؟', other: 'حذف ${count} إشعارات؟')}";
+
+  static String m10(count) =>
       "${Intl.plural(count, one: 'جهاز', other: 'أجهزة')}";
 
-  static String m10(count) => "رمز من ${count} أرقام";
+  static String m11(count) => "رمز من ${count} أرقام";
 
-  static String m11(contact) =>
+  static String m12(contact) =>
       "تم إرسال رمز أمني إلى بريدك الإلكتروني على العنوان ${contact}.";
 
-  static String m12(e) => "حدث خطأ: ${e}";
+  static String m13(e) => "حدث خطأ: ${e}";
 
-  static String m13(error) => "خطأ في إرسال الرمز: ${error}";
+  static String m14(error) => "خطأ في إرسال الرمز: ${error}";
 
-  static String m14(count) =>
+  static String m15(count) =>
       "${Intl.plural(count, one: 'فشلت عملية واحدة', other: 'فشلت ${count} عمليات')}";
 
-  static String m15(count) => "${count} محدد";
-
   static String m16(count) =>
+      "${Intl.plural(count, one: 'وضع علامة مقروء لإشعار واحد؟', other: 'وضع علامة مقروء لـ ${count} إشعارات؟')}";
+
+  static String m17(count) => "${count} محدد";
+
+  static String m18(count) =>
       "${Intl.plural(count, one: 'إشعار', other: 'إشعارات')}";
 
-  static String m17(permissions) =>
+  static String m19(permissions) =>
       "ليس لديك أذونات كافية لـ \"${permissions}\" للمتابعة. يرجى فتح إعدادات التطبيق ومنح الأذونات والضغط على \"حاول مرة أخرى\".";
 
-  static String m18(permissions) =>
+  static String m20(permissions) =>
       "ليس لديك أذونات كافية لـ \"${permissions}\" للمتابعة. يرجى منح الأذونات المطلوبة والضغط على \"حاول مرة أخرى\".";
 
-  static String m19(deviceName) =>
+  static String m21(deviceName) =>
       "أدخل رقم PIN الخاص بـ ${deviceName} لتأكيد إثبات الحيازة";
 
-  static String m20(time) =>
+  static String m22(time) =>
       "إعادة إرسال الرمز في ${Intl.plural(time, one: 'ثانية واحدة', other: '${time} ثواني')}";
 
-  static String m21(name) => "المسار غير محدد: ${name}";
+  static String m23(name) => "المسار غير محدد: ${name}";
 
-  static String m22(count) =>
+  static String m24(count) =>
       "${Intl.plural(count, one: 'البحث عن مستخدم', other: 'البحث عن مستخدمين')}";
 
-  static String m23(contact) =>
+  static String m25(contact) =>
       "تم إرسال رمز أمني إلى هاتفك على الرقم ${contact}.";
 
-  static String m24(name) =>
+  static String m26(name) =>
       "تعذر الاتصال بـ Wi-Fi لأن الجهاز ${name} لم يجد شبكات";
 
-  static String m25(version) => "تحديث إلى ${version}";
+  static String m27(version) => "تحديث إلى ${version}";
 
-  static String m26(deviceName) =>
+  static String m28(deviceName) =>
       "لمتابعة إعداد جهازك ${deviceName}، يرجى تقديم بيانات اعتماد الشبكة الخاصة بك.";
 
-  static String m27(network) => "أدخل كلمة المرور لـ ${network}";
+  static String m29(network) => "أدخل كلمة المرور لـ ${network}";
 
   final messages = _notInlinedMessages(_notInlinedMessages);
   static Map<String, Function> _notInlinedMessages(_) => <String, Function>{
@@ -367,6 +373,7 @@ class MessageLookup extends MessageLookupByLibrary {
     "delete": MessageLookupByLibrary.simpleMessage("حذف"),
     "deleteAccount": MessageLookupByLibrary.simpleMessage("حذف الحساب"),
     "deleteComment": MessageLookupByLibrary.simpleMessage("حذف التعليق"),
+    "deleteSelectedNotifications": m9,
     "details": MessageLookupByLibrary.simpleMessage("التفاصيل"),
     "deviceList": MessageLookupByLibrary.simpleMessage("قائمة الأجهزة"),
     "deviceNotAbleToFindWifiNearby": MessageLookupByLibrary.simpleMessage(
@@ -377,8 +384,8 @@ class MessageLookup extends MessageLookupByLibrary {
     ),
     "deviceProfile": MessageLookupByLibrary.simpleMessage("ملف تعريف الجهاز"),
     "deviceProvisioning": MessageLookupByLibrary.simpleMessage("تهيئة الجهاز"),
-    "devices": m9,
-    "digitsCode": m10,
+    "devices": m10,
+    "digitsCode": m11,
     "discardChanges": MessageLookupByLibrary.simpleMessage("تجاهل التغييرات"),
     "domain": MessageLookupByLibrary.simpleMessage("النطاق"),
     "done": MessageLookupByLibrary.simpleMessage("تم"),
@@ -387,7 +394,7 @@ class MessageLookup extends MessageLookupByLibrary {
     "edit": MessageLookupByLibrary.simpleMessage("تحرير"),
     "edited": MessageLookupByLibrary.simpleMessage("محرر"),
     "email": MessageLookupByLibrary.simpleMessage("البريد الإلكتروني"),
-    "emailAuthDescription": m11,
+    "emailAuthDescription": m12,
     "emailAuthPlaceholder": MessageLookupByLibrary.simpleMessage(
       "رمز البريد الإلكتروني",
     ),
@@ -428,8 +435,8 @@ class MessageLookup extends MessageLookupByLibrary {
     "entityGroup": MessageLookupByLibrary.simpleMessage("مجموعة الكيانات"),
     "entityType": MessageLookupByLibrary.simpleMessage("نوع الكيان"),
     "entityView": MessageLookupByLibrary.simpleMessage("عرض الكيان"),
-    "errorOccured": m12,
-    "errorSendingCode": m13,
+    "errorOccured": m13,
+    "errorSendingCode": m14,
     "europe": MessageLookupByLibrary.simpleMessage("أوروبا"),
     "europeRegionShort": MessageLookupByLibrary.simpleMessage("فرانكفورت"),
     "exitDeviceProvisioning": MessageLookupByLibrary.simpleMessage(
@@ -444,7 +451,7 @@ class MessageLookup extends MessageLookupByLibrary {
     "failedToLoadTheList": MessageLookupByLibrary.simpleMessage(
       "فشل في تحميل القائمة",
     ),
-    "failedToPerformOperation": m14,
+    "failedToPerformOperation": m15,
     "failedToSaveImage": MessageLookupByLibrary.simpleMessage(
       "فشل في حفظ الصورة",
     ),
@@ -520,6 +527,7 @@ class MessageLookup extends MessageLookupByLibrary {
     "major": MessageLookupByLibrary.simpleMessage("رئيسي"),
     "markAllAsRead": MessageLookupByLibrary.simpleMessage("تحديد الكل كمقروء"),
     "markAsRead": MessageLookupByLibrary.simpleMessage("تحديد كمقروء"),
+    "markSelectedNotificationsAsRead": m16,
     "metricUnitSystem": MessageLookupByLibrary.simpleMessage("متري"),
     "mfaProviderBackupCode": MessageLookupByLibrary.simpleMessage(
       "الرمز الاحتياطي",
@@ -540,7 +548,7 @@ class MessageLookup extends MessageLookupByLibrary {
           "يجب تكوين لوحة المعلومات المحمولة في ملف تعريف الجهاز!",
         ),
     "more": MessageLookupByLibrary.simpleMessage("المزيد"),
-    "nSelected": m15,
+    "nSelected": m17,
     "newPassword": MessageLookupByLibrary.simpleMessage("كلمة المرور الجديدة"),
     "newPassword2": MessageLookupByLibrary.simpleMessage(
       "تأكيد كلمة المرور الجديدة",
@@ -581,12 +589,12 @@ class MessageLookup extends MessageLookupByLibrary {
     "notificationTemplate": MessageLookupByLibrary.simpleMessage(
       "قالب الإشعار",
     ),
-    "notifications": m16,
+    "notifications": m18,
     "oauth2Client": MessageLookupByLibrary.simpleMessage("عميل OAuth2"),
     "openAppSettings": MessageLookupByLibrary.simpleMessage(
       "فتح إعدادات التطبيق",
     ),
-    "openAppSettingsToGrantPermissionMessage": m17,
+    "openAppSettingsToGrantPermissionMessage": m19,
     "openSettingsAndGrantAccessToCameraToContinue":
         MessageLookupByLibrary.simpleMessage(
           "افتح الإعدادات ومنح الوصول للكاميرا للمتابعة",
@@ -621,7 +629,7 @@ class MessageLookup extends MessageLookupByLibrary {
       "تم تغيير كلمة المرور بنجاح",
     ),
     "permissions": MessageLookupByLibrary.simpleMessage("الأذونات"),
-    "permissionsNotEnoughMessage": m18,
+    "permissionsNotEnoughMessage": m20,
     "phone": MessageLookupByLibrary.simpleMessage("الهاتف"),
     "phoneIsInvalid": MessageLookupByLibrary.simpleMessage(
       "رقم الهاتف غير صالح",
@@ -644,7 +652,7 @@ class MessageLookup extends MessageLookupByLibrary {
       "يرجى مسح رمز QR على جهازك",
     ),
     "plusAlarmType": MessageLookupByLibrary.simpleMessage("+ نوع تنبيه"),
-    "popTitle": m19,
+    "popTitle": m21,
     "postalCode": MessageLookupByLibrary.simpleMessage("الرمز البريدي"),
     "privacyPolicy": MessageLookupByLibrary.simpleMessage("سياسة الخصوصية"),
     "profile": MessageLookupByLibrary.simpleMessage("الملف الشخصي"),
@@ -673,7 +681,7 @@ class MessageLookup extends MessageLookupByLibrary {
     ),
     "resend": MessageLookupByLibrary.simpleMessage("إعادة إرسال"),
     "resendCode": MessageLookupByLibrary.simpleMessage("إعادة إرسال الرمز"),
-    "resendCodeWait": m20,
+    "resendCodeWait": m22,
     "reset": MessageLookupByLibrary.simpleMessage("إعادة تعيين"),
     "retry": MessageLookupByLibrary.simpleMessage("إعادة المحاولة"),
     "returnToDashboard": MessageLookupByLibrary.simpleMessage(
@@ -683,7 +691,7 @@ class MessageLookup extends MessageLookupByLibrary {
       "عد إلى التطبيق واضغط على زر جاهز",
     ),
     "role": MessageLookupByLibrary.simpleMessage("دور"),
-    "routeNotDefined": m21,
+    "routeNotDefined": m23,
     "rpc": MessageLookupByLibrary.simpleMessage("RPC"),
     "ruleChain": MessageLookupByLibrary.simpleMessage("سلسلة القواعد"),
     "ruleNode": MessageLookupByLibrary.simpleMessage("عقدة القواعد"),
@@ -692,7 +700,7 @@ class MessageLookup extends MessageLookupByLibrary {
     "schedulerEvent": MessageLookupByLibrary.simpleMessage("حدث المجدول"),
     "search": MessageLookupByLibrary.simpleMessage("بحث"),
     "searchResults": MessageLookupByLibrary.simpleMessage("نتائج البحث"),
-    "searchUsers": m22,
+    "searchUsers": m24,
     "seconds": MessageLookupByLibrary.simpleMessage("ثواني"),
     "security": MessageLookupByLibrary.simpleMessage("الأمان"),
     "selectAll": MessageLookupByLibrary.simpleMessage("تحديد الكل"),
@@ -719,7 +727,7 @@ class MessageLookup extends MessageLookupByLibrary {
     "severity": MessageLookupByLibrary.simpleMessage("الخطورة"),
     "signIn": MessageLookupByLibrary.simpleMessage("تسجيل الدخول"),
     "signUp": MessageLookupByLibrary.simpleMessage("التسجيل"),
-    "smsAuthDescription": m23,
+    "smsAuthDescription": m25,
     "smsAuthPlaceholder": MessageLookupByLibrary.simpleMessage("رمز SMS"),
     "smsSetupSuccessDescription": MessageLookupByLibrary.simpleMessage(
       "في المرة القادمة التي تسجل فيها الدخول، سيُطلب منك إدخال رمز الأمان المرسل إلى رقم الهاتف",
@@ -779,7 +787,7 @@ class MessageLookup extends MessageLookupByLibrary {
     "unableConnectToDevice": MessageLookupByLibrary.simpleMessage(
       "تعذر الاتصال بالجهاز",
     ),
-    "unableConnectToWifiBecauseNetworksWasntFoundByDevice": m24,
+    "unableConnectToWifiBecauseNetworksWasntFoundByDevice": m26,
     "unableToUseCamera": MessageLookupByLibrary.simpleMessage(
       "غير قادر على استخدام الكاميرا",
     ),
@@ -793,7 +801,7 @@ class MessageLookup extends MessageLookupByLibrary {
     ),
     "update": MessageLookupByLibrary.simpleMessage("تحديث"),
     "updateRequired": MessageLookupByLibrary.simpleMessage("تحديث مطلوب"),
-    "updateTo": m25,
+    "updateTo": m27,
     "url": MessageLookupByLibrary.simpleMessage("رابط"),
     "user": MessageLookupByLibrary.simpleMessage("المستخدم"),
     "username": MessageLookupByLibrary.simpleMessage("اسم المستخدم"),
@@ -816,9 +824,9 @@ class MessageLookup extends MessageLookupByLibrary {
     "warning": MessageLookupByLibrary.simpleMessage("تحذير"),
     "widgetType": MessageLookupByLibrary.simpleMessage("نوع الأداة"),
     "widgetsBundle": MessageLookupByLibrary.simpleMessage("حزمة الأدوات"),
-    "wifiHelpMessage": m26,
+    "wifiHelpMessage": m28,
     "wifiPassword": MessageLookupByLibrary.simpleMessage("كلمة مرور Wi-Fi"),
-    "wifiPasswordMessage": m27,
+    "wifiPasswordMessage": m29,
     "yes": MessageLookupByLibrary.simpleMessage("نعم"),
     "yesDeactivate": MessageLookupByLibrary.simpleMessage("نعم، تعطيل"),
     "yesDiscard": MessageLookupByLibrary.simpleMessage("نعم، تجاهل"),

--- a/lib/generated/intl/messages_ar.dart
+++ b/lib/generated/intl/messages_ar.dart
@@ -703,7 +703,7 @@ class MessageLookup extends MessageLookupByLibrary {
     "searchUsers": m24,
     "seconds": MessageLookupByLibrary.simpleMessage("ثواني"),
     "security": MessageLookupByLibrary.simpleMessage("الأمان"),
-    "selectAll": MessageLookupByLibrary.simpleMessage("تحديد الكل"),
+    "selectAll": MessageLookupByLibrary.simpleMessage("تحديد الكل المحمّل"),
     "selectCountry": MessageLookupByLibrary.simpleMessage("اختيار البلد"),
     "selectRegion": MessageLookupByLibrary.simpleMessage("حدد المنطقة"),
     "selectUser": MessageLookupByLibrary.simpleMessage("اختيار المستخدمين"),

--- a/lib/generated/intl/messages_da_DK.dart
+++ b/lib/generated/intl/messages_da_DK.dart
@@ -59,40 +59,43 @@ class MessageLookup extends MessageLookupByLibrary {
 
   static String m13(error) => "Fejl ved afsendelse af kode: ${error}";
 
-  static String m14(count) => "${count} valgt";
+  static String m14(count) =>
+      "${Intl.plural(count, one: '1 handling mislykkedes', other: '${count} handlinger mislykkedes')}";
 
-  static String m15(count) =>
+  static String m15(count) => "${count} valgt";
+
+  static String m16(count) =>
       "${Intl.plural(count, one: 'Notifikation', other: 'Notifikationer')}";
 
-  static String m16(permissions) =>
+  static String m17(permissions) =>
       "Du har ikke tilstrækkelige tilladelser til \"${permissions}\" for at fortsætte. Åbn app-indstillingerne, giv tilladelser og tryk på \"Prøv igen\".";
 
-  static String m17(permissions) =>
+  static String m18(permissions) =>
       "Du har ikke tilstrækkelige tilladelser til \"${permissions}\" for at fortsætte. Giv de nødvendige tilladelser og tryk på \"Prøv igen\".";
 
-  static String m18(deviceName) =>
+  static String m19(deviceName) =>
       "Indtast PIN-kode for ${deviceName} for at bekræfte ejerskab";
 
-  static String m19(time) =>
+  static String m20(time) =>
       "Send kode igen om ${Intl.plural(time, one: '1 sekund', other: '${time} sekunder')}";
 
-  static String m20(name) => "Rute ikke defineret: ${name}";
+  static String m21(name) => "Rute ikke defineret: ${name}";
 
-  static String m21(count) =>
+  static String m22(count) =>
       "${Intl.plural(count, one: 'Søg bruger', other: 'Søg brugere')}";
 
-  static String m22(contact) =>
+  static String m23(contact) =>
       "En sikkerhedskode er blevet sendt til din telefon på ${contact}.";
 
-  static String m23(name) =>
+  static String m24(name) =>
       "Kan ikke oprette forbindelse til Wi-Fi, fordi netværk ikke blev fundet af enheden ${name}";
 
-  static String m24(version) => "Opdater til ${version}";
+  static String m25(version) => "Opdater til ${version}";
 
-  static String m25(deviceName) =>
+  static String m26(deviceName) =>
       "For at fortsætte opsætningen af din enhed ${deviceName}, skal du angive netværkets legitimationsoplysninger.";
 
-  static String m26(network) => "Indtast adgangskode til ${network}";
+  static String m27(network) => "Indtast adgangskode til ${network}";
 
   final messages = _notInlinedMessages(_notInlinedMessages);
   static Map<String, Function> _notInlinedMessages(_) => <String, Function>{
@@ -447,6 +450,7 @@ class MessageLookup extends MessageLookupByLibrary {
     "failedToLoadTheList": MessageLookupByLibrary.simpleMessage(
       "Kunne ikke indlæse listen",
     ),
+    "failedToPerformOperation": m14,
     "failedToSaveImage": MessageLookupByLibrary.simpleMessage(
       "Kunne ikke gemme billede",
     ),
@@ -540,7 +544,7 @@ class MessageLookup extends MessageLookupByLibrary {
           "Mobilt dashboard skal konfigureres i enhedsprofilen!",
         ),
     "more": MessageLookupByLibrary.simpleMessage("Mere"),
-    "nSelected": m14,
+    "nSelected": m15,
     "newPassword": MessageLookupByLibrary.simpleMessage("Ny adgangskode"),
     "newPassword2": MessageLookupByLibrary.simpleMessage(
       "Bekræft ny adgangskode",
@@ -589,12 +593,12 @@ class MessageLookup extends MessageLookupByLibrary {
     "notificationTemplate": MessageLookupByLibrary.simpleMessage(
       "Notifikationsskabelon",
     ),
-    "notifications": m15,
+    "notifications": m16,
     "oauth2Client": MessageLookupByLibrary.simpleMessage("OAuth2-klient"),
     "openAppSettings": MessageLookupByLibrary.simpleMessage(
       "Åbn app-indstillinger",
     ),
-    "openAppSettingsToGrantPermissionMessage": m16,
+    "openAppSettingsToGrantPermissionMessage": m17,
     "openSettingsAndGrantAccessToCameraToContinue":
         MessageLookupByLibrary.simpleMessage(
           "Åbn indstillinger og giv adgang til kameraet for at fortsætte",
@@ -629,7 +633,7 @@ class MessageLookup extends MessageLookupByLibrary {
       "Adgangskoden blev ændret",
     ),
     "permissions": MessageLookupByLibrary.simpleMessage("Tilladelser"),
-    "permissionsNotEnoughMessage": m17,
+    "permissionsNotEnoughMessage": m18,
     "phone": MessageLookupByLibrary.simpleMessage("Telefon"),
     "phoneIsInvalid": MessageLookupByLibrary.simpleMessage(
       "Telefonnummer er ugyldigt",
@@ -656,7 +660,7 @@ class MessageLookup extends MessageLookupByLibrary {
       "Scan venligst QR-koden på din enhed",
     ),
     "plusAlarmType": MessageLookupByLibrary.simpleMessage("+ Alarmtype"),
-    "popTitle": m18,
+    "popTitle": m19,
     "postalCode": MessageLookupByLibrary.simpleMessage("Postnummer"),
     "privacyPolicy": MessageLookupByLibrary.simpleMessage("Privatlivspolitik"),
     "profile": MessageLookupByLibrary.simpleMessage("Profil"),
@@ -685,7 +689,7 @@ class MessageLookup extends MessageLookupByLibrary {
     ),
     "resend": MessageLookupByLibrary.simpleMessage("Gensend"),
     "resendCode": MessageLookupByLibrary.simpleMessage("Send kode igen"),
-    "resendCodeWait": m19,
+    "resendCodeWait": m20,
     "reset": MessageLookupByLibrary.simpleMessage("Nulstil"),
     "retry": MessageLookupByLibrary.simpleMessage("Prøv igen"),
     "returnToDashboard": MessageLookupByLibrary.simpleMessage(
@@ -695,7 +699,7 @@ class MessageLookup extends MessageLookupByLibrary {
       "Vend tilbage til appen og tryk på Klar-knappen",
     ),
     "role": MessageLookupByLibrary.simpleMessage("Rolle"),
-    "routeNotDefined": m20,
+    "routeNotDefined": m21,
     "rpc": MessageLookupByLibrary.simpleMessage("RPC"),
     "ruleChain": MessageLookupByLibrary.simpleMessage("Regelkæde"),
     "ruleNode": MessageLookupByLibrary.simpleMessage("Regelknude"),
@@ -706,7 +710,7 @@ class MessageLookup extends MessageLookupByLibrary {
     ),
     "search": MessageLookupByLibrary.simpleMessage("Søg"),
     "searchResults": MessageLookupByLibrary.simpleMessage("Søgeresultater"),
-    "searchUsers": m21,
+    "searchUsers": m22,
     "seconds": MessageLookupByLibrary.simpleMessage("sekunder"),
     "security": MessageLookupByLibrary.simpleMessage("Sikkerhed"),
     "selectAll": MessageLookupByLibrary.simpleMessage("Vælg alle"),
@@ -733,7 +737,7 @@ class MessageLookup extends MessageLookupByLibrary {
     "severity": MessageLookupByLibrary.simpleMessage("Alvorlighed"),
     "signIn": MessageLookupByLibrary.simpleMessage("Log ind"),
     "signUp": MessageLookupByLibrary.simpleMessage("Tilmeld"),
-    "smsAuthDescription": m22,
+    "smsAuthDescription": m23,
     "smsAuthPlaceholder": MessageLookupByLibrary.simpleMessage("SMS-kode"),
     "smsSetupSuccessDescription": MessageLookupByLibrary.simpleMessage(
       "Næste gang du logger ind, vil du blive bedt om at indtaste sikkerhedskoden, der sendes til telefonnummeret",
@@ -797,7 +801,7 @@ class MessageLookup extends MessageLookupByLibrary {
     "unableConnectToDevice": MessageLookupByLibrary.simpleMessage(
       "Kan ikke oprette forbindelse til enhed",
     ),
-    "unableConnectToWifiBecauseNetworksWasntFoundByDevice": m23,
+    "unableConnectToWifiBecauseNetworksWasntFoundByDevice": m24,
     "unableToUseCamera": MessageLookupByLibrary.simpleMessage(
       "Kan ikke bruge kameraet",
     ),
@@ -813,7 +817,7 @@ class MessageLookup extends MessageLookupByLibrary {
     "updateRequired": MessageLookupByLibrary.simpleMessage(
       "Opdatering påkrævet",
     ),
-    "updateTo": m24,
+    "updateTo": m25,
     "url": MessageLookupByLibrary.simpleMessage("Url"),
     "user": MessageLookupByLibrary.simpleMessage("Bruger"),
     "username": MessageLookupByLibrary.simpleMessage("brugernavn"),
@@ -838,9 +842,9 @@ class MessageLookup extends MessageLookupByLibrary {
     "warning": MessageLookupByLibrary.simpleMessage("Advarsel"),
     "widgetType": MessageLookupByLibrary.simpleMessage("Widget-type"),
     "widgetsBundle": MessageLookupByLibrary.simpleMessage("Widget-pakke"),
-    "wifiHelpMessage": m25,
+    "wifiHelpMessage": m26,
     "wifiPassword": MessageLookupByLibrary.simpleMessage("Wi-Fi adgangskode"),
-    "wifiPasswordMessage": m26,
+    "wifiPasswordMessage": m27,
     "yes": MessageLookupByLibrary.simpleMessage("Ja"),
     "yesDeactivate": MessageLookupByLibrary.simpleMessage("Ja, deaktiver"),
     "yesDiscard": MessageLookupByLibrary.simpleMessage("Ja, kassér"),

--- a/lib/generated/intl/messages_da_DK.dart
+++ b/lib/generated/intl/messages_da_DK.dart
@@ -721,7 +721,7 @@ class MessageLookup extends MessageLookupByLibrary {
     "searchUsers": m24,
     "seconds": MessageLookupByLibrary.simpleMessage("sekunder"),
     "security": MessageLookupByLibrary.simpleMessage("Sikkerhed"),
-    "selectAll": MessageLookupByLibrary.simpleMessage("Vælg alle"),
+    "selectAll": MessageLookupByLibrary.simpleMessage("Vælg alle indlæste"),
     "selectCountry": MessageLookupByLibrary.simpleMessage("Vælg land"),
     "selectRegion": MessageLookupByLibrary.simpleMessage("Vælg region"),
     "selectUser": MessageLookupByLibrary.simpleMessage("Vælg brugere"),

--- a/lib/generated/intl/messages_da_DK.dart
+++ b/lib/generated/intl/messages_da_DK.dart
@@ -47,55 +47,61 @@ class MessageLookup extends MessageLookupByLibrary {
       "${Intl.plural(count, one: 'Dashboard', other: 'Dashboards')}";
 
   static String m9(count) =>
-      "${Intl.plural(count, one: 'Enhed', other: 'Enheder')}";
+      "${Intl.plural(count, one: 'Slet 1 notifikation?', other: 'Slet ${count} notifikationer?')}";
 
   static String m10(count) =>
+      "${Intl.plural(count, one: 'Enhed', other: 'Enheder')}";
+
+  static String m11(count) =>
       "${count}-${Intl.plural(count, one: 'cifret', other: 'cifre')} kode";
 
-  static String m11(contact) =>
+  static String m12(contact) =>
       "En sikkerhedskode er blevet sendt til din emailadresse på ${contact}.";
 
-  static String m12(e) => "Fejl opstod: ${e}";
+  static String m13(e) => "Fejl opstod: ${e}";
 
-  static String m13(error) => "Fejl ved afsendelse af kode: ${error}";
+  static String m14(error) => "Fejl ved afsendelse af kode: ${error}";
 
-  static String m14(count) =>
+  static String m15(count) =>
       "${Intl.plural(count, one: '1 handling mislykkedes', other: '${count} handlinger mislykkedes')}";
 
-  static String m15(count) => "${count} valgt";
-
   static String m16(count) =>
+      "${Intl.plural(count, one: 'Markér 1 notifikation som læst?', other: 'Markér ${count} notifikationer som læst?')}";
+
+  static String m17(count) => "${count} valgt";
+
+  static String m18(count) =>
       "${Intl.plural(count, one: 'Notifikation', other: 'Notifikationer')}";
 
-  static String m17(permissions) =>
+  static String m19(permissions) =>
       "Du har ikke tilstrækkelige tilladelser til \"${permissions}\" for at fortsætte. Åbn app-indstillingerne, giv tilladelser og tryk på \"Prøv igen\".";
 
-  static String m18(permissions) =>
+  static String m20(permissions) =>
       "Du har ikke tilstrækkelige tilladelser til \"${permissions}\" for at fortsætte. Giv de nødvendige tilladelser og tryk på \"Prøv igen\".";
 
-  static String m19(deviceName) =>
+  static String m21(deviceName) =>
       "Indtast PIN-kode for ${deviceName} for at bekræfte ejerskab";
 
-  static String m20(time) =>
+  static String m22(time) =>
       "Send kode igen om ${Intl.plural(time, one: '1 sekund', other: '${time} sekunder')}";
 
-  static String m21(name) => "Rute ikke defineret: ${name}";
+  static String m23(name) => "Rute ikke defineret: ${name}";
 
-  static String m22(count) =>
+  static String m24(count) =>
       "${Intl.plural(count, one: 'Søg bruger', other: 'Søg brugere')}";
 
-  static String m23(contact) =>
+  static String m25(contact) =>
       "En sikkerhedskode er blevet sendt til din telefon på ${contact}.";
 
-  static String m24(name) =>
+  static String m26(name) =>
       "Kan ikke oprette forbindelse til Wi-Fi, fordi netværk ikke blev fundet af enheden ${name}";
 
-  static String m25(version) => "Opdater til ${version}";
+  static String m27(version) => "Opdater til ${version}";
 
-  static String m26(deviceName) =>
+  static String m28(deviceName) =>
       "For at fortsætte opsætningen af din enhed ${deviceName}, skal du angive netværkets legitimationsoplysninger.";
 
-  static String m27(network) => "Indtast adgangskode til ${network}";
+  static String m29(network) => "Indtast adgangskode til ${network}";
 
   final messages = _notInlinedMessages(_notInlinedMessages);
   static Map<String, Function> _notInlinedMessages(_) => <String, Function>{
@@ -373,6 +379,7 @@ class MessageLookup extends MessageLookupByLibrary {
     "delete": MessageLookupByLibrary.simpleMessage("Slet"),
     "deleteAccount": MessageLookupByLibrary.simpleMessage("Slet konto"),
     "deleteComment": MessageLookupByLibrary.simpleMessage("Slet kommentar"),
+    "deleteSelectedNotifications": m9,
     "details": MessageLookupByLibrary.simpleMessage("Detaljer"),
     "deviceList": MessageLookupByLibrary.simpleMessage("Enhedsliste"),
     "deviceNotAbleToFindWifiNearby": MessageLookupByLibrary.simpleMessage(
@@ -385,8 +392,8 @@ class MessageLookup extends MessageLookupByLibrary {
     "deviceProvisioning": MessageLookupByLibrary.simpleMessage(
       "Enhedsklargøring",
     ),
-    "devices": m9,
-    "digitsCode": m10,
+    "devices": m10,
+    "digitsCode": m11,
     "discardChanges": MessageLookupByLibrary.simpleMessage("Kassér ændringer"),
     "domain": MessageLookupByLibrary.simpleMessage("Domæne"),
     "done": MessageLookupByLibrary.simpleMessage("Færdig"),
@@ -395,7 +402,7 @@ class MessageLookup extends MessageLookupByLibrary {
     "edit": MessageLookupByLibrary.simpleMessage("Rediger"),
     "edited": MessageLookupByLibrary.simpleMessage("Redigeret"),
     "email": MessageLookupByLibrary.simpleMessage("Email"),
-    "emailAuthDescription": m11,
+    "emailAuthDescription": m12,
     "emailAuthPlaceholder": MessageLookupByLibrary.simpleMessage("Email-kode"),
     "emailInvalidText": MessageLookupByLibrary.simpleMessage(
       "Ugyldigt emailformat.",
@@ -434,8 +441,8 @@ class MessageLookup extends MessageLookupByLibrary {
     "entityGroup": MessageLookupByLibrary.simpleMessage("Entitetsgruppe"),
     "entityType": MessageLookupByLibrary.simpleMessage("Enhedstype"),
     "entityView": MessageLookupByLibrary.simpleMessage("Entitetsvisning"),
-    "errorOccured": m12,
-    "errorSendingCode": m13,
+    "errorOccured": m13,
+    "errorSendingCode": m14,
     "europe": MessageLookupByLibrary.simpleMessage("Europa"),
     "europeRegionShort": MessageLookupByLibrary.simpleMessage("Frankfurt"),
     "exitDeviceProvisioning": MessageLookupByLibrary.simpleMessage(
@@ -450,7 +457,7 @@ class MessageLookup extends MessageLookupByLibrary {
     "failedToLoadTheList": MessageLookupByLibrary.simpleMessage(
       "Kunne ikke indlæse listen",
     ),
-    "failedToPerformOperation": m14,
+    "failedToPerformOperation": m15,
     "failedToSaveImage": MessageLookupByLibrary.simpleMessage(
       "Kunne ikke gemme billede",
     ),
@@ -528,6 +535,7 @@ class MessageLookup extends MessageLookupByLibrary {
       "Markér alle som læst",
     ),
     "markAsRead": MessageLookupByLibrary.simpleMessage("Markér som læst"),
+    "markSelectedNotificationsAsRead": m16,
     "metricUnitSystem": MessageLookupByLibrary.simpleMessage("Metrisk"),
     "mfaProviderBackupCode": MessageLookupByLibrary.simpleMessage("Backupkode"),
     "mfaProviderEmail": MessageLookupByLibrary.simpleMessage("Email"),
@@ -544,7 +552,7 @@ class MessageLookup extends MessageLookupByLibrary {
           "Mobilt dashboard skal konfigureres i enhedsprofilen!",
         ),
     "more": MessageLookupByLibrary.simpleMessage("Mere"),
-    "nSelected": m15,
+    "nSelected": m17,
     "newPassword": MessageLookupByLibrary.simpleMessage("Ny adgangskode"),
     "newPassword2": MessageLookupByLibrary.simpleMessage(
       "Bekræft ny adgangskode",
@@ -593,12 +601,12 @@ class MessageLookup extends MessageLookupByLibrary {
     "notificationTemplate": MessageLookupByLibrary.simpleMessage(
       "Notifikationsskabelon",
     ),
-    "notifications": m16,
+    "notifications": m18,
     "oauth2Client": MessageLookupByLibrary.simpleMessage("OAuth2-klient"),
     "openAppSettings": MessageLookupByLibrary.simpleMessage(
       "Åbn app-indstillinger",
     ),
-    "openAppSettingsToGrantPermissionMessage": m17,
+    "openAppSettingsToGrantPermissionMessage": m19,
     "openSettingsAndGrantAccessToCameraToContinue":
         MessageLookupByLibrary.simpleMessage(
           "Åbn indstillinger og giv adgang til kameraet for at fortsætte",
@@ -633,7 +641,7 @@ class MessageLookup extends MessageLookupByLibrary {
       "Adgangskoden blev ændret",
     ),
     "permissions": MessageLookupByLibrary.simpleMessage("Tilladelser"),
-    "permissionsNotEnoughMessage": m18,
+    "permissionsNotEnoughMessage": m20,
     "phone": MessageLookupByLibrary.simpleMessage("Telefon"),
     "phoneIsInvalid": MessageLookupByLibrary.simpleMessage(
       "Telefonnummer er ugyldigt",
@@ -660,7 +668,7 @@ class MessageLookup extends MessageLookupByLibrary {
       "Scan venligst QR-koden på din enhed",
     ),
     "plusAlarmType": MessageLookupByLibrary.simpleMessage("+ Alarmtype"),
-    "popTitle": m19,
+    "popTitle": m21,
     "postalCode": MessageLookupByLibrary.simpleMessage("Postnummer"),
     "privacyPolicy": MessageLookupByLibrary.simpleMessage("Privatlivspolitik"),
     "profile": MessageLookupByLibrary.simpleMessage("Profil"),
@@ -689,7 +697,7 @@ class MessageLookup extends MessageLookupByLibrary {
     ),
     "resend": MessageLookupByLibrary.simpleMessage("Gensend"),
     "resendCode": MessageLookupByLibrary.simpleMessage("Send kode igen"),
-    "resendCodeWait": m20,
+    "resendCodeWait": m22,
     "reset": MessageLookupByLibrary.simpleMessage("Nulstil"),
     "retry": MessageLookupByLibrary.simpleMessage("Prøv igen"),
     "returnToDashboard": MessageLookupByLibrary.simpleMessage(
@@ -699,7 +707,7 @@ class MessageLookup extends MessageLookupByLibrary {
       "Vend tilbage til appen og tryk på Klar-knappen",
     ),
     "role": MessageLookupByLibrary.simpleMessage("Rolle"),
-    "routeNotDefined": m21,
+    "routeNotDefined": m23,
     "rpc": MessageLookupByLibrary.simpleMessage("RPC"),
     "ruleChain": MessageLookupByLibrary.simpleMessage("Regelkæde"),
     "ruleNode": MessageLookupByLibrary.simpleMessage("Regelknude"),
@@ -710,7 +718,7 @@ class MessageLookup extends MessageLookupByLibrary {
     ),
     "search": MessageLookupByLibrary.simpleMessage("Søg"),
     "searchResults": MessageLookupByLibrary.simpleMessage("Søgeresultater"),
-    "searchUsers": m22,
+    "searchUsers": m24,
     "seconds": MessageLookupByLibrary.simpleMessage("sekunder"),
     "security": MessageLookupByLibrary.simpleMessage("Sikkerhed"),
     "selectAll": MessageLookupByLibrary.simpleMessage("Vælg alle"),
@@ -737,7 +745,7 @@ class MessageLookup extends MessageLookupByLibrary {
     "severity": MessageLookupByLibrary.simpleMessage("Alvorlighed"),
     "signIn": MessageLookupByLibrary.simpleMessage("Log ind"),
     "signUp": MessageLookupByLibrary.simpleMessage("Tilmeld"),
-    "smsAuthDescription": m23,
+    "smsAuthDescription": m25,
     "smsAuthPlaceholder": MessageLookupByLibrary.simpleMessage("SMS-kode"),
     "smsSetupSuccessDescription": MessageLookupByLibrary.simpleMessage(
       "Næste gang du logger ind, vil du blive bedt om at indtaste sikkerhedskoden, der sendes til telefonnummeret",
@@ -801,7 +809,7 @@ class MessageLookup extends MessageLookupByLibrary {
     "unableConnectToDevice": MessageLookupByLibrary.simpleMessage(
       "Kan ikke oprette forbindelse til enhed",
     ),
-    "unableConnectToWifiBecauseNetworksWasntFoundByDevice": m24,
+    "unableConnectToWifiBecauseNetworksWasntFoundByDevice": m26,
     "unableToUseCamera": MessageLookupByLibrary.simpleMessage(
       "Kan ikke bruge kameraet",
     ),
@@ -817,7 +825,7 @@ class MessageLookup extends MessageLookupByLibrary {
     "updateRequired": MessageLookupByLibrary.simpleMessage(
       "Opdatering påkrævet",
     ),
-    "updateTo": m25,
+    "updateTo": m27,
     "url": MessageLookupByLibrary.simpleMessage("Url"),
     "user": MessageLookupByLibrary.simpleMessage("Bruger"),
     "username": MessageLookupByLibrary.simpleMessage("brugernavn"),
@@ -842,9 +850,9 @@ class MessageLookup extends MessageLookupByLibrary {
     "warning": MessageLookupByLibrary.simpleMessage("Advarsel"),
     "widgetType": MessageLookupByLibrary.simpleMessage("Widget-type"),
     "widgetsBundle": MessageLookupByLibrary.simpleMessage("Widget-pakke"),
-    "wifiHelpMessage": m26,
+    "wifiHelpMessage": m28,
     "wifiPassword": MessageLookupByLibrary.simpleMessage("Wi-Fi adgangskode"),
-    "wifiPasswordMessage": m27,
+    "wifiPasswordMessage": m29,
     "yes": MessageLookupByLibrary.simpleMessage("Ja"),
     "yesDeactivate": MessageLookupByLibrary.simpleMessage("Ja, deaktiver"),
     "yesDiscard": MessageLookupByLibrary.simpleMessage("Ja, kassér"),

--- a/lib/generated/intl/messages_da_DK.dart
+++ b/lib/generated/intl/messages_da_DK.dart
@@ -59,38 +59,40 @@ class MessageLookup extends MessageLookupByLibrary {
 
   static String m13(error) => "Fejl ved afsendelse af kode: ${error}";
 
-  static String m14(count) =>
+  static String m14(count) => "${count} valgt";
+
+  static String m15(count) =>
       "${Intl.plural(count, one: 'Notifikation', other: 'Notifikationer')}";
 
-  static String m15(permissions) =>
+  static String m16(permissions) =>
       "Du har ikke tilstrækkelige tilladelser til \"${permissions}\" for at fortsætte. Åbn app-indstillingerne, giv tilladelser og tryk på \"Prøv igen\".";
 
-  static String m16(permissions) =>
+  static String m17(permissions) =>
       "Du har ikke tilstrækkelige tilladelser til \"${permissions}\" for at fortsætte. Giv de nødvendige tilladelser og tryk på \"Prøv igen\".";
 
-  static String m17(deviceName) =>
+  static String m18(deviceName) =>
       "Indtast PIN-kode for ${deviceName} for at bekræfte ejerskab";
 
-  static String m18(time) =>
+  static String m19(time) =>
       "Send kode igen om ${Intl.plural(time, one: '1 sekund', other: '${time} sekunder')}";
 
-  static String m19(name) => "Rute ikke defineret: ${name}";
+  static String m20(name) => "Rute ikke defineret: ${name}";
 
-  static String m20(count) =>
+  static String m21(count) =>
       "${Intl.plural(count, one: 'Søg bruger', other: 'Søg brugere')}";
 
-  static String m21(contact) =>
+  static String m22(contact) =>
       "En sikkerhedskode er blevet sendt til din telefon på ${contact}.";
 
-  static String m22(name) =>
+  static String m23(name) =>
       "Kan ikke oprette forbindelse til Wi-Fi, fordi netværk ikke blev fundet af enheden ${name}";
 
-  static String m23(version) => "Opdater til ${version}";
+  static String m24(version) => "Opdater til ${version}";
 
-  static String m24(deviceName) =>
+  static String m25(deviceName) =>
       "For at fortsætte opsætningen af din enhed ${deviceName}, skal du angive netværkets legitimationsoplysninger.";
 
-  static String m25(network) => "Indtast adgangskode til ${network}";
+  static String m26(network) => "Indtast adgangskode til ${network}";
 
   final messages = _notInlinedMessages(_notInlinedMessages);
   static Map<String, Function> _notInlinedMessages(_) => <String, Function>{
@@ -538,6 +540,7 @@ class MessageLookup extends MessageLookupByLibrary {
           "Mobilt dashboard skal konfigureres i enhedsprofilen!",
         ),
     "more": MessageLookupByLibrary.simpleMessage("Mere"),
+    "nSelected": m14,
     "newPassword": MessageLookupByLibrary.simpleMessage("Ny adgangskode"),
     "newPassword2": MessageLookupByLibrary.simpleMessage(
       "Bekræft ny adgangskode",
@@ -586,12 +589,12 @@ class MessageLookup extends MessageLookupByLibrary {
     "notificationTemplate": MessageLookupByLibrary.simpleMessage(
       "Notifikationsskabelon",
     ),
-    "notifications": m14,
+    "notifications": m15,
     "oauth2Client": MessageLookupByLibrary.simpleMessage("OAuth2-klient"),
     "openAppSettings": MessageLookupByLibrary.simpleMessage(
       "Åbn app-indstillinger",
     ),
-    "openAppSettingsToGrantPermissionMessage": m15,
+    "openAppSettingsToGrantPermissionMessage": m16,
     "openSettingsAndGrantAccessToCameraToContinue":
         MessageLookupByLibrary.simpleMessage(
           "Åbn indstillinger og giv adgang til kameraet for at fortsætte",
@@ -626,7 +629,7 @@ class MessageLookup extends MessageLookupByLibrary {
       "Adgangskoden blev ændret",
     ),
     "permissions": MessageLookupByLibrary.simpleMessage("Tilladelser"),
-    "permissionsNotEnoughMessage": m16,
+    "permissionsNotEnoughMessage": m17,
     "phone": MessageLookupByLibrary.simpleMessage("Telefon"),
     "phoneIsInvalid": MessageLookupByLibrary.simpleMessage(
       "Telefonnummer er ugyldigt",
@@ -653,7 +656,7 @@ class MessageLookup extends MessageLookupByLibrary {
       "Scan venligst QR-koden på din enhed",
     ),
     "plusAlarmType": MessageLookupByLibrary.simpleMessage("+ Alarmtype"),
-    "popTitle": m17,
+    "popTitle": m18,
     "postalCode": MessageLookupByLibrary.simpleMessage("Postnummer"),
     "privacyPolicy": MessageLookupByLibrary.simpleMessage("Privatlivspolitik"),
     "profile": MessageLookupByLibrary.simpleMessage("Profil"),
@@ -682,7 +685,7 @@ class MessageLookup extends MessageLookupByLibrary {
     ),
     "resend": MessageLookupByLibrary.simpleMessage("Gensend"),
     "resendCode": MessageLookupByLibrary.simpleMessage("Send kode igen"),
-    "resendCodeWait": m18,
+    "resendCodeWait": m19,
     "reset": MessageLookupByLibrary.simpleMessage("Nulstil"),
     "retry": MessageLookupByLibrary.simpleMessage("Prøv igen"),
     "returnToDashboard": MessageLookupByLibrary.simpleMessage(
@@ -692,7 +695,7 @@ class MessageLookup extends MessageLookupByLibrary {
       "Vend tilbage til appen og tryk på Klar-knappen",
     ),
     "role": MessageLookupByLibrary.simpleMessage("Rolle"),
-    "routeNotDefined": m19,
+    "routeNotDefined": m20,
     "rpc": MessageLookupByLibrary.simpleMessage("RPC"),
     "ruleChain": MessageLookupByLibrary.simpleMessage("Regelkæde"),
     "ruleNode": MessageLookupByLibrary.simpleMessage("Regelknude"),
@@ -703,9 +706,10 @@ class MessageLookup extends MessageLookupByLibrary {
     ),
     "search": MessageLookupByLibrary.simpleMessage("Søg"),
     "searchResults": MessageLookupByLibrary.simpleMessage("Søgeresultater"),
-    "searchUsers": m20,
+    "searchUsers": m21,
     "seconds": MessageLookupByLibrary.simpleMessage("sekunder"),
     "security": MessageLookupByLibrary.simpleMessage("Sikkerhed"),
+    "selectAll": MessageLookupByLibrary.simpleMessage("Vælg alle"),
     "selectCountry": MessageLookupByLibrary.simpleMessage("Vælg land"),
     "selectRegion": MessageLookupByLibrary.simpleMessage("Vælg region"),
     "selectUser": MessageLookupByLibrary.simpleMessage("Vælg brugere"),
@@ -729,7 +733,7 @@ class MessageLookup extends MessageLookupByLibrary {
     "severity": MessageLookupByLibrary.simpleMessage("Alvorlighed"),
     "signIn": MessageLookupByLibrary.simpleMessage("Log ind"),
     "signUp": MessageLookupByLibrary.simpleMessage("Tilmeld"),
-    "smsAuthDescription": m21,
+    "smsAuthDescription": m22,
     "smsAuthPlaceholder": MessageLookupByLibrary.simpleMessage("SMS-kode"),
     "smsSetupSuccessDescription": MessageLookupByLibrary.simpleMessage(
       "Næste gang du logger ind, vil du blive bedt om at indtaste sikkerhedskoden, der sendes til telefonnummeret",
@@ -793,7 +797,7 @@ class MessageLookup extends MessageLookupByLibrary {
     "unableConnectToDevice": MessageLookupByLibrary.simpleMessage(
       "Kan ikke oprette forbindelse til enhed",
     ),
-    "unableConnectToWifiBecauseNetworksWasntFoundByDevice": m22,
+    "unableConnectToWifiBecauseNetworksWasntFoundByDevice": m23,
     "unableToUseCamera": MessageLookupByLibrary.simpleMessage(
       "Kan ikke bruge kameraet",
     ),
@@ -809,7 +813,7 @@ class MessageLookup extends MessageLookupByLibrary {
     "updateRequired": MessageLookupByLibrary.simpleMessage(
       "Opdatering påkrævet",
     ),
-    "updateTo": m23,
+    "updateTo": m24,
     "url": MessageLookupByLibrary.simpleMessage("Url"),
     "user": MessageLookupByLibrary.simpleMessage("Bruger"),
     "username": MessageLookupByLibrary.simpleMessage("brugernavn"),
@@ -834,9 +838,9 @@ class MessageLookup extends MessageLookupByLibrary {
     "warning": MessageLookupByLibrary.simpleMessage("Advarsel"),
     "widgetType": MessageLookupByLibrary.simpleMessage("Widget-type"),
     "widgetsBundle": MessageLookupByLibrary.simpleMessage("Widget-pakke"),
-    "wifiHelpMessage": m24,
+    "wifiHelpMessage": m25,
     "wifiPassword": MessageLookupByLibrary.simpleMessage("Wi-Fi adgangskode"),
-    "wifiPasswordMessage": m25,
+    "wifiPasswordMessage": m26,
     "yes": MessageLookupByLibrary.simpleMessage("Ja"),
     "yesDeactivate": MessageLookupByLibrary.simpleMessage("Ja, deaktiver"),
     "yesDiscard": MessageLookupByLibrary.simpleMessage("Ja, kassér"),

--- a/lib/generated/intl/messages_de_DE.dart
+++ b/lib/generated/intl/messages_de_DE.dart
@@ -739,7 +739,9 @@ class MessageLookup extends MessageLookupByLibrary {
     "searchUsers": m24,
     "seconds": MessageLookupByLibrary.simpleMessage("Sekunden"),
     "security": MessageLookupByLibrary.simpleMessage("Sicherheit"),
-    "selectAll": MessageLookupByLibrary.simpleMessage("Alle auswählen"),
+    "selectAll": MessageLookupByLibrary.simpleMessage(
+      "Alle geladenen auswählen",
+    ),
     "selectCountry": MessageLookupByLibrary.simpleMessage("Land auswählen"),
     "selectRegion": MessageLookupByLibrary.simpleMessage("Region auswählen"),
     "selectUser": MessageLookupByLibrary.simpleMessage("Benutzer auswählen"),

--- a/lib/generated/intl/messages_de_DE.dart
+++ b/lib/generated/intl/messages_de_DE.dart
@@ -59,40 +59,43 @@ class MessageLookup extends MessageLookupByLibrary {
 
   static String m13(error) => "Fehler beim Senden des Codes: ${error}";
 
-  static String m14(count) => "${count} ausgewählt";
+  static String m14(count) =>
+      "${Intl.plural(count, one: '1 Vorgang fehlgeschlagen', other: '${count} Vorgänge fehlgeschlagen')}";
 
-  static String m15(count) =>
+  static String m15(count) => "${count} ausgewählt";
+
+  static String m16(count) =>
       "${Intl.plural(count, one: 'Benachrichtigung', other: 'Benachrichtigungen')}";
 
-  static String m16(permissions) =>
+  static String m17(permissions) =>
       "Sie haben nicht genügend Berechtigungen für \"${permissions}\". Bitte öffnen Sie die App-Einstellungen, erteilen Sie die Berechtigungen und tippen Sie auf \"Erneut versuchen\".";
 
-  static String m17(permissions) =>
+  static String m18(permissions) =>
       "Sie haben nicht genügend Berechtigungen für \"${permissions}\". Bitte erteilen Sie die erforderlichen Berechtigungen und tippen Sie auf \"Erneut versuchen\".";
 
-  static String m18(deviceName) =>
+  static String m19(deviceName) =>
       "Geben Sie die PIN von ${deviceName} ein, um den Besitznachweis zu bestätigen";
 
-  static String m19(time) =>
+  static String m20(time) =>
       "Code erneut senden in ${Intl.plural(time, one: '1 Sekunde', other: '${time} Sekunden')}";
 
-  static String m20(name) => "Route nicht definiert: ${name}";
+  static String m21(name) => "Route nicht definiert: ${name}";
 
-  static String m21(count) =>
+  static String m22(count) =>
       "${Intl.plural(count, one: 'Benutzer suchen', other: 'Benutzer suchen')}";
 
-  static String m22(contact) =>
+  static String m23(contact) =>
       "Ein Sicherheitscode wurde an Ihr Telefon unter ${contact} gesendet.";
 
-  static String m23(name) =>
+  static String m24(name) =>
       "WLAN-Verbindung nicht möglich, da das Gerät ${name} keine Netzwerke gefunden hat";
 
-  static String m24(version) => "Aktualisieren auf ${version}";
+  static String m25(version) => "Aktualisieren auf ${version}";
 
-  static String m25(deviceName) =>
+  static String m26(deviceName) =>
       "Um die Einrichtung Ihres Geräts ${deviceName} fortzusetzen, geben Sie bitte die Zugangsdaten Ihres Netzwerks ein.";
 
-  static String m26(network) => "Passwort für ${network} eingeben";
+  static String m27(network) => "Passwort für ${network} eingeben";
 
   final messages = _notInlinedMessages(_notInlinedMessages);
   static Map<String, Function> _notInlinedMessages(_) => <String, Function>{
@@ -459,6 +462,7 @@ class MessageLookup extends MessageLookupByLibrary {
     "failedToLoadTheList": MessageLookupByLibrary.simpleMessage(
       "Liste konnte nicht geladen werden",
     ),
+    "failedToPerformOperation": m14,
     "failedToSaveImage": MessageLookupByLibrary.simpleMessage(
       "Bild konnte nicht gespeichert werden",
     ),
@@ -556,7 +560,7 @@ class MessageLookup extends MessageLookupByLibrary {
           "Das mobile Dashboard sollte im Geräteprofil konfiguriert werden!",
         ),
     "more": MessageLookupByLibrary.simpleMessage("Mehr"),
-    "nSelected": m14,
+    "nSelected": m15,
     "newPassword": MessageLookupByLibrary.simpleMessage("Neues Passwort"),
     "newPassword2": MessageLookupByLibrary.simpleMessage(
       "Neues Passwort bestätigen",
@@ -605,12 +609,12 @@ class MessageLookup extends MessageLookupByLibrary {
     "notificationTemplate": MessageLookupByLibrary.simpleMessage(
       "Benachrichtigungsvorlage",
     ),
-    "notifications": m15,
+    "notifications": m16,
     "oauth2Client": MessageLookupByLibrary.simpleMessage("OAuth2-Client"),
     "openAppSettings": MessageLookupByLibrary.simpleMessage(
       "App-Einstellungen öffnen",
     ),
-    "openAppSettingsToGrantPermissionMessage": m16,
+    "openAppSettingsToGrantPermissionMessage": m17,
     "openSettingsAndGrantAccessToCameraToContinue":
         MessageLookupByLibrary.simpleMessage(
           "Öffnen Sie die Einstellungen und gewähren Sie Kamerazugriff, um fortzufahren",
@@ -645,7 +649,7 @@ class MessageLookup extends MessageLookupByLibrary {
       "Passwort erfolgreich geändert",
     ),
     "permissions": MessageLookupByLibrary.simpleMessage("Berechtigungen"),
-    "permissionsNotEnoughMessage": m17,
+    "permissionsNotEnoughMessage": m18,
     "phone": MessageLookupByLibrary.simpleMessage("Telefon"),
     "phoneIsInvalid": MessageLookupByLibrary.simpleMessage(
       "Telefonnummer ist ungültig",
@@ -672,7 +676,7 @@ class MessageLookup extends MessageLookupByLibrary {
       "Bitte scannen Sie den QR-Code auf Ihrem Gerät",
     ),
     "plusAlarmType": MessageLookupByLibrary.simpleMessage("+ Alarmtyp"),
-    "popTitle": m18,
+    "popTitle": m19,
     "postalCode": MessageLookupByLibrary.simpleMessage("PLZ / Postleitzahl"),
     "privacyPolicy": MessageLookupByLibrary.simpleMessage(
       "Datenschutzerklärung",
@@ -705,7 +709,7 @@ class MessageLookup extends MessageLookupByLibrary {
     ),
     "resend": MessageLookupByLibrary.simpleMessage("Erneut senden"),
     "resendCode": MessageLookupByLibrary.simpleMessage("Code erneut senden"),
-    "resendCodeWait": m19,
+    "resendCodeWait": m20,
     "reset": MessageLookupByLibrary.simpleMessage("Zurücksetzen"),
     "retry": MessageLookupByLibrary.simpleMessage("Erneut versuchen"),
     "returnToDashboard": MessageLookupByLibrary.simpleMessage(
@@ -715,7 +719,7 @@ class MessageLookup extends MessageLookupByLibrary {
       "Kehren Sie zur App zurück und tippen Sie auf Bereit",
     ),
     "role": MessageLookupByLibrary.simpleMessage("Rolle"),
-    "routeNotDefined": m20,
+    "routeNotDefined": m21,
     "rpc": MessageLookupByLibrary.simpleMessage("RPC"),
     "ruleChain": MessageLookupByLibrary.simpleMessage("Regelkette"),
     "ruleNode": MessageLookupByLibrary.simpleMessage("Regelknoten"),
@@ -724,7 +728,7 @@ class MessageLookup extends MessageLookupByLibrary {
     "schedulerEvent": MessageLookupByLibrary.simpleMessage("Planer-Ereignis"),
     "search": MessageLookupByLibrary.simpleMessage("Suchen"),
     "searchResults": MessageLookupByLibrary.simpleMessage("Suchergebnisse"),
-    "searchUsers": m21,
+    "searchUsers": m22,
     "seconds": MessageLookupByLibrary.simpleMessage("Sekunden"),
     "security": MessageLookupByLibrary.simpleMessage("Sicherheit"),
     "selectAll": MessageLookupByLibrary.simpleMessage("Alle auswählen"),
@@ -751,7 +755,7 @@ class MessageLookup extends MessageLookupByLibrary {
     "severity": MessageLookupByLibrary.simpleMessage("Schweregrad"),
     "signIn": MessageLookupByLibrary.simpleMessage("Anmelden"),
     "signUp": MessageLookupByLibrary.simpleMessage("Registrieren"),
-    "smsAuthDescription": m22,
+    "smsAuthDescription": m23,
     "smsAuthPlaceholder": MessageLookupByLibrary.simpleMessage("SMS-Code"),
     "smsSetupSuccessDescription": MessageLookupByLibrary.simpleMessage(
       "Bei der nächsten Anmeldung werden Sie aufgefordert, den Sicherheitscode einzugeben, der an die Telefonnummer gesendet wird",
@@ -817,7 +821,7 @@ class MessageLookup extends MessageLookupByLibrary {
     "unableConnectToDevice": MessageLookupByLibrary.simpleMessage(
       "Verbindung zum Gerät nicht möglich",
     ),
-    "unableConnectToWifiBecauseNetworksWasntFoundByDevice": m23,
+    "unableConnectToWifiBecauseNetworksWasntFoundByDevice": m24,
     "unableToUseCamera": MessageLookupByLibrary.simpleMessage(
       "Kamera kann nicht verwendet werden",
     ),
@@ -833,7 +837,7 @@ class MessageLookup extends MessageLookupByLibrary {
     "updateRequired": MessageLookupByLibrary.simpleMessage(
       "Aktualisierung erforderlich",
     ),
-    "updateTo": m24,
+    "updateTo": m25,
     "url": MessageLookupByLibrary.simpleMessage("URL"),
     "user": MessageLookupByLibrary.simpleMessage("Benutzer"),
     "username": MessageLookupByLibrary.simpleMessage("Benutzername"),
@@ -858,9 +862,9 @@ class MessageLookup extends MessageLookupByLibrary {
     "warning": MessageLookupByLibrary.simpleMessage("Warnung"),
     "widgetType": MessageLookupByLibrary.simpleMessage("Widget-Typ"),
     "widgetsBundle": MessageLookupByLibrary.simpleMessage("Widget-Paket"),
-    "wifiHelpMessage": m25,
+    "wifiHelpMessage": m26,
     "wifiPassword": MessageLookupByLibrary.simpleMessage("WLAN-Passwort"),
-    "wifiPasswordMessage": m26,
+    "wifiPasswordMessage": m27,
     "yes": MessageLookupByLibrary.simpleMessage("Ja"),
     "yesDeactivate": MessageLookupByLibrary.simpleMessage("Ja, deaktivieren"),
     "yesDiscard": MessageLookupByLibrary.simpleMessage("Ja, verwerfen"),

--- a/lib/generated/intl/messages_de_DE.dart
+++ b/lib/generated/intl/messages_de_DE.dart
@@ -47,55 +47,61 @@ class MessageLookup extends MessageLookupByLibrary {
       "${Intl.plural(count, one: 'Dashboard', other: 'Dashboards')}";
 
   static String m9(count) =>
-      "${Intl.plural(count, one: 'Gerät', other: 'Geräte')}";
+      "${Intl.plural(count, one: '1 Benachrichtigung löschen?', other: '${count} Benachrichtigungen löschen?')}";
 
   static String m10(count) =>
+      "${Intl.plural(count, one: 'Gerät', other: 'Geräte')}";
+
+  static String m11(count) =>
       "${count}-${Intl.plural(count, one: 'stelliger', other: 'stelliger')} Code";
 
-  static String m11(contact) =>
+  static String m12(contact) =>
       "Ein Sicherheitscode wurde an Ihre E-Mail-Adresse unter ${contact} gesendet.";
 
-  static String m12(e) => "Fehler aufgetreten: ${e}";
+  static String m13(e) => "Fehler aufgetreten: ${e}";
 
-  static String m13(error) => "Fehler beim Senden des Codes: ${error}";
+  static String m14(error) => "Fehler beim Senden des Codes: ${error}";
 
-  static String m14(count) =>
+  static String m15(count) =>
       "${Intl.plural(count, one: '1 Vorgang fehlgeschlagen', other: '${count} Vorgänge fehlgeschlagen')}";
 
-  static String m15(count) => "${count} ausgewählt";
-
   static String m16(count) =>
+      "${Intl.plural(count, one: '1 Benachrichtigung als gelesen markieren?', other: '${count} Benachrichtigungen als gelesen markieren?')}";
+
+  static String m17(count) => "${count} ausgewählt";
+
+  static String m18(count) =>
       "${Intl.plural(count, one: 'Benachrichtigung', other: 'Benachrichtigungen')}";
 
-  static String m17(permissions) =>
+  static String m19(permissions) =>
       "Sie haben nicht genügend Berechtigungen für \"${permissions}\". Bitte öffnen Sie die App-Einstellungen, erteilen Sie die Berechtigungen und tippen Sie auf \"Erneut versuchen\".";
 
-  static String m18(permissions) =>
+  static String m20(permissions) =>
       "Sie haben nicht genügend Berechtigungen für \"${permissions}\". Bitte erteilen Sie die erforderlichen Berechtigungen und tippen Sie auf \"Erneut versuchen\".";
 
-  static String m19(deviceName) =>
+  static String m21(deviceName) =>
       "Geben Sie die PIN von ${deviceName} ein, um den Besitznachweis zu bestätigen";
 
-  static String m20(time) =>
+  static String m22(time) =>
       "Code erneut senden in ${Intl.plural(time, one: '1 Sekunde', other: '${time} Sekunden')}";
 
-  static String m21(name) => "Route nicht definiert: ${name}";
+  static String m23(name) => "Route nicht definiert: ${name}";
 
-  static String m22(count) =>
+  static String m24(count) =>
       "${Intl.plural(count, one: 'Benutzer suchen', other: 'Benutzer suchen')}";
 
-  static String m23(contact) =>
+  static String m25(contact) =>
       "Ein Sicherheitscode wurde an Ihr Telefon unter ${contact} gesendet.";
 
-  static String m24(name) =>
+  static String m26(name) =>
       "WLAN-Verbindung nicht möglich, da das Gerät ${name} keine Netzwerke gefunden hat";
 
-  static String m25(version) => "Aktualisieren auf ${version}";
+  static String m27(version) => "Aktualisieren auf ${version}";
 
-  static String m26(deviceName) =>
+  static String m28(deviceName) =>
       "Um die Einrichtung Ihres Geräts ${deviceName} fortzusetzen, geben Sie bitte die Zugangsdaten Ihres Netzwerks ein.";
 
-  static String m27(network) => "Passwort für ${network} eingeben";
+  static String m29(network) => "Passwort für ${network} eingeben";
 
   final messages = _notInlinedMessages(_notInlinedMessages);
   static Map<String, Function> _notInlinedMessages(_) => <String, Function>{
@@ -383,6 +389,7 @@ class MessageLookup extends MessageLookupByLibrary {
     "delete": MessageLookupByLibrary.simpleMessage("Löschen"),
     "deleteAccount": MessageLookupByLibrary.simpleMessage("Konto löschen"),
     "deleteComment": MessageLookupByLibrary.simpleMessage("Kommentar löschen"),
+    "deleteSelectedNotifications": m9,
     "details": MessageLookupByLibrary.simpleMessage("Details"),
     "deviceList": MessageLookupByLibrary.simpleMessage("Geräteliste"),
     "deviceNotAbleToFindWifiNearby": MessageLookupByLibrary.simpleMessage(
@@ -395,8 +402,8 @@ class MessageLookup extends MessageLookupByLibrary {
     "deviceProvisioning": MessageLookupByLibrary.simpleMessage(
       "Gerätebereitstellung",
     ),
-    "devices": m9,
-    "digitsCode": m10,
+    "devices": m10,
+    "digitsCode": m11,
     "discardChanges": MessageLookupByLibrary.simpleMessage(
       "Änderungen verwerfen",
     ),
@@ -407,7 +414,7 @@ class MessageLookup extends MessageLookupByLibrary {
     "edit": MessageLookupByLibrary.simpleMessage("Bearbeiten"),
     "edited": MessageLookupByLibrary.simpleMessage("Bearbeitet"),
     "email": MessageLookupByLibrary.simpleMessage("E-Mail"),
-    "emailAuthDescription": m11,
+    "emailAuthDescription": m12,
     "emailAuthPlaceholder": MessageLookupByLibrary.simpleMessage("E-Mail-Code"),
     "emailInvalidText": MessageLookupByLibrary.simpleMessage(
       "Ungültiges E-Mail-Format.",
@@ -446,8 +453,8 @@ class MessageLookup extends MessageLookupByLibrary {
     "entityGroup": MessageLookupByLibrary.simpleMessage("Entitätsgruppe"),
     "entityType": MessageLookupByLibrary.simpleMessage("Entitätstyp"),
     "entityView": MessageLookupByLibrary.simpleMessage("Entitätsansicht"),
-    "errorOccured": m12,
-    "errorSendingCode": m13,
+    "errorOccured": m13,
+    "errorSendingCode": m14,
     "europe": MessageLookupByLibrary.simpleMessage("Europa"),
     "europeRegionShort": MessageLookupByLibrary.simpleMessage("Frankfurt"),
     "exitDeviceProvisioning": MessageLookupByLibrary.simpleMessage(
@@ -462,7 +469,7 @@ class MessageLookup extends MessageLookupByLibrary {
     "failedToLoadTheList": MessageLookupByLibrary.simpleMessage(
       "Liste konnte nicht geladen werden",
     ),
-    "failedToPerformOperation": m14,
+    "failedToPerformOperation": m15,
     "failedToSaveImage": MessageLookupByLibrary.simpleMessage(
       "Bild konnte nicht gespeichert werden",
     ),
@@ -542,6 +549,7 @@ class MessageLookup extends MessageLookupByLibrary {
       "Alle als gelesen markieren",
     ),
     "markAsRead": MessageLookupByLibrary.simpleMessage("Als gelesen markieren"),
+    "markSelectedNotificationsAsRead": m16,
     "metricUnitSystem": MessageLookupByLibrary.simpleMessage("Metrisch"),
     "mfaProviderBackupCode": MessageLookupByLibrary.simpleMessage(
       "Backup-Code",
@@ -560,7 +568,7 @@ class MessageLookup extends MessageLookupByLibrary {
           "Das mobile Dashboard sollte im Geräteprofil konfiguriert werden!",
         ),
     "more": MessageLookupByLibrary.simpleMessage("Mehr"),
-    "nSelected": m15,
+    "nSelected": m17,
     "newPassword": MessageLookupByLibrary.simpleMessage("Neues Passwort"),
     "newPassword2": MessageLookupByLibrary.simpleMessage(
       "Neues Passwort bestätigen",
@@ -609,12 +617,12 @@ class MessageLookup extends MessageLookupByLibrary {
     "notificationTemplate": MessageLookupByLibrary.simpleMessage(
       "Benachrichtigungsvorlage",
     ),
-    "notifications": m16,
+    "notifications": m18,
     "oauth2Client": MessageLookupByLibrary.simpleMessage("OAuth2-Client"),
     "openAppSettings": MessageLookupByLibrary.simpleMessage(
       "App-Einstellungen öffnen",
     ),
-    "openAppSettingsToGrantPermissionMessage": m17,
+    "openAppSettingsToGrantPermissionMessage": m19,
     "openSettingsAndGrantAccessToCameraToContinue":
         MessageLookupByLibrary.simpleMessage(
           "Öffnen Sie die Einstellungen und gewähren Sie Kamerazugriff, um fortzufahren",
@@ -649,7 +657,7 @@ class MessageLookup extends MessageLookupByLibrary {
       "Passwort erfolgreich geändert",
     ),
     "permissions": MessageLookupByLibrary.simpleMessage("Berechtigungen"),
-    "permissionsNotEnoughMessage": m18,
+    "permissionsNotEnoughMessage": m20,
     "phone": MessageLookupByLibrary.simpleMessage("Telefon"),
     "phoneIsInvalid": MessageLookupByLibrary.simpleMessage(
       "Telefonnummer ist ungültig",
@@ -676,7 +684,7 @@ class MessageLookup extends MessageLookupByLibrary {
       "Bitte scannen Sie den QR-Code auf Ihrem Gerät",
     ),
     "plusAlarmType": MessageLookupByLibrary.simpleMessage("+ Alarmtyp"),
-    "popTitle": m19,
+    "popTitle": m21,
     "postalCode": MessageLookupByLibrary.simpleMessage("PLZ / Postleitzahl"),
     "privacyPolicy": MessageLookupByLibrary.simpleMessage(
       "Datenschutzerklärung",
@@ -709,7 +717,7 @@ class MessageLookup extends MessageLookupByLibrary {
     ),
     "resend": MessageLookupByLibrary.simpleMessage("Erneut senden"),
     "resendCode": MessageLookupByLibrary.simpleMessage("Code erneut senden"),
-    "resendCodeWait": m20,
+    "resendCodeWait": m22,
     "reset": MessageLookupByLibrary.simpleMessage("Zurücksetzen"),
     "retry": MessageLookupByLibrary.simpleMessage("Erneut versuchen"),
     "returnToDashboard": MessageLookupByLibrary.simpleMessage(
@@ -719,7 +727,7 @@ class MessageLookup extends MessageLookupByLibrary {
       "Kehren Sie zur App zurück und tippen Sie auf Bereit",
     ),
     "role": MessageLookupByLibrary.simpleMessage("Rolle"),
-    "routeNotDefined": m21,
+    "routeNotDefined": m23,
     "rpc": MessageLookupByLibrary.simpleMessage("RPC"),
     "ruleChain": MessageLookupByLibrary.simpleMessage("Regelkette"),
     "ruleNode": MessageLookupByLibrary.simpleMessage("Regelknoten"),
@@ -728,7 +736,7 @@ class MessageLookup extends MessageLookupByLibrary {
     "schedulerEvent": MessageLookupByLibrary.simpleMessage("Planer-Ereignis"),
     "search": MessageLookupByLibrary.simpleMessage("Suchen"),
     "searchResults": MessageLookupByLibrary.simpleMessage("Suchergebnisse"),
-    "searchUsers": m22,
+    "searchUsers": m24,
     "seconds": MessageLookupByLibrary.simpleMessage("Sekunden"),
     "security": MessageLookupByLibrary.simpleMessage("Sicherheit"),
     "selectAll": MessageLookupByLibrary.simpleMessage("Alle auswählen"),
@@ -755,7 +763,7 @@ class MessageLookup extends MessageLookupByLibrary {
     "severity": MessageLookupByLibrary.simpleMessage("Schweregrad"),
     "signIn": MessageLookupByLibrary.simpleMessage("Anmelden"),
     "signUp": MessageLookupByLibrary.simpleMessage("Registrieren"),
-    "smsAuthDescription": m23,
+    "smsAuthDescription": m25,
     "smsAuthPlaceholder": MessageLookupByLibrary.simpleMessage("SMS-Code"),
     "smsSetupSuccessDescription": MessageLookupByLibrary.simpleMessage(
       "Bei der nächsten Anmeldung werden Sie aufgefordert, den Sicherheitscode einzugeben, der an die Telefonnummer gesendet wird",
@@ -821,7 +829,7 @@ class MessageLookup extends MessageLookupByLibrary {
     "unableConnectToDevice": MessageLookupByLibrary.simpleMessage(
       "Verbindung zum Gerät nicht möglich",
     ),
-    "unableConnectToWifiBecauseNetworksWasntFoundByDevice": m24,
+    "unableConnectToWifiBecauseNetworksWasntFoundByDevice": m26,
     "unableToUseCamera": MessageLookupByLibrary.simpleMessage(
       "Kamera kann nicht verwendet werden",
     ),
@@ -837,7 +845,7 @@ class MessageLookup extends MessageLookupByLibrary {
     "updateRequired": MessageLookupByLibrary.simpleMessage(
       "Aktualisierung erforderlich",
     ),
-    "updateTo": m25,
+    "updateTo": m27,
     "url": MessageLookupByLibrary.simpleMessage("URL"),
     "user": MessageLookupByLibrary.simpleMessage("Benutzer"),
     "username": MessageLookupByLibrary.simpleMessage("Benutzername"),
@@ -862,9 +870,9 @@ class MessageLookup extends MessageLookupByLibrary {
     "warning": MessageLookupByLibrary.simpleMessage("Warnung"),
     "widgetType": MessageLookupByLibrary.simpleMessage("Widget-Typ"),
     "widgetsBundle": MessageLookupByLibrary.simpleMessage("Widget-Paket"),
-    "wifiHelpMessage": m26,
+    "wifiHelpMessage": m28,
     "wifiPassword": MessageLookupByLibrary.simpleMessage("WLAN-Passwort"),
-    "wifiPasswordMessage": m27,
+    "wifiPasswordMessage": m29,
     "yes": MessageLookupByLibrary.simpleMessage("Ja"),
     "yesDeactivate": MessageLookupByLibrary.simpleMessage("Ja, deaktivieren"),
     "yesDiscard": MessageLookupByLibrary.simpleMessage("Ja, verwerfen"),

--- a/lib/generated/intl/messages_de_DE.dart
+++ b/lib/generated/intl/messages_de_DE.dart
@@ -59,38 +59,40 @@ class MessageLookup extends MessageLookupByLibrary {
 
   static String m13(error) => "Fehler beim Senden des Codes: ${error}";
 
-  static String m14(count) =>
+  static String m14(count) => "${count} ausgewählt";
+
+  static String m15(count) =>
       "${Intl.plural(count, one: 'Benachrichtigung', other: 'Benachrichtigungen')}";
 
-  static String m15(permissions) =>
+  static String m16(permissions) =>
       "Sie haben nicht genügend Berechtigungen für \"${permissions}\". Bitte öffnen Sie die App-Einstellungen, erteilen Sie die Berechtigungen und tippen Sie auf \"Erneut versuchen\".";
 
-  static String m16(permissions) =>
+  static String m17(permissions) =>
       "Sie haben nicht genügend Berechtigungen für \"${permissions}\". Bitte erteilen Sie die erforderlichen Berechtigungen und tippen Sie auf \"Erneut versuchen\".";
 
-  static String m17(deviceName) =>
+  static String m18(deviceName) =>
       "Geben Sie die PIN von ${deviceName} ein, um den Besitznachweis zu bestätigen";
 
-  static String m18(time) =>
+  static String m19(time) =>
       "Code erneut senden in ${Intl.plural(time, one: '1 Sekunde', other: '${time} Sekunden')}";
 
-  static String m19(name) => "Route nicht definiert: ${name}";
+  static String m20(name) => "Route nicht definiert: ${name}";
 
-  static String m20(count) =>
+  static String m21(count) =>
       "${Intl.plural(count, one: 'Benutzer suchen', other: 'Benutzer suchen')}";
 
-  static String m21(contact) =>
+  static String m22(contact) =>
       "Ein Sicherheitscode wurde an Ihr Telefon unter ${contact} gesendet.";
 
-  static String m22(name) =>
+  static String m23(name) =>
       "WLAN-Verbindung nicht möglich, da das Gerät ${name} keine Netzwerke gefunden hat";
 
-  static String m23(version) => "Aktualisieren auf ${version}";
+  static String m24(version) => "Aktualisieren auf ${version}";
 
-  static String m24(deviceName) =>
+  static String m25(deviceName) =>
       "Um die Einrichtung Ihres Geräts ${deviceName} fortzusetzen, geben Sie bitte die Zugangsdaten Ihres Netzwerks ein.";
 
-  static String m25(network) => "Passwort für ${network} eingeben";
+  static String m26(network) => "Passwort für ${network} eingeben";
 
   final messages = _notInlinedMessages(_notInlinedMessages);
   static Map<String, Function> _notInlinedMessages(_) => <String, Function>{
@@ -554,6 +556,7 @@ class MessageLookup extends MessageLookupByLibrary {
           "Das mobile Dashboard sollte im Geräteprofil konfiguriert werden!",
         ),
     "more": MessageLookupByLibrary.simpleMessage("Mehr"),
+    "nSelected": m14,
     "newPassword": MessageLookupByLibrary.simpleMessage("Neues Passwort"),
     "newPassword2": MessageLookupByLibrary.simpleMessage(
       "Neues Passwort bestätigen",
@@ -602,12 +605,12 @@ class MessageLookup extends MessageLookupByLibrary {
     "notificationTemplate": MessageLookupByLibrary.simpleMessage(
       "Benachrichtigungsvorlage",
     ),
-    "notifications": m14,
+    "notifications": m15,
     "oauth2Client": MessageLookupByLibrary.simpleMessage("OAuth2-Client"),
     "openAppSettings": MessageLookupByLibrary.simpleMessage(
       "App-Einstellungen öffnen",
     ),
-    "openAppSettingsToGrantPermissionMessage": m15,
+    "openAppSettingsToGrantPermissionMessage": m16,
     "openSettingsAndGrantAccessToCameraToContinue":
         MessageLookupByLibrary.simpleMessage(
           "Öffnen Sie die Einstellungen und gewähren Sie Kamerazugriff, um fortzufahren",
@@ -642,7 +645,7 @@ class MessageLookup extends MessageLookupByLibrary {
       "Passwort erfolgreich geändert",
     ),
     "permissions": MessageLookupByLibrary.simpleMessage("Berechtigungen"),
-    "permissionsNotEnoughMessage": m16,
+    "permissionsNotEnoughMessage": m17,
     "phone": MessageLookupByLibrary.simpleMessage("Telefon"),
     "phoneIsInvalid": MessageLookupByLibrary.simpleMessage(
       "Telefonnummer ist ungültig",
@@ -669,7 +672,7 @@ class MessageLookup extends MessageLookupByLibrary {
       "Bitte scannen Sie den QR-Code auf Ihrem Gerät",
     ),
     "plusAlarmType": MessageLookupByLibrary.simpleMessage("+ Alarmtyp"),
-    "popTitle": m17,
+    "popTitle": m18,
     "postalCode": MessageLookupByLibrary.simpleMessage("PLZ / Postleitzahl"),
     "privacyPolicy": MessageLookupByLibrary.simpleMessage(
       "Datenschutzerklärung",
@@ -702,7 +705,7 @@ class MessageLookup extends MessageLookupByLibrary {
     ),
     "resend": MessageLookupByLibrary.simpleMessage("Erneut senden"),
     "resendCode": MessageLookupByLibrary.simpleMessage("Code erneut senden"),
-    "resendCodeWait": m18,
+    "resendCodeWait": m19,
     "reset": MessageLookupByLibrary.simpleMessage("Zurücksetzen"),
     "retry": MessageLookupByLibrary.simpleMessage("Erneut versuchen"),
     "returnToDashboard": MessageLookupByLibrary.simpleMessage(
@@ -712,7 +715,7 @@ class MessageLookup extends MessageLookupByLibrary {
       "Kehren Sie zur App zurück und tippen Sie auf Bereit",
     ),
     "role": MessageLookupByLibrary.simpleMessage("Rolle"),
-    "routeNotDefined": m19,
+    "routeNotDefined": m20,
     "rpc": MessageLookupByLibrary.simpleMessage("RPC"),
     "ruleChain": MessageLookupByLibrary.simpleMessage("Regelkette"),
     "ruleNode": MessageLookupByLibrary.simpleMessage("Regelknoten"),
@@ -721,9 +724,10 @@ class MessageLookup extends MessageLookupByLibrary {
     "schedulerEvent": MessageLookupByLibrary.simpleMessage("Planer-Ereignis"),
     "search": MessageLookupByLibrary.simpleMessage("Suchen"),
     "searchResults": MessageLookupByLibrary.simpleMessage("Suchergebnisse"),
-    "searchUsers": m20,
+    "searchUsers": m21,
     "seconds": MessageLookupByLibrary.simpleMessage("Sekunden"),
     "security": MessageLookupByLibrary.simpleMessage("Sicherheit"),
+    "selectAll": MessageLookupByLibrary.simpleMessage("Alle auswählen"),
     "selectCountry": MessageLookupByLibrary.simpleMessage("Land auswählen"),
     "selectRegion": MessageLookupByLibrary.simpleMessage("Region auswählen"),
     "selectUser": MessageLookupByLibrary.simpleMessage("Benutzer auswählen"),
@@ -747,7 +751,7 @@ class MessageLookup extends MessageLookupByLibrary {
     "severity": MessageLookupByLibrary.simpleMessage("Schweregrad"),
     "signIn": MessageLookupByLibrary.simpleMessage("Anmelden"),
     "signUp": MessageLookupByLibrary.simpleMessage("Registrieren"),
-    "smsAuthDescription": m21,
+    "smsAuthDescription": m22,
     "smsAuthPlaceholder": MessageLookupByLibrary.simpleMessage("SMS-Code"),
     "smsSetupSuccessDescription": MessageLookupByLibrary.simpleMessage(
       "Bei der nächsten Anmeldung werden Sie aufgefordert, den Sicherheitscode einzugeben, der an die Telefonnummer gesendet wird",
@@ -813,7 +817,7 @@ class MessageLookup extends MessageLookupByLibrary {
     "unableConnectToDevice": MessageLookupByLibrary.simpleMessage(
       "Verbindung zum Gerät nicht möglich",
     ),
-    "unableConnectToWifiBecauseNetworksWasntFoundByDevice": m22,
+    "unableConnectToWifiBecauseNetworksWasntFoundByDevice": m23,
     "unableToUseCamera": MessageLookupByLibrary.simpleMessage(
       "Kamera kann nicht verwendet werden",
     ),
@@ -829,7 +833,7 @@ class MessageLookup extends MessageLookupByLibrary {
     "updateRequired": MessageLookupByLibrary.simpleMessage(
       "Aktualisierung erforderlich",
     ),
-    "updateTo": m23,
+    "updateTo": m24,
     "url": MessageLookupByLibrary.simpleMessage("URL"),
     "user": MessageLookupByLibrary.simpleMessage("Benutzer"),
     "username": MessageLookupByLibrary.simpleMessage("Benutzername"),
@@ -854,9 +858,9 @@ class MessageLookup extends MessageLookupByLibrary {
     "warning": MessageLookupByLibrary.simpleMessage("Warnung"),
     "widgetType": MessageLookupByLibrary.simpleMessage("Widget-Typ"),
     "widgetsBundle": MessageLookupByLibrary.simpleMessage("Widget-Paket"),
-    "wifiHelpMessage": m24,
+    "wifiHelpMessage": m25,
     "wifiPassword": MessageLookupByLibrary.simpleMessage("WLAN-Passwort"),
-    "wifiPasswordMessage": m25,
+    "wifiPasswordMessage": m26,
     "yes": MessageLookupByLibrary.simpleMessage("Ja"),
     "yesDeactivate": MessageLookupByLibrary.simpleMessage("Ja, deaktivieren"),
     "yesDiscard": MessageLookupByLibrary.simpleMessage("Ja, verwerfen"),

--- a/lib/generated/intl/messages_el_GR.dart
+++ b/lib/generated/intl/messages_el_GR.dart
@@ -767,7 +767,9 @@ class MessageLookup extends MessageLookupByLibrary {
     "searchUsers": m24,
     "seconds": MessageLookupByLibrary.simpleMessage("δευτερόλεπτα"),
     "security": MessageLookupByLibrary.simpleMessage("Ασφάλεια"),
-    "selectAll": MessageLookupByLibrary.simpleMessage("Επιλογή όλων"),
+    "selectAll": MessageLookupByLibrary.simpleMessage(
+      "Επιλογή όλων των φορτωμένων",
+    ),
     "selectCountry": MessageLookupByLibrary.simpleMessage("Επιλογή χώρας"),
     "selectRegion": MessageLookupByLibrary.simpleMessage("Επιλογή περιοχής"),
     "selectUser": MessageLookupByLibrary.simpleMessage("Επιλέξτε χρήστες"),

--- a/lib/generated/intl/messages_el_GR.dart
+++ b/lib/generated/intl/messages_el_GR.dart
@@ -58,38 +58,40 @@ class MessageLookup extends MessageLookupByLibrary {
 
   static String m13(error) => "Σφάλμα αποστολής κωδικού: ${error}";
 
-  static String m14(count) =>
+  static String m14(count) => "${count} επιλεγμένα";
+
+  static String m15(count) =>
       "${Intl.plural(count, one: 'Ειδοποίηση', other: 'Ειδοποιήσεις')}";
 
-  static String m15(permissions) =>
+  static String m16(permissions) =>
       "Δεν έχετε επαρκή δικαιώματα για \"${permissions}\" για να συνεχίσετε. Ανοίξτε τις ρυθμίσεις της εφαρμογής, παραχωρήστε τα δικαιώματα και πατήστε \"Δοκιμάστε ξανά\".";
 
-  static String m16(permissions) =>
+  static String m17(permissions) =>
       "Δεν έχετε επαρκή δικαιώματα για \"${permissions}\" για να συνεχίσετε. Παρακαλώ δώστε τα απαραίτητα δικαιώματα και πατήστε \"Δοκιμάστε ξανά\".";
 
-  static String m17(deviceName) =>
+  static String m18(deviceName) =>
       "Εισαγάγετε το PIN της συσκευής ${deviceName} για επιβεβαίωση ιδιοκτησίας";
 
-  static String m18(time) =>
+  static String m19(time) =>
       "Επανάληψη αποστολής σε ${Intl.plural(time, one: '1 δευτερόλεπτο', other: '${time} δευτερόλεπτα')}";
 
-  static String m19(name) => "Η διαδρομή δεν έχει οριστεί: ${name}";
+  static String m20(name) => "Η διαδρομή δεν έχει οριστεί: ${name}";
 
-  static String m20(count) =>
+  static String m21(count) =>
       "${Intl.plural(count, one: 'Αναζήτηση χρήστη', other: 'Αναζήτηση χρηστών')}";
 
-  static String m21(contact) =>
+  static String m22(contact) =>
       "Ένας κωδικός ασφαλείας έχει σταλεί στο τηλέφωνό σας στο ${contact}.";
 
-  static String m22(name) =>
+  static String m23(name) =>
       "Αδυναμία σύνδεσης στο Wi-Fi επειδή η συσκευή ${name} δεν βρήκε δίκτυα";
 
-  static String m23(version) => "Ενημέρωση σε ${version}";
+  static String m24(version) => "Ενημέρωση σε ${version}";
 
-  static String m24(deviceName) =>
+  static String m25(deviceName) =>
       "Για να συνεχίσετε τη ρύθμιση της συσκευής ${deviceName}, παρακαλώ δώστε τα διαπιστευτήρια του δικτύου σας.";
 
-  static String m25(network) =>
+  static String m26(network) =>
       "Εισαγάγετε τον κωδικό για το δίκτυο ${network}";
 
   final messages = _notInlinedMessages(_notInlinedMessages);
@@ -580,6 +582,7 @@ class MessageLookup extends MessageLookupByLibrary {
           "Ο πίνακας ελέγχου κινητού πρέπει να ρυθμιστεί στο προφίλ συσκευής!",
         ),
     "more": MessageLookupByLibrary.simpleMessage("Περισσότερα"),
+    "nSelected": m14,
     "newPassword": MessageLookupByLibrary.simpleMessage(
       "Νέος κωδικός πρόσβασης",
     ),
@@ -630,12 +633,12 @@ class MessageLookup extends MessageLookupByLibrary {
     "notificationTemplate": MessageLookupByLibrary.simpleMessage(
       "Πρότυπο ειδοποίησης",
     ),
-    "notifications": m14,
+    "notifications": m15,
     "oauth2Client": MessageLookupByLibrary.simpleMessage("Πελάτης OAuth2"),
     "openAppSettings": MessageLookupByLibrary.simpleMessage(
       "Άνοιγμα ρυθμίσεων εφαρμογής",
     ),
-    "openAppSettingsToGrantPermissionMessage": m15,
+    "openAppSettingsToGrantPermissionMessage": m16,
     "openSettingsAndGrantAccessToCameraToContinue":
         MessageLookupByLibrary.simpleMessage(
           "Ανοίξτε τις ρυθμίσεις και δώστε πρόσβαση στην κάμερα για να συνεχίσετε",
@@ -668,7 +671,7 @@ class MessageLookup extends MessageLookupByLibrary {
       "Ο κωδικός πρόσβασης άλλαξε με επιτυχία",
     ),
     "permissions": MessageLookupByLibrary.simpleMessage("Δικαιώματα"),
-    "permissionsNotEnoughMessage": m16,
+    "permissionsNotEnoughMessage": m17,
     "phone": MessageLookupByLibrary.simpleMessage("Τηλέφωνο"),
     "phoneIsInvalid": MessageLookupByLibrary.simpleMessage(
       "Ο αριθμός τηλεφώνου δεν είναι έγκυρος",
@@ -695,7 +698,7 @@ class MessageLookup extends MessageLookupByLibrary {
       "Σαρώστε τον κωδικό QR στη συσκευή σας",
     ),
     "plusAlarmType": MessageLookupByLibrary.simpleMessage("+ Τύπος συναγερμού"),
-    "popTitle": m17,
+    "popTitle": m18,
     "postalCode": MessageLookupByLibrary.simpleMessage("Ταχυδρομικός κώδικας"),
     "privacyPolicy": MessageLookupByLibrary.simpleMessage("Πολιτική απορρήτου"),
     "profile": MessageLookupByLibrary.simpleMessage("Προφίλ"),
@@ -726,7 +729,7 @@ class MessageLookup extends MessageLookupByLibrary {
     "resendCode": MessageLookupByLibrary.simpleMessage(
       "Επανάληψη αποστολής κωδικού",
     ),
-    "resendCodeWait": m18,
+    "resendCodeWait": m19,
     "reset": MessageLookupByLibrary.simpleMessage("Επαναφορά"),
     "retry": MessageLookupByLibrary.simpleMessage("Επανάληψη"),
     "returnToDashboard": MessageLookupByLibrary.simpleMessage(
@@ -736,7 +739,7 @@ class MessageLookup extends MessageLookupByLibrary {
       "Επιστρέψτε στην εφαρμογή και πατήστε το κουμπί Έτοιμο",
     ),
     "role": MessageLookupByLibrary.simpleMessage("Ρόλος"),
-    "routeNotDefined": m19,
+    "routeNotDefined": m20,
     "rpc": MessageLookupByLibrary.simpleMessage("RPC"),
     "ruleChain": MessageLookupByLibrary.simpleMessage("Αλυσίδα κανόνων"),
     "ruleNode": MessageLookupByLibrary.simpleMessage("Κόμβος κανόνων"),
@@ -749,9 +752,10 @@ class MessageLookup extends MessageLookupByLibrary {
     "searchResults": MessageLookupByLibrary.simpleMessage(
       "Αποτελέσματα αναζήτησης",
     ),
-    "searchUsers": m20,
+    "searchUsers": m21,
     "seconds": MessageLookupByLibrary.simpleMessage("δευτερόλεπτα"),
     "security": MessageLookupByLibrary.simpleMessage("Ασφάλεια"),
+    "selectAll": MessageLookupByLibrary.simpleMessage("Επιλογή όλων"),
     "selectCountry": MessageLookupByLibrary.simpleMessage("Επιλογή χώρας"),
     "selectRegion": MessageLookupByLibrary.simpleMessage("Επιλογή περιοχής"),
     "selectUser": MessageLookupByLibrary.simpleMessage("Επιλέξτε χρήστες"),
@@ -775,7 +779,7 @@ class MessageLookup extends MessageLookupByLibrary {
     "severity": MessageLookupByLibrary.simpleMessage("Σοβαρότητα"),
     "signIn": MessageLookupByLibrary.simpleMessage("Σύνδεση"),
     "signUp": MessageLookupByLibrary.simpleMessage("Εγγραφή"),
-    "smsAuthDescription": m21,
+    "smsAuthDescription": m22,
     "smsAuthPlaceholder": MessageLookupByLibrary.simpleMessage("Κωδικός SMS"),
     "smsSetupSuccessDescription": MessageLookupByLibrary.simpleMessage(
       "Την επόμενη φορά που θα συνδεθείτε, θα σας ζητηθεί ο κωδικός ασφαλείας που θα σταλεί στο τηλέφωνο",
@@ -841,7 +845,7 @@ class MessageLookup extends MessageLookupByLibrary {
     "unableConnectToDevice": MessageLookupByLibrary.simpleMessage(
       "Αδυναμία σύνδεσης στη συσκευή",
     ),
-    "unableConnectToWifiBecauseNetworksWasntFoundByDevice": m22,
+    "unableConnectToWifiBecauseNetworksWasntFoundByDevice": m23,
     "unableToUseCamera": MessageLookupByLibrary.simpleMessage(
       "Αδυναμία χρήσης κάμερας",
     ),
@@ -857,7 +861,7 @@ class MessageLookup extends MessageLookupByLibrary {
     "updateRequired": MessageLookupByLibrary.simpleMessage(
       "Απαιτείται ενημέρωση",
     ),
-    "updateTo": m23,
+    "updateTo": m24,
     "url": MessageLookupByLibrary.simpleMessage("URL"),
     "user": MessageLookupByLibrary.simpleMessage("Χρήστης"),
     "username": MessageLookupByLibrary.simpleMessage("όνομα χρήστη"),
@@ -884,9 +888,9 @@ class MessageLookup extends MessageLookupByLibrary {
     "warning": MessageLookupByLibrary.simpleMessage("Προειδοποίηση"),
     "widgetType": MessageLookupByLibrary.simpleMessage("Τύπος widget"),
     "widgetsBundle": MessageLookupByLibrary.simpleMessage("Πακέτο widgets"),
-    "wifiHelpMessage": m24,
+    "wifiHelpMessage": m25,
     "wifiPassword": MessageLookupByLibrary.simpleMessage("Κωδικός Wi-Fi"),
-    "wifiPasswordMessage": m25,
+    "wifiPasswordMessage": m26,
     "yes": MessageLookupByLibrary.simpleMessage("Ναι"),
     "yesDeactivate": MessageLookupByLibrary.simpleMessage(
       "Ναι, απενεργοποίηση",

--- a/lib/generated/intl/messages_el_GR.dart
+++ b/lib/generated/intl/messages_el_GR.dart
@@ -58,40 +58,43 @@ class MessageLookup extends MessageLookupByLibrary {
 
   static String m13(error) => "Σφάλμα αποστολής κωδικού: ${error}";
 
-  static String m14(count) => "${count} επιλεγμένα";
+  static String m14(count) =>
+      "${Intl.plural(count, one: '1 ενέργεια απέτυχε', other: '${count} ενέργειες απέτυχαν')}";
 
-  static String m15(count) =>
+  static String m15(count) => "${count} επιλεγμένα";
+
+  static String m16(count) =>
       "${Intl.plural(count, one: 'Ειδοποίηση', other: 'Ειδοποιήσεις')}";
 
-  static String m16(permissions) =>
+  static String m17(permissions) =>
       "Δεν έχετε επαρκή δικαιώματα για \"${permissions}\" για να συνεχίσετε. Ανοίξτε τις ρυθμίσεις της εφαρμογής, παραχωρήστε τα δικαιώματα και πατήστε \"Δοκιμάστε ξανά\".";
 
-  static String m17(permissions) =>
+  static String m18(permissions) =>
       "Δεν έχετε επαρκή δικαιώματα για \"${permissions}\" για να συνεχίσετε. Παρακαλώ δώστε τα απαραίτητα δικαιώματα και πατήστε \"Δοκιμάστε ξανά\".";
 
-  static String m18(deviceName) =>
+  static String m19(deviceName) =>
       "Εισαγάγετε το PIN της συσκευής ${deviceName} για επιβεβαίωση ιδιοκτησίας";
 
-  static String m19(time) =>
+  static String m20(time) =>
       "Επανάληψη αποστολής σε ${Intl.plural(time, one: '1 δευτερόλεπτο', other: '${time} δευτερόλεπτα')}";
 
-  static String m20(name) => "Η διαδρομή δεν έχει οριστεί: ${name}";
+  static String m21(name) => "Η διαδρομή δεν έχει οριστεί: ${name}";
 
-  static String m21(count) =>
+  static String m22(count) =>
       "${Intl.plural(count, one: 'Αναζήτηση χρήστη', other: 'Αναζήτηση χρηστών')}";
 
-  static String m22(contact) =>
+  static String m23(contact) =>
       "Ένας κωδικός ασφαλείας έχει σταλεί στο τηλέφωνό σας στο ${contact}.";
 
-  static String m23(name) =>
+  static String m24(name) =>
       "Αδυναμία σύνδεσης στο Wi-Fi επειδή η συσκευή ${name} δεν βρήκε δίκτυα";
 
-  static String m24(version) => "Ενημέρωση σε ${version}";
+  static String m25(version) => "Ενημέρωση σε ${version}";
 
-  static String m25(deviceName) =>
+  static String m26(deviceName) =>
       "Για να συνεχίσετε τη ρύθμιση της συσκευής ${deviceName}, παρακαλώ δώστε τα διαπιστευτήρια του δικτύου σας.";
 
-  static String m26(network) =>
+  static String m27(network) =>
       "Εισαγάγετε τον κωδικό για το δίκτυο ${network}";
 
   final messages = _notInlinedMessages(_notInlinedMessages);
@@ -479,6 +482,7 @@ class MessageLookup extends MessageLookupByLibrary {
     "failedToLoadTheList": MessageLookupByLibrary.simpleMessage(
       "Αποτυχία φόρτωσης της λίστας",
     ),
+    "failedToPerformOperation": m14,
     "failedToSaveImage": MessageLookupByLibrary.simpleMessage(
       "Αποτυχία αποθήκευσης εικόνας",
     ),
@@ -582,7 +586,7 @@ class MessageLookup extends MessageLookupByLibrary {
           "Ο πίνακας ελέγχου κινητού πρέπει να ρυθμιστεί στο προφίλ συσκευής!",
         ),
     "more": MessageLookupByLibrary.simpleMessage("Περισσότερα"),
-    "nSelected": m14,
+    "nSelected": m15,
     "newPassword": MessageLookupByLibrary.simpleMessage(
       "Νέος κωδικός πρόσβασης",
     ),
@@ -633,12 +637,12 @@ class MessageLookup extends MessageLookupByLibrary {
     "notificationTemplate": MessageLookupByLibrary.simpleMessage(
       "Πρότυπο ειδοποίησης",
     ),
-    "notifications": m15,
+    "notifications": m16,
     "oauth2Client": MessageLookupByLibrary.simpleMessage("Πελάτης OAuth2"),
     "openAppSettings": MessageLookupByLibrary.simpleMessage(
       "Άνοιγμα ρυθμίσεων εφαρμογής",
     ),
-    "openAppSettingsToGrantPermissionMessage": m16,
+    "openAppSettingsToGrantPermissionMessage": m17,
     "openSettingsAndGrantAccessToCameraToContinue":
         MessageLookupByLibrary.simpleMessage(
           "Ανοίξτε τις ρυθμίσεις και δώστε πρόσβαση στην κάμερα για να συνεχίσετε",
@@ -671,7 +675,7 @@ class MessageLookup extends MessageLookupByLibrary {
       "Ο κωδικός πρόσβασης άλλαξε με επιτυχία",
     ),
     "permissions": MessageLookupByLibrary.simpleMessage("Δικαιώματα"),
-    "permissionsNotEnoughMessage": m17,
+    "permissionsNotEnoughMessage": m18,
     "phone": MessageLookupByLibrary.simpleMessage("Τηλέφωνο"),
     "phoneIsInvalid": MessageLookupByLibrary.simpleMessage(
       "Ο αριθμός τηλεφώνου δεν είναι έγκυρος",
@@ -698,7 +702,7 @@ class MessageLookup extends MessageLookupByLibrary {
       "Σαρώστε τον κωδικό QR στη συσκευή σας",
     ),
     "plusAlarmType": MessageLookupByLibrary.simpleMessage("+ Τύπος συναγερμού"),
-    "popTitle": m18,
+    "popTitle": m19,
     "postalCode": MessageLookupByLibrary.simpleMessage("Ταχυδρομικός κώδικας"),
     "privacyPolicy": MessageLookupByLibrary.simpleMessage("Πολιτική απορρήτου"),
     "profile": MessageLookupByLibrary.simpleMessage("Προφίλ"),
@@ -729,7 +733,7 @@ class MessageLookup extends MessageLookupByLibrary {
     "resendCode": MessageLookupByLibrary.simpleMessage(
       "Επανάληψη αποστολής κωδικού",
     ),
-    "resendCodeWait": m19,
+    "resendCodeWait": m20,
     "reset": MessageLookupByLibrary.simpleMessage("Επαναφορά"),
     "retry": MessageLookupByLibrary.simpleMessage("Επανάληψη"),
     "returnToDashboard": MessageLookupByLibrary.simpleMessage(
@@ -739,7 +743,7 @@ class MessageLookup extends MessageLookupByLibrary {
       "Επιστρέψτε στην εφαρμογή και πατήστε το κουμπί Έτοιμο",
     ),
     "role": MessageLookupByLibrary.simpleMessage("Ρόλος"),
-    "routeNotDefined": m20,
+    "routeNotDefined": m21,
     "rpc": MessageLookupByLibrary.simpleMessage("RPC"),
     "ruleChain": MessageLookupByLibrary.simpleMessage("Αλυσίδα κανόνων"),
     "ruleNode": MessageLookupByLibrary.simpleMessage("Κόμβος κανόνων"),
@@ -752,7 +756,7 @@ class MessageLookup extends MessageLookupByLibrary {
     "searchResults": MessageLookupByLibrary.simpleMessage(
       "Αποτελέσματα αναζήτησης",
     ),
-    "searchUsers": m21,
+    "searchUsers": m22,
     "seconds": MessageLookupByLibrary.simpleMessage("δευτερόλεπτα"),
     "security": MessageLookupByLibrary.simpleMessage("Ασφάλεια"),
     "selectAll": MessageLookupByLibrary.simpleMessage("Επιλογή όλων"),
@@ -779,7 +783,7 @@ class MessageLookup extends MessageLookupByLibrary {
     "severity": MessageLookupByLibrary.simpleMessage("Σοβαρότητα"),
     "signIn": MessageLookupByLibrary.simpleMessage("Σύνδεση"),
     "signUp": MessageLookupByLibrary.simpleMessage("Εγγραφή"),
-    "smsAuthDescription": m22,
+    "smsAuthDescription": m23,
     "smsAuthPlaceholder": MessageLookupByLibrary.simpleMessage("Κωδικός SMS"),
     "smsSetupSuccessDescription": MessageLookupByLibrary.simpleMessage(
       "Την επόμενη φορά που θα συνδεθείτε, θα σας ζητηθεί ο κωδικός ασφαλείας που θα σταλεί στο τηλέφωνο",
@@ -845,7 +849,7 @@ class MessageLookup extends MessageLookupByLibrary {
     "unableConnectToDevice": MessageLookupByLibrary.simpleMessage(
       "Αδυναμία σύνδεσης στη συσκευή",
     ),
-    "unableConnectToWifiBecauseNetworksWasntFoundByDevice": m23,
+    "unableConnectToWifiBecauseNetworksWasntFoundByDevice": m24,
     "unableToUseCamera": MessageLookupByLibrary.simpleMessage(
       "Αδυναμία χρήσης κάμερας",
     ),
@@ -861,7 +865,7 @@ class MessageLookup extends MessageLookupByLibrary {
     "updateRequired": MessageLookupByLibrary.simpleMessage(
       "Απαιτείται ενημέρωση",
     ),
-    "updateTo": m24,
+    "updateTo": m25,
     "url": MessageLookupByLibrary.simpleMessage("URL"),
     "user": MessageLookupByLibrary.simpleMessage("Χρήστης"),
     "username": MessageLookupByLibrary.simpleMessage("όνομα χρήστη"),
@@ -888,9 +892,9 @@ class MessageLookup extends MessageLookupByLibrary {
     "warning": MessageLookupByLibrary.simpleMessage("Προειδοποίηση"),
     "widgetType": MessageLookupByLibrary.simpleMessage("Τύπος widget"),
     "widgetsBundle": MessageLookupByLibrary.simpleMessage("Πακέτο widgets"),
-    "wifiHelpMessage": m25,
+    "wifiHelpMessage": m26,
     "wifiPassword": MessageLookupByLibrary.simpleMessage("Κωδικός Wi-Fi"),
-    "wifiPasswordMessage": m26,
+    "wifiPasswordMessage": m27,
     "yes": MessageLookupByLibrary.simpleMessage("Ναι"),
     "yesDeactivate": MessageLookupByLibrary.simpleMessage(
       "Ναι, απενεργοποίηση",

--- a/lib/generated/intl/messages_el_GR.dart
+++ b/lib/generated/intl/messages_el_GR.dart
@@ -46,55 +46,61 @@ class MessageLookup extends MessageLookupByLibrary {
       "${Intl.plural(count, one: 'Πίνακας ελέγχου', other: 'Πίνακες ελέγχου')}";
 
   static String m9(count) =>
-      "${Intl.plural(count, one: 'Συσκευή', other: 'Συσκευές')}";
+      "${Intl.plural(count, one: 'Διαγραφή 1 ειδοποίησης;', other: 'Διαγραφή ${count} ειδοποιήσεων;')}";
 
   static String m10(count) =>
+      "${Intl.plural(count, one: 'Συσκευή', other: 'Συσκευές')}";
+
+  static String m11(count) =>
       "${count}-${Intl.plural(count, one: 'ψήφιος', other: 'ψήφιος')} κωδικός";
 
-  static String m11(contact) =>
+  static String m12(contact) =>
       "Ένας κωδικός ασφαλείας έχει σταλεί στο email σας στη διεύθυνση ${contact}.";
 
-  static String m12(e) => "Παρουσιάστηκε σφάλμα: ${e}";
+  static String m13(e) => "Παρουσιάστηκε σφάλμα: ${e}";
 
-  static String m13(error) => "Σφάλμα αποστολής κωδικού: ${error}";
+  static String m14(error) => "Σφάλμα αποστολής κωδικού: ${error}";
 
-  static String m14(count) =>
+  static String m15(count) =>
       "${Intl.plural(count, one: '1 ενέργεια απέτυχε', other: '${count} ενέργειες απέτυχαν')}";
 
-  static String m15(count) => "${count} επιλεγμένα";
-
   static String m16(count) =>
+      "${Intl.plural(count, one: 'Σήμανση 1 ειδοποίησης ως αναγνωσμένης;', other: 'Σήμανση ${count} ειδοποιήσεων ως αναγνωσμένων;')}";
+
+  static String m17(count) => "${count} επιλεγμένα";
+
+  static String m18(count) =>
       "${Intl.plural(count, one: 'Ειδοποίηση', other: 'Ειδοποιήσεις')}";
 
-  static String m17(permissions) =>
+  static String m19(permissions) =>
       "Δεν έχετε επαρκή δικαιώματα για \"${permissions}\" για να συνεχίσετε. Ανοίξτε τις ρυθμίσεις της εφαρμογής, παραχωρήστε τα δικαιώματα και πατήστε \"Δοκιμάστε ξανά\".";
 
-  static String m18(permissions) =>
+  static String m20(permissions) =>
       "Δεν έχετε επαρκή δικαιώματα για \"${permissions}\" για να συνεχίσετε. Παρακαλώ δώστε τα απαραίτητα δικαιώματα και πατήστε \"Δοκιμάστε ξανά\".";
 
-  static String m19(deviceName) =>
+  static String m21(deviceName) =>
       "Εισαγάγετε το PIN της συσκευής ${deviceName} για επιβεβαίωση ιδιοκτησίας";
 
-  static String m20(time) =>
+  static String m22(time) =>
       "Επανάληψη αποστολής σε ${Intl.plural(time, one: '1 δευτερόλεπτο', other: '${time} δευτερόλεπτα')}";
 
-  static String m21(name) => "Η διαδρομή δεν έχει οριστεί: ${name}";
+  static String m23(name) => "Η διαδρομή δεν έχει οριστεί: ${name}";
 
-  static String m22(count) =>
+  static String m24(count) =>
       "${Intl.plural(count, one: 'Αναζήτηση χρήστη', other: 'Αναζήτηση χρηστών')}";
 
-  static String m23(contact) =>
+  static String m25(contact) =>
       "Ένας κωδικός ασφαλείας έχει σταλεί στο τηλέφωνό σας στο ${contact}.";
 
-  static String m24(name) =>
+  static String m26(name) =>
       "Αδυναμία σύνδεσης στο Wi-Fi επειδή η συσκευή ${name} δεν βρήκε δίκτυα";
 
-  static String m25(version) => "Ενημέρωση σε ${version}";
+  static String m27(version) => "Ενημέρωση σε ${version}";
 
-  static String m26(deviceName) =>
+  static String m28(deviceName) =>
       "Για να συνεχίσετε τη ρύθμιση της συσκευής ${deviceName}, παρακαλώ δώστε τα διαπιστευτήρια του δικτύου σας.";
 
-  static String m27(network) =>
+  static String m29(network) =>
       "Εισαγάγετε τον κωδικό για το δίκτυο ${network}";
 
   final messages = _notInlinedMessages(_notInlinedMessages);
@@ -401,6 +407,7 @@ class MessageLookup extends MessageLookupByLibrary {
       "Διαγραφή λογαριασμού",
     ),
     "deleteComment": MessageLookupByLibrary.simpleMessage("Διαγραφή σχολίου"),
+    "deleteSelectedNotifications": m9,
     "details": MessageLookupByLibrary.simpleMessage("Λεπτομέρειες"),
     "deviceList": MessageLookupByLibrary.simpleMessage("Λίστα συσκευών"),
     "deviceNotAbleToFindWifiNearby": MessageLookupByLibrary.simpleMessage(
@@ -413,8 +420,8 @@ class MessageLookup extends MessageLookupByLibrary {
     "deviceProvisioning": MessageLookupByLibrary.simpleMessage(
       "Διαμόρφωση συσκευής",
     ),
-    "devices": m9,
-    "digitsCode": m10,
+    "devices": m10,
+    "digitsCode": m11,
     "discardChanges": MessageLookupByLibrary.simpleMessage("Απόρριψη αλλαγών"),
     "domain": MessageLookupByLibrary.simpleMessage("Τομέας"),
     "done": MessageLookupByLibrary.simpleMessage("Ολοκληρώθηκε"),
@@ -423,7 +430,7 @@ class MessageLookup extends MessageLookupByLibrary {
     "edit": MessageLookupByLibrary.simpleMessage("Επεξεργασία"),
     "edited": MessageLookupByLibrary.simpleMessage("Επεξεργασμένο"),
     "email": MessageLookupByLibrary.simpleMessage("Email"),
-    "emailAuthDescription": m11,
+    "emailAuthDescription": m12,
     "emailAuthPlaceholder": MessageLookupByLibrary.simpleMessage(
       "Κωδικός email",
     ),
@@ -466,8 +473,8 @@ class MessageLookup extends MessageLookupByLibrary {
     "entityGroup": MessageLookupByLibrary.simpleMessage("Ομάδα οντοτήτων"),
     "entityType": MessageLookupByLibrary.simpleMessage("Τύπος οντότητας"),
     "entityView": MessageLookupByLibrary.simpleMessage("Προβολή οντότητας"),
-    "errorOccured": m12,
-    "errorSendingCode": m13,
+    "errorOccured": m13,
+    "errorSendingCode": m14,
     "europe": MessageLookupByLibrary.simpleMessage("Ευρώπη"),
     "europeRegionShort": MessageLookupByLibrary.simpleMessage("Φρανκφούρτη"),
     "exitDeviceProvisioning": MessageLookupByLibrary.simpleMessage(
@@ -482,7 +489,7 @@ class MessageLookup extends MessageLookupByLibrary {
     "failedToLoadTheList": MessageLookupByLibrary.simpleMessage(
       "Αποτυχία φόρτωσης της λίστας",
     ),
-    "failedToPerformOperation": m14,
+    "failedToPerformOperation": m15,
     "failedToSaveImage": MessageLookupByLibrary.simpleMessage(
       "Αποτυχία αποθήκευσης εικόνας",
     ),
@@ -566,6 +573,7 @@ class MessageLookup extends MessageLookupByLibrary {
     "markAsRead": MessageLookupByLibrary.simpleMessage(
       "Σήμανση ως αναγνωσμένο",
     ),
+    "markSelectedNotificationsAsRead": m16,
     "metricUnitSystem": MessageLookupByLibrary.simpleMessage("Μετρικό"),
     "mfaProviderBackupCode": MessageLookupByLibrary.simpleMessage(
       "Εφεδρικός κωδικός",
@@ -586,7 +594,7 @@ class MessageLookup extends MessageLookupByLibrary {
           "Ο πίνακας ελέγχου κινητού πρέπει να ρυθμιστεί στο προφίλ συσκευής!",
         ),
     "more": MessageLookupByLibrary.simpleMessage("Περισσότερα"),
-    "nSelected": m15,
+    "nSelected": m17,
     "newPassword": MessageLookupByLibrary.simpleMessage(
       "Νέος κωδικός πρόσβασης",
     ),
@@ -637,12 +645,12 @@ class MessageLookup extends MessageLookupByLibrary {
     "notificationTemplate": MessageLookupByLibrary.simpleMessage(
       "Πρότυπο ειδοποίησης",
     ),
-    "notifications": m16,
+    "notifications": m18,
     "oauth2Client": MessageLookupByLibrary.simpleMessage("Πελάτης OAuth2"),
     "openAppSettings": MessageLookupByLibrary.simpleMessage(
       "Άνοιγμα ρυθμίσεων εφαρμογής",
     ),
-    "openAppSettingsToGrantPermissionMessage": m17,
+    "openAppSettingsToGrantPermissionMessage": m19,
     "openSettingsAndGrantAccessToCameraToContinue":
         MessageLookupByLibrary.simpleMessage(
           "Ανοίξτε τις ρυθμίσεις και δώστε πρόσβαση στην κάμερα για να συνεχίσετε",
@@ -675,7 +683,7 @@ class MessageLookup extends MessageLookupByLibrary {
       "Ο κωδικός πρόσβασης άλλαξε με επιτυχία",
     ),
     "permissions": MessageLookupByLibrary.simpleMessage("Δικαιώματα"),
-    "permissionsNotEnoughMessage": m18,
+    "permissionsNotEnoughMessage": m20,
     "phone": MessageLookupByLibrary.simpleMessage("Τηλέφωνο"),
     "phoneIsInvalid": MessageLookupByLibrary.simpleMessage(
       "Ο αριθμός τηλεφώνου δεν είναι έγκυρος",
@@ -702,7 +710,7 @@ class MessageLookup extends MessageLookupByLibrary {
       "Σαρώστε τον κωδικό QR στη συσκευή σας",
     ),
     "plusAlarmType": MessageLookupByLibrary.simpleMessage("+ Τύπος συναγερμού"),
-    "popTitle": m19,
+    "popTitle": m21,
     "postalCode": MessageLookupByLibrary.simpleMessage("Ταχυδρομικός κώδικας"),
     "privacyPolicy": MessageLookupByLibrary.simpleMessage("Πολιτική απορρήτου"),
     "profile": MessageLookupByLibrary.simpleMessage("Προφίλ"),
@@ -733,7 +741,7 @@ class MessageLookup extends MessageLookupByLibrary {
     "resendCode": MessageLookupByLibrary.simpleMessage(
       "Επανάληψη αποστολής κωδικού",
     ),
-    "resendCodeWait": m20,
+    "resendCodeWait": m22,
     "reset": MessageLookupByLibrary.simpleMessage("Επαναφορά"),
     "retry": MessageLookupByLibrary.simpleMessage("Επανάληψη"),
     "returnToDashboard": MessageLookupByLibrary.simpleMessage(
@@ -743,7 +751,7 @@ class MessageLookup extends MessageLookupByLibrary {
       "Επιστρέψτε στην εφαρμογή και πατήστε το κουμπί Έτοιμο",
     ),
     "role": MessageLookupByLibrary.simpleMessage("Ρόλος"),
-    "routeNotDefined": m21,
+    "routeNotDefined": m23,
     "rpc": MessageLookupByLibrary.simpleMessage("RPC"),
     "ruleChain": MessageLookupByLibrary.simpleMessage("Αλυσίδα κανόνων"),
     "ruleNode": MessageLookupByLibrary.simpleMessage("Κόμβος κανόνων"),
@@ -756,7 +764,7 @@ class MessageLookup extends MessageLookupByLibrary {
     "searchResults": MessageLookupByLibrary.simpleMessage(
       "Αποτελέσματα αναζήτησης",
     ),
-    "searchUsers": m22,
+    "searchUsers": m24,
     "seconds": MessageLookupByLibrary.simpleMessage("δευτερόλεπτα"),
     "security": MessageLookupByLibrary.simpleMessage("Ασφάλεια"),
     "selectAll": MessageLookupByLibrary.simpleMessage("Επιλογή όλων"),
@@ -783,7 +791,7 @@ class MessageLookup extends MessageLookupByLibrary {
     "severity": MessageLookupByLibrary.simpleMessage("Σοβαρότητα"),
     "signIn": MessageLookupByLibrary.simpleMessage("Σύνδεση"),
     "signUp": MessageLookupByLibrary.simpleMessage("Εγγραφή"),
-    "smsAuthDescription": m23,
+    "smsAuthDescription": m25,
     "smsAuthPlaceholder": MessageLookupByLibrary.simpleMessage("Κωδικός SMS"),
     "smsSetupSuccessDescription": MessageLookupByLibrary.simpleMessage(
       "Την επόμενη φορά που θα συνδεθείτε, θα σας ζητηθεί ο κωδικός ασφαλείας που θα σταλεί στο τηλέφωνο",
@@ -849,7 +857,7 @@ class MessageLookup extends MessageLookupByLibrary {
     "unableConnectToDevice": MessageLookupByLibrary.simpleMessage(
       "Αδυναμία σύνδεσης στη συσκευή",
     ),
-    "unableConnectToWifiBecauseNetworksWasntFoundByDevice": m24,
+    "unableConnectToWifiBecauseNetworksWasntFoundByDevice": m26,
     "unableToUseCamera": MessageLookupByLibrary.simpleMessage(
       "Αδυναμία χρήσης κάμερας",
     ),
@@ -865,7 +873,7 @@ class MessageLookup extends MessageLookupByLibrary {
     "updateRequired": MessageLookupByLibrary.simpleMessage(
       "Απαιτείται ενημέρωση",
     ),
-    "updateTo": m25,
+    "updateTo": m27,
     "url": MessageLookupByLibrary.simpleMessage("URL"),
     "user": MessageLookupByLibrary.simpleMessage("Χρήστης"),
     "username": MessageLookupByLibrary.simpleMessage("όνομα χρήστη"),
@@ -892,9 +900,9 @@ class MessageLookup extends MessageLookupByLibrary {
     "warning": MessageLookupByLibrary.simpleMessage("Προειδοποίηση"),
     "widgetType": MessageLookupByLibrary.simpleMessage("Τύπος widget"),
     "widgetsBundle": MessageLookupByLibrary.simpleMessage("Πακέτο widgets"),
-    "wifiHelpMessage": m26,
+    "wifiHelpMessage": m28,
     "wifiPassword": MessageLookupByLibrary.simpleMessage("Κωδικός Wi-Fi"),
-    "wifiPasswordMessage": m27,
+    "wifiPasswordMessage": m29,
     "yes": MessageLookupByLibrary.simpleMessage("Ναι"),
     "yesDeactivate": MessageLookupByLibrary.simpleMessage(
       "Ναι, απενεργοποίηση",

--- a/lib/generated/intl/messages_en.dart
+++ b/lib/generated/intl/messages_en.dart
@@ -46,55 +46,61 @@ class MessageLookup extends MessageLookupByLibrary {
       "${Intl.plural(count, one: 'Dashboard', other: 'Dashboards')}";
 
   static String m9(count) =>
-      "${Intl.plural(count, one: 'Device', other: 'Devices')}";
+      "${Intl.plural(count, one: 'Delete 1 notification?', other: 'Delete ${count} notifications?')}";
 
   static String m10(count) =>
+      "${Intl.plural(count, one: 'Device', other: 'Devices')}";
+
+  static String m11(count) =>
       "${count}-${Intl.plural(count, one: 'digit', other: 'digits')} code";
 
-  static String m11(contact) =>
+  static String m12(contact) =>
       "A security code has been sent to your email address at ${contact}.";
 
-  static String m12(e) => "Error occured: ${e}";
+  static String m13(e) => "Error occured: ${e}";
 
-  static String m13(error) => "Error sending code: ${error}";
+  static String m14(error) => "Error sending code: ${error}";
 
-  static String m14(count) =>
+  static String m15(count) =>
       "${Intl.plural(count, one: '1 operation failed', other: '${count} operations failed')}";
 
-  static String m15(count) => "${count} selected";
-
   static String m16(count) =>
+      "${Intl.plural(count, one: 'Mark 1 notification as read?', other: 'Mark ${count} notifications as read?')}";
+
+  static String m17(count) => "${count} selected";
+
+  static String m18(count) =>
       "${Intl.plural(count, one: 'Notification', other: 'Notifications')}";
 
-  static String m17(permissions) =>
+  static String m19(permissions) =>
       "You don\'t have enough permissions for \"${permissions}\" to proceed. Please open app settings, grant permissions and trap \"Try Again\".";
 
-  static String m18(permissions) =>
+  static String m20(permissions) =>
       "You don\'t have enough permissions for \"${permissions}\" to proceed. Please grant the required permissions and tap \"Try Again\".";
 
-  static String m19(deviceName) =>
+  static String m21(deviceName) =>
       "Enter PIN of ${deviceName} to confirm proof of possession";
 
-  static String m20(time) =>
+  static String m22(time) =>
       "Resend code in ${Intl.plural(time, one: '1 second', other: '${time} seconds')}";
 
-  static String m21(name) => "Route not defined: ${name}";
+  static String m23(name) => "Route not defined: ${name}";
 
-  static String m22(count) =>
+  static String m24(count) =>
       "${Intl.plural(count, one: 'Search user', other: 'Search users')}";
 
-  static String m23(contact) =>
+  static String m25(contact) =>
       "A security code has been sent to your phone at ${contact}.";
 
-  static String m24(name) =>
+  static String m26(name) =>
       "Unable connect to Wi-Fi because networks wasn\'t found by device ${name}";
 
-  static String m25(version) => "Update to ${version}";
+  static String m27(version) => "Update to ${version}";
 
-  static String m26(deviceName) =>
+  static String m28(deviceName) =>
       "To continue setup of your device ${deviceName}, please provide your Network\'s credentials.";
 
-  static String m27(network) => "Enter password for ${network}";
+  static String m29(network) => "Enter password for ${network}";
 
   final messages = _notInlinedMessages(_notInlinedMessages);
   static Map<String, Function> _notInlinedMessages(_) => <String, Function>{
@@ -368,6 +374,7 @@ class MessageLookup extends MessageLookupByLibrary {
     "delete": MessageLookupByLibrary.simpleMessage("Delete"),
     "deleteAccount": MessageLookupByLibrary.simpleMessage("Delete account"),
     "deleteComment": MessageLookupByLibrary.simpleMessage("Delete comment"),
+    "deleteSelectedNotifications": m9,
     "details": MessageLookupByLibrary.simpleMessage("Details"),
     "deviceList": MessageLookupByLibrary.simpleMessage("Device list"),
     "deviceNotAbleToFindWifiNearby": MessageLookupByLibrary.simpleMessage(
@@ -380,8 +387,8 @@ class MessageLookup extends MessageLookupByLibrary {
     "deviceProvisioning": MessageLookupByLibrary.simpleMessage(
       "Device provisioning",
     ),
-    "devices": m9,
-    "digitsCode": m10,
+    "devices": m10,
+    "digitsCode": m11,
     "discardChanges": MessageLookupByLibrary.simpleMessage("Discard changes"),
     "domain": MessageLookupByLibrary.simpleMessage("Domain"),
     "done": MessageLookupByLibrary.simpleMessage("Done"),
@@ -390,7 +397,7 @@ class MessageLookup extends MessageLookupByLibrary {
     "edit": MessageLookupByLibrary.simpleMessage("Edit"),
     "edited": MessageLookupByLibrary.simpleMessage("Edited"),
     "email": MessageLookupByLibrary.simpleMessage("Email"),
-    "emailAuthDescription": m11,
+    "emailAuthDescription": m12,
     "emailAuthPlaceholder": MessageLookupByLibrary.simpleMessage("Email code"),
     "emailInvalidText": MessageLookupByLibrary.simpleMessage(
       "Invalid email format.",
@@ -429,8 +436,8 @@ class MessageLookup extends MessageLookupByLibrary {
     "entityGroup": MessageLookupByLibrary.simpleMessage("Entity Group"),
     "entityType": MessageLookupByLibrary.simpleMessage("Entity Type"),
     "entityView": MessageLookupByLibrary.simpleMessage("Entity view"),
-    "errorOccured": m12,
-    "errorSendingCode": m13,
+    "errorOccured": m13,
+    "errorSendingCode": m14,
     "europe": MessageLookupByLibrary.simpleMessage("Europe"),
     "europeRegionShort": MessageLookupByLibrary.simpleMessage("Frankfurt"),
     "exitDeviceProvisioning": MessageLookupByLibrary.simpleMessage(
@@ -445,7 +452,7 @@ class MessageLookup extends MessageLookupByLibrary {
     "failedToLoadTheList": MessageLookupByLibrary.simpleMessage(
       "Failed to load the list",
     ),
-    "failedToPerformOperation": m14,
+    "failedToPerformOperation": m15,
     "failedToSaveImage": MessageLookupByLibrary.simpleMessage(
       "Failed to save image",
     ),
@@ -519,6 +526,7 @@ class MessageLookup extends MessageLookupByLibrary {
     "major": MessageLookupByLibrary.simpleMessage("Major"),
     "markAllAsRead": MessageLookupByLibrary.simpleMessage("Mark all as read"),
     "markAsRead": MessageLookupByLibrary.simpleMessage("Mark as read"),
+    "markSelectedNotificationsAsRead": m16,
     "metricUnitSystem": MessageLookupByLibrary.simpleMessage("Metric"),
     "mfaProviderBackupCode": MessageLookupByLibrary.simpleMessage(
       "Backup code",
@@ -539,7 +547,7 @@ class MessageLookup extends MessageLookupByLibrary {
           "Mobile dashboard should be configured in device profile!",
         ),
     "more": MessageLookupByLibrary.simpleMessage("More"),
-    "nSelected": m15,
+    "nSelected": m17,
     "newPassword": MessageLookupByLibrary.simpleMessage("New password"),
     "newPassword2": MessageLookupByLibrary.simpleMessage(
       "Confirm new password",
@@ -582,12 +590,12 @@ class MessageLookup extends MessageLookupByLibrary {
     "notificationTemplate": MessageLookupByLibrary.simpleMessage(
       "Notification template",
     ),
-    "notifications": m16,
+    "notifications": m18,
     "oauth2Client": MessageLookupByLibrary.simpleMessage("Oauth2 client"),
     "openAppSettings": MessageLookupByLibrary.simpleMessage(
       "Open app settings",
     ),
-    "openAppSettingsToGrantPermissionMessage": m17,
+    "openAppSettingsToGrantPermissionMessage": m19,
     "openSettingsAndGrantAccessToCameraToContinue":
         MessageLookupByLibrary.simpleMessage(
           "Open settings and grant access to camera to continue",
@@ -620,7 +628,7 @@ class MessageLookup extends MessageLookupByLibrary {
       "Password successfully changed",
     ),
     "permissions": MessageLookupByLibrary.simpleMessage("Permissions"),
-    "permissionsNotEnoughMessage": m18,
+    "permissionsNotEnoughMessage": m20,
     "phone": MessageLookupByLibrary.simpleMessage("Phone"),
     "phoneIsInvalid": MessageLookupByLibrary.simpleMessage("Phone is invalid"),
     "phoneIsRequired": MessageLookupByLibrary.simpleMessage(
@@ -645,7 +653,7 @@ class MessageLookup extends MessageLookupByLibrary {
       "Please scan QR code on your device",
     ),
     "plusAlarmType": MessageLookupByLibrary.simpleMessage("+ Alarm type"),
-    "popTitle": m19,
+    "popTitle": m21,
     "postalCode": MessageLookupByLibrary.simpleMessage("Zip / Postal Code"),
     "privacyPolicy": MessageLookupByLibrary.simpleMessage("Privacy Policy"),
     "profile": MessageLookupByLibrary.simpleMessage("Profile"),
@@ -674,7 +682,7 @@ class MessageLookup extends MessageLookupByLibrary {
     ),
     "resend": MessageLookupByLibrary.simpleMessage("Resend"),
     "resendCode": MessageLookupByLibrary.simpleMessage("Resend code"),
-    "resendCodeWait": m20,
+    "resendCodeWait": m22,
     "reset": MessageLookupByLibrary.simpleMessage("Reset"),
     "retry": MessageLookupByLibrary.simpleMessage("Retry"),
     "returnToDashboard": MessageLookupByLibrary.simpleMessage(
@@ -684,7 +692,7 @@ class MessageLookup extends MessageLookupByLibrary {
       "Return to the app and tap Ready button",
     ),
     "role": MessageLookupByLibrary.simpleMessage("Role"),
-    "routeNotDefined": m21,
+    "routeNotDefined": m23,
     "rpc": MessageLookupByLibrary.simpleMessage("RPC"),
     "ruleChain": MessageLookupByLibrary.simpleMessage("Rule chain"),
     "ruleNode": MessageLookupByLibrary.simpleMessage("Rule node"),
@@ -693,7 +701,7 @@ class MessageLookup extends MessageLookupByLibrary {
     "schedulerEvent": MessageLookupByLibrary.simpleMessage("Scheduler Event"),
     "search": MessageLookupByLibrary.simpleMessage("Search"),
     "searchResults": MessageLookupByLibrary.simpleMessage("Search results"),
-    "searchUsers": m22,
+    "searchUsers": m24,
     "seconds": MessageLookupByLibrary.simpleMessage("seconds"),
     "security": MessageLookupByLibrary.simpleMessage("Security"),
     "selectAll": MessageLookupByLibrary.simpleMessage("Select all"),
@@ -720,7 +728,7 @@ class MessageLookup extends MessageLookupByLibrary {
     "severity": MessageLookupByLibrary.simpleMessage("Severity"),
     "signIn": MessageLookupByLibrary.simpleMessage("Sign In"),
     "signUp": MessageLookupByLibrary.simpleMessage("Sign up"),
-    "smsAuthDescription": m23,
+    "smsAuthDescription": m25,
     "smsAuthPlaceholder": MessageLookupByLibrary.simpleMessage("SMS code"),
     "smsSetupSuccessDescription": MessageLookupByLibrary.simpleMessage(
       "The next time you log in, you will be prompted to enter the security code that will be sent to the phone number",
@@ -782,7 +790,7 @@ class MessageLookup extends MessageLookupByLibrary {
     "unableConnectToDevice": MessageLookupByLibrary.simpleMessage(
       "Unable connect to device",
     ),
-    "unableConnectToWifiBecauseNetworksWasntFoundByDevice": m24,
+    "unableConnectToWifiBecauseNetworksWasntFoundByDevice": m26,
     "unableToUseCamera": MessageLookupByLibrary.simpleMessage(
       "Unable to use camera",
     ),
@@ -794,7 +802,7 @@ class MessageLookup extends MessageLookupByLibrary {
     "unsavedChanges": MessageLookupByLibrary.simpleMessage("Unsaved changes"),
     "update": MessageLookupByLibrary.simpleMessage("Update"),
     "updateRequired": MessageLookupByLibrary.simpleMessage("Update required"),
-    "updateTo": m25,
+    "updateTo": m27,
     "url": MessageLookupByLibrary.simpleMessage("Url"),
     "user": MessageLookupByLibrary.simpleMessage("User"),
     "username": MessageLookupByLibrary.simpleMessage("username"),
@@ -819,9 +827,9 @@ class MessageLookup extends MessageLookupByLibrary {
     "warning": MessageLookupByLibrary.simpleMessage("Warning"),
     "widgetType": MessageLookupByLibrary.simpleMessage("Widget type"),
     "widgetsBundle": MessageLookupByLibrary.simpleMessage("Widgets bundle"),
-    "wifiHelpMessage": m26,
+    "wifiHelpMessage": m28,
     "wifiPassword": MessageLookupByLibrary.simpleMessage("Wi-Fi password"),
-    "wifiPasswordMessage": m27,
+    "wifiPasswordMessage": m29,
     "yes": MessageLookupByLibrary.simpleMessage("Yes"),
     "yesDeactivate": MessageLookupByLibrary.simpleMessage("Yes, deactivate"),
     "yesDiscard": MessageLookupByLibrary.simpleMessage("Yes, discard"),

--- a/lib/generated/intl/messages_en.dart
+++ b/lib/generated/intl/messages_en.dart
@@ -58,6 +58,8 @@ class MessageLookup extends MessageLookupByLibrary {
 
   static String m13(error) => "Error sending code: ${error}";
 
+  static String m26(count) => "${count} selected";
+
   static String m14(count) =>
       "${Intl.plural(count, one: 'Notification', other: 'Notifications')}";
 
@@ -533,6 +535,7 @@ class MessageLookup extends MessageLookupByLibrary {
           "Mobile dashboard should be configured in device profile!",
         ),
     "more": MessageLookupByLibrary.simpleMessage("More"),
+    "nSelected": m26,
     "newPassword": MessageLookupByLibrary.simpleMessage("New password"),
     "newPassword2": MessageLookupByLibrary.simpleMessage(
       "Confirm new password",
@@ -689,6 +692,7 @@ class MessageLookup extends MessageLookupByLibrary {
     "searchUsers": m20,
     "seconds": MessageLookupByLibrary.simpleMessage("seconds"),
     "security": MessageLookupByLibrary.simpleMessage("Security"),
+    "selectAll": MessageLookupByLibrary.simpleMessage("Select all"),
     "selectCountry": MessageLookupByLibrary.simpleMessage("Select country"),
     "selectRegion": MessageLookupByLibrary.simpleMessage("Select region"),
     "selectUser": MessageLookupByLibrary.simpleMessage("Select users"),

--- a/lib/generated/intl/messages_en.dart
+++ b/lib/generated/intl/messages_en.dart
@@ -58,40 +58,40 @@ class MessageLookup extends MessageLookupByLibrary {
 
   static String m13(error) => "Error sending code: ${error}";
 
-  static String m26(count) => "${count} selected";
+  static String m14(count) => "${count} selected";
 
-  static String m14(count) =>
+  static String m15(count) =>
       "${Intl.plural(count, one: 'Notification', other: 'Notifications')}";
 
-  static String m15(permissions) =>
+  static String m16(permissions) =>
       "You don\'t have enough permissions for \"${permissions}\" to proceed. Please open app settings, grant permissions and trap \"Try Again\".";
 
-  static String m16(permissions) =>
+  static String m17(permissions) =>
       "You don\'t have enough permissions for \"${permissions}\" to proceed. Please grant the required permissions and tap \"Try Again\".";
 
-  static String m17(deviceName) =>
+  static String m18(deviceName) =>
       "Enter PIN of ${deviceName} to confirm proof of possession";
 
-  static String m18(time) =>
+  static String m19(time) =>
       "Resend code in ${Intl.plural(time, one: '1 second', other: '${time} seconds')}";
 
-  static String m19(name) => "Route not defined: ${name}";
+  static String m20(name) => "Route not defined: ${name}";
 
-  static String m20(count) =>
+  static String m21(count) =>
       "${Intl.plural(count, one: 'Search user', other: 'Search users')}";
 
-  static String m21(contact) =>
+  static String m22(contact) =>
       "A security code has been sent to your phone at ${contact}.";
 
-  static String m22(name) =>
+  static String m23(name) =>
       "Unable connect to Wi-Fi because networks wasn\'t found by device ${name}";
 
-  static String m23(version) => "Update to ${version}";
+  static String m24(version) => "Update to ${version}";
 
-  static String m24(deviceName) =>
+  static String m25(deviceName) =>
       "To continue setup of your device ${deviceName}, please provide your Network\'s credentials.";
 
-  static String m25(network) => "Enter password for ${network}";
+  static String m26(network) => "Enter password for ${network}";
 
   final messages = _notInlinedMessages(_notInlinedMessages);
   static Map<String, Function> _notInlinedMessages(_) => <String, Function>{
@@ -535,7 +535,7 @@ class MessageLookup extends MessageLookupByLibrary {
           "Mobile dashboard should be configured in device profile!",
         ),
     "more": MessageLookupByLibrary.simpleMessage("More"),
-    "nSelected": m26,
+    "nSelected": m14,
     "newPassword": MessageLookupByLibrary.simpleMessage("New password"),
     "newPassword2": MessageLookupByLibrary.simpleMessage(
       "Confirm new password",
@@ -578,12 +578,12 @@ class MessageLookup extends MessageLookupByLibrary {
     "notificationTemplate": MessageLookupByLibrary.simpleMessage(
       "Notification template",
     ),
-    "notifications": m14,
+    "notifications": m15,
     "oauth2Client": MessageLookupByLibrary.simpleMessage("Oauth2 client"),
     "openAppSettings": MessageLookupByLibrary.simpleMessage(
       "Open app settings",
     ),
-    "openAppSettingsToGrantPermissionMessage": m15,
+    "openAppSettingsToGrantPermissionMessage": m16,
     "openSettingsAndGrantAccessToCameraToContinue":
         MessageLookupByLibrary.simpleMessage(
           "Open settings and grant access to camera to continue",
@@ -616,7 +616,7 @@ class MessageLookup extends MessageLookupByLibrary {
       "Password successfully changed",
     ),
     "permissions": MessageLookupByLibrary.simpleMessage("Permissions"),
-    "permissionsNotEnoughMessage": m16,
+    "permissionsNotEnoughMessage": m17,
     "phone": MessageLookupByLibrary.simpleMessage("Phone"),
     "phoneIsInvalid": MessageLookupByLibrary.simpleMessage("Phone is invalid"),
     "phoneIsRequired": MessageLookupByLibrary.simpleMessage(
@@ -641,7 +641,7 @@ class MessageLookup extends MessageLookupByLibrary {
       "Please scan QR code on your device",
     ),
     "plusAlarmType": MessageLookupByLibrary.simpleMessage("+ Alarm type"),
-    "popTitle": m17,
+    "popTitle": m18,
     "postalCode": MessageLookupByLibrary.simpleMessage("Zip / Postal Code"),
     "privacyPolicy": MessageLookupByLibrary.simpleMessage("Privacy Policy"),
     "profile": MessageLookupByLibrary.simpleMessage("Profile"),
@@ -670,7 +670,7 @@ class MessageLookup extends MessageLookupByLibrary {
     ),
     "resend": MessageLookupByLibrary.simpleMessage("Resend"),
     "resendCode": MessageLookupByLibrary.simpleMessage("Resend code"),
-    "resendCodeWait": m18,
+    "resendCodeWait": m19,
     "reset": MessageLookupByLibrary.simpleMessage("Reset"),
     "retry": MessageLookupByLibrary.simpleMessage("Retry"),
     "returnToDashboard": MessageLookupByLibrary.simpleMessage(
@@ -680,7 +680,7 @@ class MessageLookup extends MessageLookupByLibrary {
       "Return to the app and tap Ready button",
     ),
     "role": MessageLookupByLibrary.simpleMessage("Role"),
-    "routeNotDefined": m19,
+    "routeNotDefined": m20,
     "rpc": MessageLookupByLibrary.simpleMessage("RPC"),
     "ruleChain": MessageLookupByLibrary.simpleMessage("Rule chain"),
     "ruleNode": MessageLookupByLibrary.simpleMessage("Rule node"),
@@ -689,7 +689,7 @@ class MessageLookup extends MessageLookupByLibrary {
     "schedulerEvent": MessageLookupByLibrary.simpleMessage("Scheduler Event"),
     "search": MessageLookupByLibrary.simpleMessage("Search"),
     "searchResults": MessageLookupByLibrary.simpleMessage("Search results"),
-    "searchUsers": m20,
+    "searchUsers": m21,
     "seconds": MessageLookupByLibrary.simpleMessage("seconds"),
     "security": MessageLookupByLibrary.simpleMessage("Security"),
     "selectAll": MessageLookupByLibrary.simpleMessage("Select all"),
@@ -716,7 +716,7 @@ class MessageLookup extends MessageLookupByLibrary {
     "severity": MessageLookupByLibrary.simpleMessage("Severity"),
     "signIn": MessageLookupByLibrary.simpleMessage("Sign In"),
     "signUp": MessageLookupByLibrary.simpleMessage("Sign up"),
-    "smsAuthDescription": m21,
+    "smsAuthDescription": m22,
     "smsAuthPlaceholder": MessageLookupByLibrary.simpleMessage("SMS code"),
     "smsSetupSuccessDescription": MessageLookupByLibrary.simpleMessage(
       "The next time you log in, you will be prompted to enter the security code that will be sent to the phone number",
@@ -778,7 +778,7 @@ class MessageLookup extends MessageLookupByLibrary {
     "unableConnectToDevice": MessageLookupByLibrary.simpleMessage(
       "Unable connect to device",
     ),
-    "unableConnectToWifiBecauseNetworksWasntFoundByDevice": m22,
+    "unableConnectToWifiBecauseNetworksWasntFoundByDevice": m23,
     "unableToUseCamera": MessageLookupByLibrary.simpleMessage(
       "Unable to use camera",
     ),
@@ -790,7 +790,7 @@ class MessageLookup extends MessageLookupByLibrary {
     "unsavedChanges": MessageLookupByLibrary.simpleMessage("Unsaved changes"),
     "update": MessageLookupByLibrary.simpleMessage("Update"),
     "updateRequired": MessageLookupByLibrary.simpleMessage("Update required"),
-    "updateTo": m23,
+    "updateTo": m24,
     "url": MessageLookupByLibrary.simpleMessage("Url"),
     "user": MessageLookupByLibrary.simpleMessage("User"),
     "username": MessageLookupByLibrary.simpleMessage("username"),
@@ -815,9 +815,9 @@ class MessageLookup extends MessageLookupByLibrary {
     "warning": MessageLookupByLibrary.simpleMessage("Warning"),
     "widgetType": MessageLookupByLibrary.simpleMessage("Widget type"),
     "widgetsBundle": MessageLookupByLibrary.simpleMessage("Widgets bundle"),
-    "wifiHelpMessage": m24,
+    "wifiHelpMessage": m25,
     "wifiPassword": MessageLookupByLibrary.simpleMessage("Wi-Fi password"),
-    "wifiPasswordMessage": m25,
+    "wifiPasswordMessage": m26,
     "yes": MessageLookupByLibrary.simpleMessage("Yes"),
     "yesDeactivate": MessageLookupByLibrary.simpleMessage("Yes, deactivate"),
     "yesDiscard": MessageLookupByLibrary.simpleMessage("Yes, discard"),

--- a/lib/generated/intl/messages_en.dart
+++ b/lib/generated/intl/messages_en.dart
@@ -58,40 +58,43 @@ class MessageLookup extends MessageLookupByLibrary {
 
   static String m13(error) => "Error sending code: ${error}";
 
-  static String m14(count) => "${count} selected";
+  static String m14(count) =>
+      "${Intl.plural(count, one: '1 operation failed', other: '${count} operations failed')}";
 
-  static String m15(count) =>
+  static String m15(count) => "${count} selected";
+
+  static String m16(count) =>
       "${Intl.plural(count, one: 'Notification', other: 'Notifications')}";
 
-  static String m16(permissions) =>
+  static String m17(permissions) =>
       "You don\'t have enough permissions for \"${permissions}\" to proceed. Please open app settings, grant permissions and trap \"Try Again\".";
 
-  static String m17(permissions) =>
+  static String m18(permissions) =>
       "You don\'t have enough permissions for \"${permissions}\" to proceed. Please grant the required permissions and tap \"Try Again\".";
 
-  static String m18(deviceName) =>
+  static String m19(deviceName) =>
       "Enter PIN of ${deviceName} to confirm proof of possession";
 
-  static String m19(time) =>
+  static String m20(time) =>
       "Resend code in ${Intl.plural(time, one: '1 second', other: '${time} seconds')}";
 
-  static String m20(name) => "Route not defined: ${name}";
+  static String m21(name) => "Route not defined: ${name}";
 
-  static String m21(count) =>
+  static String m22(count) =>
       "${Intl.plural(count, one: 'Search user', other: 'Search users')}";
 
-  static String m22(contact) =>
+  static String m23(contact) =>
       "A security code has been sent to your phone at ${contact}.";
 
-  static String m23(name) =>
+  static String m24(name) =>
       "Unable connect to Wi-Fi because networks wasn\'t found by device ${name}";
 
-  static String m24(version) => "Update to ${version}";
+  static String m25(version) => "Update to ${version}";
 
-  static String m25(deviceName) =>
+  static String m26(deviceName) =>
       "To continue setup of your device ${deviceName}, please provide your Network\'s credentials.";
 
-  static String m26(network) => "Enter password for ${network}";
+  static String m27(network) => "Enter password for ${network}";
 
   final messages = _notInlinedMessages(_notInlinedMessages);
   static Map<String, Function> _notInlinedMessages(_) => <String, Function>{
@@ -442,6 +445,7 @@ class MessageLookup extends MessageLookupByLibrary {
     "failedToLoadTheList": MessageLookupByLibrary.simpleMessage(
       "Failed to load the list",
     ),
+    "failedToPerformOperation": m14,
     "failedToSaveImage": MessageLookupByLibrary.simpleMessage(
       "Failed to save image",
     ),
@@ -535,7 +539,7 @@ class MessageLookup extends MessageLookupByLibrary {
           "Mobile dashboard should be configured in device profile!",
         ),
     "more": MessageLookupByLibrary.simpleMessage("More"),
-    "nSelected": m14,
+    "nSelected": m15,
     "newPassword": MessageLookupByLibrary.simpleMessage("New password"),
     "newPassword2": MessageLookupByLibrary.simpleMessage(
       "Confirm new password",
@@ -578,12 +582,12 @@ class MessageLookup extends MessageLookupByLibrary {
     "notificationTemplate": MessageLookupByLibrary.simpleMessage(
       "Notification template",
     ),
-    "notifications": m15,
+    "notifications": m16,
     "oauth2Client": MessageLookupByLibrary.simpleMessage("Oauth2 client"),
     "openAppSettings": MessageLookupByLibrary.simpleMessage(
       "Open app settings",
     ),
-    "openAppSettingsToGrantPermissionMessage": m16,
+    "openAppSettingsToGrantPermissionMessage": m17,
     "openSettingsAndGrantAccessToCameraToContinue":
         MessageLookupByLibrary.simpleMessage(
           "Open settings and grant access to camera to continue",
@@ -616,7 +620,7 @@ class MessageLookup extends MessageLookupByLibrary {
       "Password successfully changed",
     ),
     "permissions": MessageLookupByLibrary.simpleMessage("Permissions"),
-    "permissionsNotEnoughMessage": m17,
+    "permissionsNotEnoughMessage": m18,
     "phone": MessageLookupByLibrary.simpleMessage("Phone"),
     "phoneIsInvalid": MessageLookupByLibrary.simpleMessage("Phone is invalid"),
     "phoneIsRequired": MessageLookupByLibrary.simpleMessage(
@@ -641,7 +645,7 @@ class MessageLookup extends MessageLookupByLibrary {
       "Please scan QR code on your device",
     ),
     "plusAlarmType": MessageLookupByLibrary.simpleMessage("+ Alarm type"),
-    "popTitle": m18,
+    "popTitle": m19,
     "postalCode": MessageLookupByLibrary.simpleMessage("Zip / Postal Code"),
     "privacyPolicy": MessageLookupByLibrary.simpleMessage("Privacy Policy"),
     "profile": MessageLookupByLibrary.simpleMessage("Profile"),
@@ -670,7 +674,7 @@ class MessageLookup extends MessageLookupByLibrary {
     ),
     "resend": MessageLookupByLibrary.simpleMessage("Resend"),
     "resendCode": MessageLookupByLibrary.simpleMessage("Resend code"),
-    "resendCodeWait": m19,
+    "resendCodeWait": m20,
     "reset": MessageLookupByLibrary.simpleMessage("Reset"),
     "retry": MessageLookupByLibrary.simpleMessage("Retry"),
     "returnToDashboard": MessageLookupByLibrary.simpleMessage(
@@ -680,7 +684,7 @@ class MessageLookup extends MessageLookupByLibrary {
       "Return to the app and tap Ready button",
     ),
     "role": MessageLookupByLibrary.simpleMessage("Role"),
-    "routeNotDefined": m20,
+    "routeNotDefined": m21,
     "rpc": MessageLookupByLibrary.simpleMessage("RPC"),
     "ruleChain": MessageLookupByLibrary.simpleMessage("Rule chain"),
     "ruleNode": MessageLookupByLibrary.simpleMessage("Rule node"),
@@ -689,7 +693,7 @@ class MessageLookup extends MessageLookupByLibrary {
     "schedulerEvent": MessageLookupByLibrary.simpleMessage("Scheduler Event"),
     "search": MessageLookupByLibrary.simpleMessage("Search"),
     "searchResults": MessageLookupByLibrary.simpleMessage("Search results"),
-    "searchUsers": m21,
+    "searchUsers": m22,
     "seconds": MessageLookupByLibrary.simpleMessage("seconds"),
     "security": MessageLookupByLibrary.simpleMessage("Security"),
     "selectAll": MessageLookupByLibrary.simpleMessage("Select all"),
@@ -716,7 +720,7 @@ class MessageLookup extends MessageLookupByLibrary {
     "severity": MessageLookupByLibrary.simpleMessage("Severity"),
     "signIn": MessageLookupByLibrary.simpleMessage("Sign In"),
     "signUp": MessageLookupByLibrary.simpleMessage("Sign up"),
-    "smsAuthDescription": m22,
+    "smsAuthDescription": m23,
     "smsAuthPlaceholder": MessageLookupByLibrary.simpleMessage("SMS code"),
     "smsSetupSuccessDescription": MessageLookupByLibrary.simpleMessage(
       "The next time you log in, you will be prompted to enter the security code that will be sent to the phone number",
@@ -778,7 +782,7 @@ class MessageLookup extends MessageLookupByLibrary {
     "unableConnectToDevice": MessageLookupByLibrary.simpleMessage(
       "Unable connect to device",
     ),
-    "unableConnectToWifiBecauseNetworksWasntFoundByDevice": m23,
+    "unableConnectToWifiBecauseNetworksWasntFoundByDevice": m24,
     "unableToUseCamera": MessageLookupByLibrary.simpleMessage(
       "Unable to use camera",
     ),
@@ -790,7 +794,7 @@ class MessageLookup extends MessageLookupByLibrary {
     "unsavedChanges": MessageLookupByLibrary.simpleMessage("Unsaved changes"),
     "update": MessageLookupByLibrary.simpleMessage("Update"),
     "updateRequired": MessageLookupByLibrary.simpleMessage("Update required"),
-    "updateTo": m24,
+    "updateTo": m25,
     "url": MessageLookupByLibrary.simpleMessage("Url"),
     "user": MessageLookupByLibrary.simpleMessage("User"),
     "username": MessageLookupByLibrary.simpleMessage("username"),
@@ -815,9 +819,9 @@ class MessageLookup extends MessageLookupByLibrary {
     "warning": MessageLookupByLibrary.simpleMessage("Warning"),
     "widgetType": MessageLookupByLibrary.simpleMessage("Widget type"),
     "widgetsBundle": MessageLookupByLibrary.simpleMessage("Widgets bundle"),
-    "wifiHelpMessage": m25,
+    "wifiHelpMessage": m26,
     "wifiPassword": MessageLookupByLibrary.simpleMessage("Wi-Fi password"),
-    "wifiPasswordMessage": m26,
+    "wifiPasswordMessage": m27,
     "yes": MessageLookupByLibrary.simpleMessage("Yes"),
     "yesDeactivate": MessageLookupByLibrary.simpleMessage("Yes, deactivate"),
     "yesDiscard": MessageLookupByLibrary.simpleMessage("Yes, discard"),

--- a/lib/generated/intl/messages_en.dart
+++ b/lib/generated/intl/messages_en.dart
@@ -704,7 +704,7 @@ class MessageLookup extends MessageLookupByLibrary {
     "searchUsers": m24,
     "seconds": MessageLookupByLibrary.simpleMessage("seconds"),
     "security": MessageLookupByLibrary.simpleMessage("Security"),
-    "selectAll": MessageLookupByLibrary.simpleMessage("Select all"),
+    "selectAll": MessageLookupByLibrary.simpleMessage("Select all loaded"),
     "selectCountry": MessageLookupByLibrary.simpleMessage("Select country"),
     "selectRegion": MessageLookupByLibrary.simpleMessage("Select region"),
     "selectUser": MessageLookupByLibrary.simpleMessage("Select users"),

--- a/lib/generated/intl/messages_es_ES.dart
+++ b/lib/generated/intl/messages_es_ES.dart
@@ -754,7 +754,9 @@ class MessageLookup extends MessageLookupByLibrary {
     "searchUsers": m24,
     "seconds": MessageLookupByLibrary.simpleMessage("segundos"),
     "security": MessageLookupByLibrary.simpleMessage("Seguridad"),
-    "selectAll": MessageLookupByLibrary.simpleMessage("Seleccionar todo"),
+    "selectAll": MessageLookupByLibrary.simpleMessage(
+      "Seleccionar todo lo cargado",
+    ),
     "selectCountry": MessageLookupByLibrary.simpleMessage("Seleccionar país"),
     "selectRegion": MessageLookupByLibrary.simpleMessage("Seleccionar región"),
     "selectUser": MessageLookupByLibrary.simpleMessage("Seleccionar usuarios"),

--- a/lib/generated/intl/messages_es_ES.dart
+++ b/lib/generated/intl/messages_es_ES.dart
@@ -58,40 +58,43 @@ class MessageLookup extends MessageLookupByLibrary {
 
   static String m13(error) => "Error al enviar el código: ${error}";
 
-  static String m14(count) => "${count} seleccionados";
+  static String m14(count) =>
+      "${Intl.plural(count, one: '1 operación falló', other: '${count} operaciones fallaron')}";
 
-  static String m15(count) =>
+  static String m15(count) => "${count} seleccionados";
+
+  static String m16(count) =>
       "${Intl.plural(count, one: 'Notificación', other: 'Notificaciones')}";
 
-  static String m16(permissions) =>
+  static String m17(permissions) =>
       "No tienes suficientes permisos para \"${permissions}\" para continuar. Abre la configuración de la app, otorga los permisos y toca \"Intentar de nuevo\".";
 
-  static String m17(permissions) =>
+  static String m18(permissions) =>
       "No tienes suficientes permisos para \"${permissions}\" para continuar. Otorga los permisos necesarios y toca \"Intentar de nuevo\".";
 
-  static String m18(deviceName) =>
+  static String m19(deviceName) =>
       "Ingresa el PIN de ${deviceName} para confirmar la prueba de posesión";
 
-  static String m19(time) =>
+  static String m20(time) =>
       "Reenviar código en ${Intl.plural(time, one: '1 segundo', other: '${time} segundos')}";
 
-  static String m20(name) => "Ruta no definida: ${name}";
+  static String m21(name) => "Ruta no definida: ${name}";
 
-  static String m21(count) =>
+  static String m22(count) =>
       "${Intl.plural(count, one: 'Buscar usuario', other: 'Buscar usuarios')}";
 
-  static String m22(contact) =>
+  static String m23(contact) =>
       "Se ha enviado un código de seguridad a tu teléfono en ${contact}.";
 
-  static String m23(name) =>
+  static String m24(name) =>
       "No se puede conectar al Wi-Fi porque el dispositivo ${name} no encontró redes";
 
-  static String m24(version) => "Actualizar a ${version}";
+  static String m25(version) => "Actualizar a ${version}";
 
-  static String m25(deviceName) =>
+  static String m26(deviceName) =>
       "Para continuar con la configuración de tu dispositivo ${deviceName}, proporciona las credenciales de tu red.";
 
-  static String m26(network) => "Ingresa la contraseña de ${network}";
+  static String m27(network) => "Ingresa la contraseña de ${network}";
 
   final messages = _notInlinedMessages(_notInlinedMessages);
   static Map<String, Function> _notInlinedMessages(_) => <String, Function>{
@@ -470,6 +473,7 @@ class MessageLookup extends MessageLookupByLibrary {
     "failedToLoadTheList": MessageLookupByLibrary.simpleMessage(
       "No se pudo cargar la lista",
     ),
+    "failedToPerformOperation": m14,
     "failedToSaveImage": MessageLookupByLibrary.simpleMessage(
       "Error al guardar la imagen",
     ),
@@ -571,7 +575,7 @@ class MessageLookup extends MessageLookupByLibrary {
           "¡El tablero móvil debe configurarse en el perfil del dispositivo!",
         ),
     "more": MessageLookupByLibrary.simpleMessage("Más"),
-    "nSelected": m14,
+    "nSelected": m15,
     "newPassword": MessageLookupByLibrary.simpleMessage("Nueva contraseña"),
     "newPassword2": MessageLookupByLibrary.simpleMessage(
       "Confirmar nueva contraseña",
@@ -618,12 +622,12 @@ class MessageLookup extends MessageLookupByLibrary {
     "notificationTemplate": MessageLookupByLibrary.simpleMessage(
       "Plantilla de notificación",
     ),
-    "notifications": m15,
+    "notifications": m16,
     "oauth2Client": MessageLookupByLibrary.simpleMessage("Cliente OAuth2"),
     "openAppSettings": MessageLookupByLibrary.simpleMessage(
       "Abrir configuración de la app",
     ),
-    "openAppSettingsToGrantPermissionMessage": m16,
+    "openAppSettingsToGrantPermissionMessage": m17,
     "openSettingsAndGrantAccessToCameraToContinue":
         MessageLookupByLibrary.simpleMessage(
           "Abre la configuración y concede acceso a la cámara para continuar",
@@ -658,7 +662,7 @@ class MessageLookup extends MessageLookupByLibrary {
       "Contraseña cambiada exitosamente",
     ),
     "permissions": MessageLookupByLibrary.simpleMessage("Permisos"),
-    "permissionsNotEnoughMessage": m17,
+    "permissionsNotEnoughMessage": m18,
     "phone": MessageLookupByLibrary.simpleMessage("Teléfono"),
     "phoneIsInvalid": MessageLookupByLibrary.simpleMessage(
       "El número de teléfono no es válido",
@@ -685,7 +689,7 @@ class MessageLookup extends MessageLookupByLibrary {
       "Escanea el código QR en tu dispositivo",
     ),
     "plusAlarmType": MessageLookupByLibrary.simpleMessage("+ Tipo de alarma"),
-    "popTitle": m18,
+    "popTitle": m19,
     "postalCode": MessageLookupByLibrary.simpleMessage("Código postal"),
     "privacyPolicy": MessageLookupByLibrary.simpleMessage(
       "Política de privacidad",
@@ -716,7 +720,7 @@ class MessageLookup extends MessageLookupByLibrary {
     ),
     "resend": MessageLookupByLibrary.simpleMessage("Reenviar"),
     "resendCode": MessageLookupByLibrary.simpleMessage("Reenviar código"),
-    "resendCodeWait": m19,
+    "resendCodeWait": m20,
     "reset": MessageLookupByLibrary.simpleMessage("Restablecer"),
     "retry": MessageLookupByLibrary.simpleMessage("Reintentar"),
     "returnToDashboard": MessageLookupByLibrary.simpleMessage(
@@ -726,7 +730,7 @@ class MessageLookup extends MessageLookupByLibrary {
       "Vuelve a la aplicación y toca el botón Listo",
     ),
     "role": MessageLookupByLibrary.simpleMessage("Rol"),
-    "routeNotDefined": m20,
+    "routeNotDefined": m21,
     "rpc": MessageLookupByLibrary.simpleMessage("RPC"),
     "ruleChain": MessageLookupByLibrary.simpleMessage("Cadena de reglas"),
     "ruleNode": MessageLookupByLibrary.simpleMessage("Nodo de regla"),
@@ -739,7 +743,7 @@ class MessageLookup extends MessageLookupByLibrary {
     "searchResults": MessageLookupByLibrary.simpleMessage(
       "Resultados de búsqueda",
     ),
-    "searchUsers": m21,
+    "searchUsers": m22,
     "seconds": MessageLookupByLibrary.simpleMessage("segundos"),
     "security": MessageLookupByLibrary.simpleMessage("Seguridad"),
     "selectAll": MessageLookupByLibrary.simpleMessage("Seleccionar todo"),
@@ -766,7 +770,7 @@ class MessageLookup extends MessageLookupByLibrary {
     "severity": MessageLookupByLibrary.simpleMessage("Severidad"),
     "signIn": MessageLookupByLibrary.simpleMessage("Iniciar sesión"),
     "signUp": MessageLookupByLibrary.simpleMessage("Registrarse"),
-    "smsAuthDescription": m22,
+    "smsAuthDescription": m23,
     "smsAuthPlaceholder": MessageLookupByLibrary.simpleMessage("Código SMS"),
     "smsSetupSuccessDescription": MessageLookupByLibrary.simpleMessage(
       "La próxima vez que inicies sesión, se te pedirá que ingreses el código de seguridad enviado al número de teléfono",
@@ -832,7 +836,7 @@ class MessageLookup extends MessageLookupByLibrary {
     "unableConnectToDevice": MessageLookupByLibrary.simpleMessage(
       "No se puede conectar al dispositivo",
     ),
-    "unableConnectToWifiBecauseNetworksWasntFoundByDevice": m23,
+    "unableConnectToWifiBecauseNetworksWasntFoundByDevice": m24,
     "unableToUseCamera": MessageLookupByLibrary.simpleMessage(
       "No se puede usar la cámara",
     ),
@@ -848,7 +852,7 @@ class MessageLookup extends MessageLookupByLibrary {
     "updateRequired": MessageLookupByLibrary.simpleMessage(
       "Actualización requerida",
     ),
-    "updateTo": m24,
+    "updateTo": m25,
     "url": MessageLookupByLibrary.simpleMessage("URL"),
     "user": MessageLookupByLibrary.simpleMessage("Usuario"),
     "username": MessageLookupByLibrary.simpleMessage("nombre de usuario"),
@@ -873,9 +877,9 @@ class MessageLookup extends MessageLookupByLibrary {
     "warning": MessageLookupByLibrary.simpleMessage("Advertencia"),
     "widgetType": MessageLookupByLibrary.simpleMessage("Tipo de widget"),
     "widgetsBundle": MessageLookupByLibrary.simpleMessage("Paquete de widgets"),
-    "wifiHelpMessage": m25,
+    "wifiHelpMessage": m26,
     "wifiPassword": MessageLookupByLibrary.simpleMessage("Contraseña de Wi-Fi"),
-    "wifiPasswordMessage": m26,
+    "wifiPasswordMessage": m27,
     "yes": MessageLookupByLibrary.simpleMessage("Sí"),
     "yesDeactivate": MessageLookupByLibrary.simpleMessage("Sí, desactivar"),
     "yesDiscard": MessageLookupByLibrary.simpleMessage("Sí, descartar"),

--- a/lib/generated/intl/messages_es_ES.dart
+++ b/lib/generated/intl/messages_es_ES.dart
@@ -46,55 +46,61 @@ class MessageLookup extends MessageLookupByLibrary {
       "${Intl.plural(count, one: 'Tablero', other: 'Tableros')}";
 
   static String m9(count) =>
-      "${Intl.plural(count, one: 'Dispositivo', other: 'Dispositivos')}";
+      "${Intl.plural(count, one: '¿Eliminar 1 notificación?', other: '¿Eliminar ${count} notificaciones?')}";
 
   static String m10(count) =>
+      "${Intl.plural(count, one: 'Dispositivo', other: 'Dispositivos')}";
+
+  static String m11(count) =>
       "Código de ${count} ${Intl.plural(count, one: 'dígito', other: 'dígitos')}";
 
-  static String m11(contact) =>
+  static String m12(contact) =>
       "Se ha enviado un código de seguridad a tu correo electrónico en ${contact}.";
 
-  static String m12(e) => "Error ocurrido: ${e}";
+  static String m13(e) => "Error ocurrido: ${e}";
 
-  static String m13(error) => "Error al enviar el código: ${error}";
+  static String m14(error) => "Error al enviar el código: ${error}";
 
-  static String m14(count) =>
+  static String m15(count) =>
       "${Intl.plural(count, one: '1 operación falló', other: '${count} operaciones fallaron')}";
 
-  static String m15(count) => "${count} seleccionados";
-
   static String m16(count) =>
+      "${Intl.plural(count, one: '¿Marcar 1 notificación como leída?', other: '¿Marcar ${count} notificaciones como leídas?')}";
+
+  static String m17(count) => "${count} seleccionados";
+
+  static String m18(count) =>
       "${Intl.plural(count, one: 'Notificación', other: 'Notificaciones')}";
 
-  static String m17(permissions) =>
+  static String m19(permissions) =>
       "No tienes suficientes permisos para \"${permissions}\" para continuar. Abre la configuración de la app, otorga los permisos y toca \"Intentar de nuevo\".";
 
-  static String m18(permissions) =>
+  static String m20(permissions) =>
       "No tienes suficientes permisos para \"${permissions}\" para continuar. Otorga los permisos necesarios y toca \"Intentar de nuevo\".";
 
-  static String m19(deviceName) =>
+  static String m21(deviceName) =>
       "Ingresa el PIN de ${deviceName} para confirmar la prueba de posesión";
 
-  static String m20(time) =>
+  static String m22(time) =>
       "Reenviar código en ${Intl.plural(time, one: '1 segundo', other: '${time} segundos')}";
 
-  static String m21(name) => "Ruta no definida: ${name}";
+  static String m23(name) => "Ruta no definida: ${name}";
 
-  static String m22(count) =>
+  static String m24(count) =>
       "${Intl.plural(count, one: 'Buscar usuario', other: 'Buscar usuarios')}";
 
-  static String m23(contact) =>
+  static String m25(contact) =>
       "Se ha enviado un código de seguridad a tu teléfono en ${contact}.";
 
-  static String m24(name) =>
+  static String m26(name) =>
       "No se puede conectar al Wi-Fi porque el dispositivo ${name} no encontró redes";
 
-  static String m25(version) => "Actualizar a ${version}";
+  static String m27(version) => "Actualizar a ${version}";
 
-  static String m26(deviceName) =>
+  static String m28(deviceName) =>
       "Para continuar con la configuración de tu dispositivo ${deviceName}, proporciona las credenciales de tu red.";
 
-  static String m27(network) => "Ingresa la contraseña de ${network}";
+  static String m29(network) => "Ingresa la contraseña de ${network}";
 
   final messages = _notInlinedMessages(_notInlinedMessages);
   static Map<String, Function> _notInlinedMessages(_) => <String, Function>{
@@ -392,6 +398,7 @@ class MessageLookup extends MessageLookupByLibrary {
     "deleteComment": MessageLookupByLibrary.simpleMessage(
       "Eliminar comentario",
     ),
+    "deleteSelectedNotifications": m9,
     "details": MessageLookupByLibrary.simpleMessage("Detalles"),
     "deviceList": MessageLookupByLibrary.simpleMessage("Lista de dispositivos"),
     "deviceNotAbleToFindWifiNearby": MessageLookupByLibrary.simpleMessage(
@@ -406,8 +413,8 @@ class MessageLookup extends MessageLookupByLibrary {
     "deviceProvisioning": MessageLookupByLibrary.simpleMessage(
       "Aprovisionamiento de dispositivo",
     ),
-    "devices": m9,
-    "digitsCode": m10,
+    "devices": m10,
+    "digitsCode": m11,
     "discardChanges": MessageLookupByLibrary.simpleMessage("Descartar cambios"),
     "domain": MessageLookupByLibrary.simpleMessage("Dominio"),
     "done": MessageLookupByLibrary.simpleMessage("Hecho"),
@@ -416,7 +423,7 @@ class MessageLookup extends MessageLookupByLibrary {
     "edit": MessageLookupByLibrary.simpleMessage("Editar"),
     "edited": MessageLookupByLibrary.simpleMessage("Editado"),
     "email": MessageLookupByLibrary.simpleMessage("Correo electrónico"),
-    "emailAuthDescription": m11,
+    "emailAuthDescription": m12,
     "emailAuthPlaceholder": MessageLookupByLibrary.simpleMessage(
       "Código de correo",
     ),
@@ -457,8 +464,8 @@ class MessageLookup extends MessageLookupByLibrary {
     "entityGroup": MessageLookupByLibrary.simpleMessage("Grupo de entidades"),
     "entityType": MessageLookupByLibrary.simpleMessage("Tipo de entidad"),
     "entityView": MessageLookupByLibrary.simpleMessage("Vista de entidad"),
-    "errorOccured": m12,
-    "errorSendingCode": m13,
+    "errorOccured": m13,
+    "errorSendingCode": m14,
     "europe": MessageLookupByLibrary.simpleMessage("Europa"),
     "europeRegionShort": MessageLookupByLibrary.simpleMessage("Frankfurt"),
     "exitDeviceProvisioning": MessageLookupByLibrary.simpleMessage(
@@ -473,7 +480,7 @@ class MessageLookup extends MessageLookupByLibrary {
     "failedToLoadTheList": MessageLookupByLibrary.simpleMessage(
       "No se pudo cargar la lista",
     ),
-    "failedToPerformOperation": m14,
+    "failedToPerformOperation": m15,
     "failedToSaveImage": MessageLookupByLibrary.simpleMessage(
       "Error al guardar la imagen",
     ),
@@ -553,6 +560,7 @@ class MessageLookup extends MessageLookupByLibrary {
       "Marcar todo como leído",
     ),
     "markAsRead": MessageLookupByLibrary.simpleMessage("Marcar como leído"),
+    "markSelectedNotificationsAsRead": m16,
     "metricUnitSystem": MessageLookupByLibrary.simpleMessage("Métrico"),
     "mfaProviderBackupCode": MessageLookupByLibrary.simpleMessage(
       "Código de respaldo",
@@ -575,7 +583,7 @@ class MessageLookup extends MessageLookupByLibrary {
           "¡El tablero móvil debe configurarse en el perfil del dispositivo!",
         ),
     "more": MessageLookupByLibrary.simpleMessage("Más"),
-    "nSelected": m15,
+    "nSelected": m17,
     "newPassword": MessageLookupByLibrary.simpleMessage("Nueva contraseña"),
     "newPassword2": MessageLookupByLibrary.simpleMessage(
       "Confirmar nueva contraseña",
@@ -622,12 +630,12 @@ class MessageLookup extends MessageLookupByLibrary {
     "notificationTemplate": MessageLookupByLibrary.simpleMessage(
       "Plantilla de notificación",
     ),
-    "notifications": m16,
+    "notifications": m18,
     "oauth2Client": MessageLookupByLibrary.simpleMessage("Cliente OAuth2"),
     "openAppSettings": MessageLookupByLibrary.simpleMessage(
       "Abrir configuración de la app",
     ),
-    "openAppSettingsToGrantPermissionMessage": m17,
+    "openAppSettingsToGrantPermissionMessage": m19,
     "openSettingsAndGrantAccessToCameraToContinue":
         MessageLookupByLibrary.simpleMessage(
           "Abre la configuración y concede acceso a la cámara para continuar",
@@ -662,7 +670,7 @@ class MessageLookup extends MessageLookupByLibrary {
       "Contraseña cambiada exitosamente",
     ),
     "permissions": MessageLookupByLibrary.simpleMessage("Permisos"),
-    "permissionsNotEnoughMessage": m18,
+    "permissionsNotEnoughMessage": m20,
     "phone": MessageLookupByLibrary.simpleMessage("Teléfono"),
     "phoneIsInvalid": MessageLookupByLibrary.simpleMessage(
       "El número de teléfono no es válido",
@@ -689,7 +697,7 @@ class MessageLookup extends MessageLookupByLibrary {
       "Escanea el código QR en tu dispositivo",
     ),
     "plusAlarmType": MessageLookupByLibrary.simpleMessage("+ Tipo de alarma"),
-    "popTitle": m19,
+    "popTitle": m21,
     "postalCode": MessageLookupByLibrary.simpleMessage("Código postal"),
     "privacyPolicy": MessageLookupByLibrary.simpleMessage(
       "Política de privacidad",
@@ -720,7 +728,7 @@ class MessageLookup extends MessageLookupByLibrary {
     ),
     "resend": MessageLookupByLibrary.simpleMessage("Reenviar"),
     "resendCode": MessageLookupByLibrary.simpleMessage("Reenviar código"),
-    "resendCodeWait": m20,
+    "resendCodeWait": m22,
     "reset": MessageLookupByLibrary.simpleMessage("Restablecer"),
     "retry": MessageLookupByLibrary.simpleMessage("Reintentar"),
     "returnToDashboard": MessageLookupByLibrary.simpleMessage(
@@ -730,7 +738,7 @@ class MessageLookup extends MessageLookupByLibrary {
       "Vuelve a la aplicación y toca el botón Listo",
     ),
     "role": MessageLookupByLibrary.simpleMessage("Rol"),
-    "routeNotDefined": m21,
+    "routeNotDefined": m23,
     "rpc": MessageLookupByLibrary.simpleMessage("RPC"),
     "ruleChain": MessageLookupByLibrary.simpleMessage("Cadena de reglas"),
     "ruleNode": MessageLookupByLibrary.simpleMessage("Nodo de regla"),
@@ -743,7 +751,7 @@ class MessageLookup extends MessageLookupByLibrary {
     "searchResults": MessageLookupByLibrary.simpleMessage(
       "Resultados de búsqueda",
     ),
-    "searchUsers": m22,
+    "searchUsers": m24,
     "seconds": MessageLookupByLibrary.simpleMessage("segundos"),
     "security": MessageLookupByLibrary.simpleMessage("Seguridad"),
     "selectAll": MessageLookupByLibrary.simpleMessage("Seleccionar todo"),
@@ -770,7 +778,7 @@ class MessageLookup extends MessageLookupByLibrary {
     "severity": MessageLookupByLibrary.simpleMessage("Severidad"),
     "signIn": MessageLookupByLibrary.simpleMessage("Iniciar sesión"),
     "signUp": MessageLookupByLibrary.simpleMessage("Registrarse"),
-    "smsAuthDescription": m23,
+    "smsAuthDescription": m25,
     "smsAuthPlaceholder": MessageLookupByLibrary.simpleMessage("Código SMS"),
     "smsSetupSuccessDescription": MessageLookupByLibrary.simpleMessage(
       "La próxima vez que inicies sesión, se te pedirá que ingreses el código de seguridad enviado al número de teléfono",
@@ -836,7 +844,7 @@ class MessageLookup extends MessageLookupByLibrary {
     "unableConnectToDevice": MessageLookupByLibrary.simpleMessage(
       "No se puede conectar al dispositivo",
     ),
-    "unableConnectToWifiBecauseNetworksWasntFoundByDevice": m24,
+    "unableConnectToWifiBecauseNetworksWasntFoundByDevice": m26,
     "unableToUseCamera": MessageLookupByLibrary.simpleMessage(
       "No se puede usar la cámara",
     ),
@@ -852,7 +860,7 @@ class MessageLookup extends MessageLookupByLibrary {
     "updateRequired": MessageLookupByLibrary.simpleMessage(
       "Actualización requerida",
     ),
-    "updateTo": m25,
+    "updateTo": m27,
     "url": MessageLookupByLibrary.simpleMessage("URL"),
     "user": MessageLookupByLibrary.simpleMessage("Usuario"),
     "username": MessageLookupByLibrary.simpleMessage("nombre de usuario"),
@@ -877,9 +885,9 @@ class MessageLookup extends MessageLookupByLibrary {
     "warning": MessageLookupByLibrary.simpleMessage("Advertencia"),
     "widgetType": MessageLookupByLibrary.simpleMessage("Tipo de widget"),
     "widgetsBundle": MessageLookupByLibrary.simpleMessage("Paquete de widgets"),
-    "wifiHelpMessage": m26,
+    "wifiHelpMessage": m28,
     "wifiPassword": MessageLookupByLibrary.simpleMessage("Contraseña de Wi-Fi"),
-    "wifiPasswordMessage": m27,
+    "wifiPasswordMessage": m29,
     "yes": MessageLookupByLibrary.simpleMessage("Sí"),
     "yesDeactivate": MessageLookupByLibrary.simpleMessage("Sí, desactivar"),
     "yesDiscard": MessageLookupByLibrary.simpleMessage("Sí, descartar"),

--- a/lib/generated/intl/messages_es_ES.dart
+++ b/lib/generated/intl/messages_es_ES.dart
@@ -58,38 +58,40 @@ class MessageLookup extends MessageLookupByLibrary {
 
   static String m13(error) => "Error al enviar el código: ${error}";
 
-  static String m14(count) =>
+  static String m14(count) => "${count} seleccionados";
+
+  static String m15(count) =>
       "${Intl.plural(count, one: 'Notificación', other: 'Notificaciones')}";
 
-  static String m15(permissions) =>
+  static String m16(permissions) =>
       "No tienes suficientes permisos para \"${permissions}\" para continuar. Abre la configuración de la app, otorga los permisos y toca \"Intentar de nuevo\".";
 
-  static String m16(permissions) =>
+  static String m17(permissions) =>
       "No tienes suficientes permisos para \"${permissions}\" para continuar. Otorga los permisos necesarios y toca \"Intentar de nuevo\".";
 
-  static String m17(deviceName) =>
+  static String m18(deviceName) =>
       "Ingresa el PIN de ${deviceName} para confirmar la prueba de posesión";
 
-  static String m18(time) =>
+  static String m19(time) =>
       "Reenviar código en ${Intl.plural(time, one: '1 segundo', other: '${time} segundos')}";
 
-  static String m19(name) => "Ruta no definida: ${name}";
+  static String m20(name) => "Ruta no definida: ${name}";
 
-  static String m20(count) =>
+  static String m21(count) =>
       "${Intl.plural(count, one: 'Buscar usuario', other: 'Buscar usuarios')}";
 
-  static String m21(contact) =>
+  static String m22(contact) =>
       "Se ha enviado un código de seguridad a tu teléfono en ${contact}.";
 
-  static String m22(name) =>
+  static String m23(name) =>
       "No se puede conectar al Wi-Fi porque el dispositivo ${name} no encontró redes";
 
-  static String m23(version) => "Actualizar a ${version}";
+  static String m24(version) => "Actualizar a ${version}";
 
-  static String m24(deviceName) =>
+  static String m25(deviceName) =>
       "Para continuar con la configuración de tu dispositivo ${deviceName}, proporciona las credenciales de tu red.";
 
-  static String m25(network) => "Ingresa la contraseña de ${network}";
+  static String m26(network) => "Ingresa la contraseña de ${network}";
 
   final messages = _notInlinedMessages(_notInlinedMessages);
   static Map<String, Function> _notInlinedMessages(_) => <String, Function>{
@@ -569,6 +571,7 @@ class MessageLookup extends MessageLookupByLibrary {
           "¡El tablero móvil debe configurarse en el perfil del dispositivo!",
         ),
     "more": MessageLookupByLibrary.simpleMessage("Más"),
+    "nSelected": m14,
     "newPassword": MessageLookupByLibrary.simpleMessage("Nueva contraseña"),
     "newPassword2": MessageLookupByLibrary.simpleMessage(
       "Confirmar nueva contraseña",
@@ -615,12 +618,12 @@ class MessageLookup extends MessageLookupByLibrary {
     "notificationTemplate": MessageLookupByLibrary.simpleMessage(
       "Plantilla de notificación",
     ),
-    "notifications": m14,
+    "notifications": m15,
     "oauth2Client": MessageLookupByLibrary.simpleMessage("Cliente OAuth2"),
     "openAppSettings": MessageLookupByLibrary.simpleMessage(
       "Abrir configuración de la app",
     ),
-    "openAppSettingsToGrantPermissionMessage": m15,
+    "openAppSettingsToGrantPermissionMessage": m16,
     "openSettingsAndGrantAccessToCameraToContinue":
         MessageLookupByLibrary.simpleMessage(
           "Abre la configuración y concede acceso a la cámara para continuar",
@@ -655,7 +658,7 @@ class MessageLookup extends MessageLookupByLibrary {
       "Contraseña cambiada exitosamente",
     ),
     "permissions": MessageLookupByLibrary.simpleMessage("Permisos"),
-    "permissionsNotEnoughMessage": m16,
+    "permissionsNotEnoughMessage": m17,
     "phone": MessageLookupByLibrary.simpleMessage("Teléfono"),
     "phoneIsInvalid": MessageLookupByLibrary.simpleMessage(
       "El número de teléfono no es válido",
@@ -682,7 +685,7 @@ class MessageLookup extends MessageLookupByLibrary {
       "Escanea el código QR en tu dispositivo",
     ),
     "plusAlarmType": MessageLookupByLibrary.simpleMessage("+ Tipo de alarma"),
-    "popTitle": m17,
+    "popTitle": m18,
     "postalCode": MessageLookupByLibrary.simpleMessage("Código postal"),
     "privacyPolicy": MessageLookupByLibrary.simpleMessage(
       "Política de privacidad",
@@ -713,7 +716,7 @@ class MessageLookup extends MessageLookupByLibrary {
     ),
     "resend": MessageLookupByLibrary.simpleMessage("Reenviar"),
     "resendCode": MessageLookupByLibrary.simpleMessage("Reenviar código"),
-    "resendCodeWait": m18,
+    "resendCodeWait": m19,
     "reset": MessageLookupByLibrary.simpleMessage("Restablecer"),
     "retry": MessageLookupByLibrary.simpleMessage("Reintentar"),
     "returnToDashboard": MessageLookupByLibrary.simpleMessage(
@@ -723,7 +726,7 @@ class MessageLookup extends MessageLookupByLibrary {
       "Vuelve a la aplicación y toca el botón Listo",
     ),
     "role": MessageLookupByLibrary.simpleMessage("Rol"),
-    "routeNotDefined": m19,
+    "routeNotDefined": m20,
     "rpc": MessageLookupByLibrary.simpleMessage("RPC"),
     "ruleChain": MessageLookupByLibrary.simpleMessage("Cadena de reglas"),
     "ruleNode": MessageLookupByLibrary.simpleMessage("Nodo de regla"),
@@ -736,9 +739,10 @@ class MessageLookup extends MessageLookupByLibrary {
     "searchResults": MessageLookupByLibrary.simpleMessage(
       "Resultados de búsqueda",
     ),
-    "searchUsers": m20,
+    "searchUsers": m21,
     "seconds": MessageLookupByLibrary.simpleMessage("segundos"),
     "security": MessageLookupByLibrary.simpleMessage("Seguridad"),
+    "selectAll": MessageLookupByLibrary.simpleMessage("Seleccionar todo"),
     "selectCountry": MessageLookupByLibrary.simpleMessage("Seleccionar país"),
     "selectRegion": MessageLookupByLibrary.simpleMessage("Seleccionar región"),
     "selectUser": MessageLookupByLibrary.simpleMessage("Seleccionar usuarios"),
@@ -762,7 +766,7 @@ class MessageLookup extends MessageLookupByLibrary {
     "severity": MessageLookupByLibrary.simpleMessage("Severidad"),
     "signIn": MessageLookupByLibrary.simpleMessage("Iniciar sesión"),
     "signUp": MessageLookupByLibrary.simpleMessage("Registrarse"),
-    "smsAuthDescription": m21,
+    "smsAuthDescription": m22,
     "smsAuthPlaceholder": MessageLookupByLibrary.simpleMessage("Código SMS"),
     "smsSetupSuccessDescription": MessageLookupByLibrary.simpleMessage(
       "La próxima vez que inicies sesión, se te pedirá que ingreses el código de seguridad enviado al número de teléfono",
@@ -828,7 +832,7 @@ class MessageLookup extends MessageLookupByLibrary {
     "unableConnectToDevice": MessageLookupByLibrary.simpleMessage(
       "No se puede conectar al dispositivo",
     ),
-    "unableConnectToWifiBecauseNetworksWasntFoundByDevice": m22,
+    "unableConnectToWifiBecauseNetworksWasntFoundByDevice": m23,
     "unableToUseCamera": MessageLookupByLibrary.simpleMessage(
       "No se puede usar la cámara",
     ),
@@ -844,7 +848,7 @@ class MessageLookup extends MessageLookupByLibrary {
     "updateRequired": MessageLookupByLibrary.simpleMessage(
       "Actualización requerida",
     ),
-    "updateTo": m23,
+    "updateTo": m24,
     "url": MessageLookupByLibrary.simpleMessage("URL"),
     "user": MessageLookupByLibrary.simpleMessage("Usuario"),
     "username": MessageLookupByLibrary.simpleMessage("nombre de usuario"),
@@ -869,9 +873,9 @@ class MessageLookup extends MessageLookupByLibrary {
     "warning": MessageLookupByLibrary.simpleMessage("Advertencia"),
     "widgetType": MessageLookupByLibrary.simpleMessage("Tipo de widget"),
     "widgetsBundle": MessageLookupByLibrary.simpleMessage("Paquete de widgets"),
-    "wifiHelpMessage": m24,
+    "wifiHelpMessage": m25,
     "wifiPassword": MessageLookupByLibrary.simpleMessage("Contraseña de Wi-Fi"),
-    "wifiPasswordMessage": m25,
+    "wifiPasswordMessage": m26,
     "yes": MessageLookupByLibrary.simpleMessage("Sí"),
     "yesDeactivate": MessageLookupByLibrary.simpleMessage("Sí, desactivar"),
     "yesDiscard": MessageLookupByLibrary.simpleMessage("Sí, descartar"),

--- a/lib/generated/intl/messages_fr_FR.dart
+++ b/lib/generated/intl/messages_fr_FR.dart
@@ -47,55 +47,61 @@ class MessageLookup extends MessageLookupByLibrary {
       "${Intl.plural(count, one: 'Tableau de bord', other: 'Tableaux de bord')}";
 
   static String m9(count) =>
-      "${Intl.plural(count, one: 'Appareil', other: 'Appareils')}";
+      "${Intl.plural(count, one: 'Supprimer 1 notification ?', other: 'Supprimer ${count} notifications ?')}";
 
   static String m10(count) =>
+      "${Intl.plural(count, one: 'Appareil', other: 'Appareils')}";
+
+  static String m11(count) =>
       "Code à ${count} ${Intl.plural(count, one: 'chiffre', other: 'chiffres')}";
 
-  static String m11(contact) =>
+  static String m12(contact) =>
       "Un code de sécurité a été envoyé à votre adresse email à ${contact}.";
 
-  static String m12(e) => "Erreur survenue : ${e}";
+  static String m13(e) => "Erreur survenue : ${e}";
 
-  static String m13(error) => "Erreur lors de l\'envoi du code : ${error}";
+  static String m14(error) => "Erreur lors de l\'envoi du code : ${error}";
 
-  static String m14(count) =>
+  static String m15(count) =>
       "${Intl.plural(count, one: '1 opération a échoué', other: '${count} opérations ont échoué')}";
 
-  static String m15(count) => "${count} sélectionnés";
-
   static String m16(count) =>
+      "${Intl.plural(count, one: 'Marquer 1 notification comme lue ?', other: 'Marquer ${count} notifications comme lues ?')}";
+
+  static String m17(count) => "${count} sélectionnés";
+
+  static String m18(count) =>
       "${Intl.plural(count, one: 'Notification', other: 'Notifications')}";
 
-  static String m17(permissions) =>
+  static String m19(permissions) =>
       "Vous n\'avez pas les autorisations nécessaires pour \"${permissions}\". Veuillez ouvrir les paramètres de l\'application, accorder les autorisations, puis appuyez sur \"Réessayer\".";
 
-  static String m18(permissions) =>
+  static String m20(permissions) =>
       "Vous n\'avez pas les autorisations nécessaires pour \"${permissions}\". Veuillez accorder les autorisations requises et appuyez sur \"Réessayer\".";
 
-  static String m19(deviceName) =>
+  static String m21(deviceName) =>
       "Saisissez le code PIN de ${deviceName} pour confirmer la preuve de possession";
 
-  static String m20(time) =>
+  static String m22(time) =>
       "Renvoyer le code dans ${Intl.plural(time, one: '1 seconde', other: '${time} secondes')}";
 
-  static String m21(name) => "Route non définie : ${name}";
+  static String m23(name) => "Route non définie : ${name}";
 
-  static String m22(count) =>
+  static String m24(count) =>
       "${Intl.plural(count, one: 'Rechercher un utilisateur', other: 'Rechercher des utilisateurs')}";
 
-  static String m23(contact) =>
+  static String m25(contact) =>
       "Un code de sécurité a été envoyé à votre téléphone au ${contact}.";
 
-  static String m24(name) =>
+  static String m26(name) =>
       "Impossible de se connecter au Wi-Fi car aucun réseau n\'a été trouvé par l\'appareil ${name}";
 
-  static String m25(version) => "Mettre à jour vers ${version}";
+  static String m27(version) => "Mettre à jour vers ${version}";
 
-  static String m26(deviceName) =>
+  static String m28(deviceName) =>
       "Pour continuer la configuration de votre appareil ${deviceName}, veuillez fournir les identifiants de votre réseau.";
 
-  static String m27(network) => "Saisir le mot de passe pour ${network}";
+  static String m29(network) => "Saisir le mot de passe pour ${network}";
 
   final messages = _notInlinedMessages(_notInlinedMessages);
   static Map<String, Function> _notInlinedMessages(_) => <String, Function>{
@@ -395,6 +401,7 @@ class MessageLookup extends MessageLookupByLibrary {
     "deleteComment": MessageLookupByLibrary.simpleMessage(
       "Supprimer le commentaire",
     ),
+    "deleteSelectedNotifications": m9,
     "details": MessageLookupByLibrary.simpleMessage("Détails"),
     "deviceList": MessageLookupByLibrary.simpleMessage("Liste des appareils"),
     "deviceNotAbleToFindWifiNearby": MessageLookupByLibrary.simpleMessage(
@@ -409,8 +416,8 @@ class MessageLookup extends MessageLookupByLibrary {
     "deviceProvisioning": MessageLookupByLibrary.simpleMessage(
       "Provisionnement de l\'appareil",
     ),
-    "devices": m9,
-    "digitsCode": m10,
+    "devices": m10,
+    "digitsCode": m11,
     "discardChanges": MessageLookupByLibrary.simpleMessage(
       "Annuler les modifications",
     ),
@@ -421,7 +428,7 @@ class MessageLookup extends MessageLookupByLibrary {
     "edit": MessageLookupByLibrary.simpleMessage("Éditer"),
     "edited": MessageLookupByLibrary.simpleMessage("Édité"),
     "email": MessageLookupByLibrary.simpleMessage("Email"),
-    "emailAuthDescription": m11,
+    "emailAuthDescription": m12,
     "emailAuthPlaceholder": MessageLookupByLibrary.simpleMessage("Code email"),
     "emailInvalidText": MessageLookupByLibrary.simpleMessage(
       "Format d\'email invalide.",
@@ -460,8 +467,8 @@ class MessageLookup extends MessageLookupByLibrary {
     "entityGroup": MessageLookupByLibrary.simpleMessage("Groupe d\'entités"),
     "entityType": MessageLookupByLibrary.simpleMessage("Type d\'entité"),
     "entityView": MessageLookupByLibrary.simpleMessage("Vue d\'entité"),
-    "errorOccured": m12,
-    "errorSendingCode": m13,
+    "errorOccured": m13,
+    "errorSendingCode": m14,
     "europe": MessageLookupByLibrary.simpleMessage("Europe"),
     "europeRegionShort": MessageLookupByLibrary.simpleMessage("Francfort"),
     "exitDeviceProvisioning": MessageLookupByLibrary.simpleMessage(
@@ -476,7 +483,7 @@ class MessageLookup extends MessageLookupByLibrary {
     "failedToLoadTheList": MessageLookupByLibrary.simpleMessage(
       "Échec du chargement de la liste",
     ),
-    "failedToPerformOperation": m14,
+    "failedToPerformOperation": m15,
     "failedToSaveImage": MessageLookupByLibrary.simpleMessage(
       "Échec de l’enregistrement de l’image",
     ),
@@ -562,6 +569,7 @@ class MessageLookup extends MessageLookupByLibrary {
       "Tout marquer comme lu",
     ),
     "markAsRead": MessageLookupByLibrary.simpleMessage("Marquer comme lu"),
+    "markSelectedNotificationsAsRead": m16,
     "metricUnitSystem": MessageLookupByLibrary.simpleMessage("Métrique"),
     "mfaProviderBackupCode": MessageLookupByLibrary.simpleMessage(
       "Code de secours",
@@ -582,7 +590,7 @@ class MessageLookup extends MessageLookupByLibrary {
           "Le tableau de bord mobile doit être configuré dans le profil de l\'appareil !",
         ),
     "more": MessageLookupByLibrary.simpleMessage("Plus"),
-    "nSelected": m15,
+    "nSelected": m17,
     "newPassword": MessageLookupByLibrary.simpleMessage("Nouveau mot de passe"),
     "newPassword2": MessageLookupByLibrary.simpleMessage(
       "Confirmer le nouveau mot de passe",
@@ -629,12 +637,12 @@ class MessageLookup extends MessageLookupByLibrary {
     "notificationTemplate": MessageLookupByLibrary.simpleMessage(
       "Modèle de notification",
     ),
-    "notifications": m16,
+    "notifications": m18,
     "oauth2Client": MessageLookupByLibrary.simpleMessage("Client OAuth2"),
     "openAppSettings": MessageLookupByLibrary.simpleMessage(
       "Ouvrir les paramètres de l\'application",
     ),
-    "openAppSettingsToGrantPermissionMessage": m17,
+    "openAppSettingsToGrantPermissionMessage": m19,
     "openSettingsAndGrantAccessToCameraToContinue":
         MessageLookupByLibrary.simpleMessage(
           "Ouvrez les paramètres et accordez l\'accès à la caméra pour continuer",
@@ -669,7 +677,7 @@ class MessageLookup extends MessageLookupByLibrary {
       "Mot de passe changé avec succès",
     ),
     "permissions": MessageLookupByLibrary.simpleMessage("Autorisations"),
-    "permissionsNotEnoughMessage": m18,
+    "permissionsNotEnoughMessage": m20,
     "phone": MessageLookupByLibrary.simpleMessage("Téléphone"),
     "phoneIsInvalid": MessageLookupByLibrary.simpleMessage(
       "Le numéro de téléphone est invalide",
@@ -696,7 +704,7 @@ class MessageLookup extends MessageLookupByLibrary {
       "Veuillez scanner le code QR sur votre appareil",
     ),
     "plusAlarmType": MessageLookupByLibrary.simpleMessage("+ Type d\'alarme"),
-    "popTitle": m19,
+    "popTitle": m21,
     "postalCode": MessageLookupByLibrary.simpleMessage("Code postal"),
     "privacyPolicy": MessageLookupByLibrary.simpleMessage(
       "Politique de confidentialité",
@@ -729,7 +737,7 @@ class MessageLookup extends MessageLookupByLibrary {
     ),
     "resend": MessageLookupByLibrary.simpleMessage("Renvoyer"),
     "resendCode": MessageLookupByLibrary.simpleMessage("Renvoyer le code"),
-    "resendCodeWait": m20,
+    "resendCodeWait": m22,
     "reset": MessageLookupByLibrary.simpleMessage("Réinitialiser"),
     "retry": MessageLookupByLibrary.simpleMessage("Réessayer"),
     "returnToDashboard": MessageLookupByLibrary.simpleMessage(
@@ -739,7 +747,7 @@ class MessageLookup extends MessageLookupByLibrary {
       "Revenez à l\'application et appuyez sur le bouton Prêt",
     ),
     "role": MessageLookupByLibrary.simpleMessage("Rôle"),
-    "routeNotDefined": m21,
+    "routeNotDefined": m23,
     "rpc": MessageLookupByLibrary.simpleMessage("RPC"),
     "ruleChain": MessageLookupByLibrary.simpleMessage("Chaîne de règles"),
     "ruleNode": MessageLookupByLibrary.simpleMessage("Nœud de règle"),
@@ -752,7 +760,7 @@ class MessageLookup extends MessageLookupByLibrary {
     "searchResults": MessageLookupByLibrary.simpleMessage(
       "Résultats de recherche",
     ),
-    "searchUsers": m22,
+    "searchUsers": m24,
     "seconds": MessageLookupByLibrary.simpleMessage("secondes"),
     "security": MessageLookupByLibrary.simpleMessage("Sécurité"),
     "selectAll": MessageLookupByLibrary.simpleMessage("Tout sélectionner"),
@@ -785,7 +793,7 @@ class MessageLookup extends MessageLookupByLibrary {
     "severity": MessageLookupByLibrary.simpleMessage("Gravité"),
     "signIn": MessageLookupByLibrary.simpleMessage("Se connecter"),
     "signUp": MessageLookupByLibrary.simpleMessage("S\'inscrire"),
-    "smsAuthDescription": m23,
+    "smsAuthDescription": m25,
     "smsAuthPlaceholder": MessageLookupByLibrary.simpleMessage("Code SMS"),
     "smsSetupSuccessDescription": MessageLookupByLibrary.simpleMessage(
       "Lors de votre prochaine connexion, vous devrez saisir le code de sécurité envoyé au numéro de téléphone",
@@ -855,7 +863,7 @@ class MessageLookup extends MessageLookupByLibrary {
     "unableConnectToDevice": MessageLookupByLibrary.simpleMessage(
       "Impossible de se connecter à l\'appareil",
     ),
-    "unableConnectToWifiBecauseNetworksWasntFoundByDevice": m24,
+    "unableConnectToWifiBecauseNetworksWasntFoundByDevice": m26,
     "unableToUseCamera": MessageLookupByLibrary.simpleMessage(
       "Impossible d\'utiliser la caméra",
     ),
@@ -871,7 +879,7 @@ class MessageLookup extends MessageLookupByLibrary {
     "updateRequired": MessageLookupByLibrary.simpleMessage(
       "Mise à jour requise",
     ),
-    "updateTo": m25,
+    "updateTo": m27,
     "url": MessageLookupByLibrary.simpleMessage("URL"),
     "user": MessageLookupByLibrary.simpleMessage("Utilisateur"),
     "username": MessageLookupByLibrary.simpleMessage("nom d\'utilisateur"),
@@ -898,9 +906,9 @@ class MessageLookup extends MessageLookupByLibrary {
     "warning": MessageLookupByLibrary.simpleMessage("Avertissement"),
     "widgetType": MessageLookupByLibrary.simpleMessage("Type de widget"),
     "widgetsBundle": MessageLookupByLibrary.simpleMessage("Pack de widgets"),
-    "wifiHelpMessage": m26,
+    "wifiHelpMessage": m28,
     "wifiPassword": MessageLookupByLibrary.simpleMessage("Mot de passe Wi-Fi"),
-    "wifiPasswordMessage": m27,
+    "wifiPasswordMessage": m29,
     "yes": MessageLookupByLibrary.simpleMessage("Oui"),
     "yesDeactivate": MessageLookupByLibrary.simpleMessage("Oui, désactiver"),
     "yesDiscard": MessageLookupByLibrary.simpleMessage("Oui, annuler"),

--- a/lib/generated/intl/messages_fr_FR.dart
+++ b/lib/generated/intl/messages_fr_FR.dart
@@ -59,40 +59,43 @@ class MessageLookup extends MessageLookupByLibrary {
 
   static String m13(error) => "Erreur lors de l\'envoi du code : ${error}";
 
-  static String m14(count) => "${count} sélectionnés";
+  static String m14(count) =>
+      "${Intl.plural(count, one: '1 opération a échoué', other: '${count} opérations ont échoué')}";
 
-  static String m15(count) =>
+  static String m15(count) => "${count} sélectionnés";
+
+  static String m16(count) =>
       "${Intl.plural(count, one: 'Notification', other: 'Notifications')}";
 
-  static String m16(permissions) =>
+  static String m17(permissions) =>
       "Vous n\'avez pas les autorisations nécessaires pour \"${permissions}\". Veuillez ouvrir les paramètres de l\'application, accorder les autorisations, puis appuyez sur \"Réessayer\".";
 
-  static String m17(permissions) =>
+  static String m18(permissions) =>
       "Vous n\'avez pas les autorisations nécessaires pour \"${permissions}\". Veuillez accorder les autorisations requises et appuyez sur \"Réessayer\".";
 
-  static String m18(deviceName) =>
+  static String m19(deviceName) =>
       "Saisissez le code PIN de ${deviceName} pour confirmer la preuve de possession";
 
-  static String m19(time) =>
+  static String m20(time) =>
       "Renvoyer le code dans ${Intl.plural(time, one: '1 seconde', other: '${time} secondes')}";
 
-  static String m20(name) => "Route non définie : ${name}";
+  static String m21(name) => "Route non définie : ${name}";
 
-  static String m21(count) =>
+  static String m22(count) =>
       "${Intl.plural(count, one: 'Rechercher un utilisateur', other: 'Rechercher des utilisateurs')}";
 
-  static String m22(contact) =>
+  static String m23(contact) =>
       "Un code de sécurité a été envoyé à votre téléphone au ${contact}.";
 
-  static String m23(name) =>
+  static String m24(name) =>
       "Impossible de se connecter au Wi-Fi car aucun réseau n\'a été trouvé par l\'appareil ${name}";
 
-  static String m24(version) => "Mettre à jour vers ${version}";
+  static String m25(version) => "Mettre à jour vers ${version}";
 
-  static String m25(deviceName) =>
+  static String m26(deviceName) =>
       "Pour continuer la configuration de votre appareil ${deviceName}, veuillez fournir les identifiants de votre réseau.";
 
-  static String m26(network) => "Saisir le mot de passe pour ${network}";
+  static String m27(network) => "Saisir le mot de passe pour ${network}";
 
   final messages = _notInlinedMessages(_notInlinedMessages);
   static Map<String, Function> _notInlinedMessages(_) => <String, Function>{
@@ -473,6 +476,7 @@ class MessageLookup extends MessageLookupByLibrary {
     "failedToLoadTheList": MessageLookupByLibrary.simpleMessage(
       "Échec du chargement de la liste",
     ),
+    "failedToPerformOperation": m14,
     "failedToSaveImage": MessageLookupByLibrary.simpleMessage(
       "Échec de l’enregistrement de l’image",
     ),
@@ -578,7 +582,7 @@ class MessageLookup extends MessageLookupByLibrary {
           "Le tableau de bord mobile doit être configuré dans le profil de l\'appareil !",
         ),
     "more": MessageLookupByLibrary.simpleMessage("Plus"),
-    "nSelected": m14,
+    "nSelected": m15,
     "newPassword": MessageLookupByLibrary.simpleMessage("Nouveau mot de passe"),
     "newPassword2": MessageLookupByLibrary.simpleMessage(
       "Confirmer le nouveau mot de passe",
@@ -625,12 +629,12 @@ class MessageLookup extends MessageLookupByLibrary {
     "notificationTemplate": MessageLookupByLibrary.simpleMessage(
       "Modèle de notification",
     ),
-    "notifications": m15,
+    "notifications": m16,
     "oauth2Client": MessageLookupByLibrary.simpleMessage("Client OAuth2"),
     "openAppSettings": MessageLookupByLibrary.simpleMessage(
       "Ouvrir les paramètres de l\'application",
     ),
-    "openAppSettingsToGrantPermissionMessage": m16,
+    "openAppSettingsToGrantPermissionMessage": m17,
     "openSettingsAndGrantAccessToCameraToContinue":
         MessageLookupByLibrary.simpleMessage(
           "Ouvrez les paramètres et accordez l\'accès à la caméra pour continuer",
@@ -665,7 +669,7 @@ class MessageLookup extends MessageLookupByLibrary {
       "Mot de passe changé avec succès",
     ),
     "permissions": MessageLookupByLibrary.simpleMessage("Autorisations"),
-    "permissionsNotEnoughMessage": m17,
+    "permissionsNotEnoughMessage": m18,
     "phone": MessageLookupByLibrary.simpleMessage("Téléphone"),
     "phoneIsInvalid": MessageLookupByLibrary.simpleMessage(
       "Le numéro de téléphone est invalide",
@@ -692,7 +696,7 @@ class MessageLookup extends MessageLookupByLibrary {
       "Veuillez scanner le code QR sur votre appareil",
     ),
     "plusAlarmType": MessageLookupByLibrary.simpleMessage("+ Type d\'alarme"),
-    "popTitle": m18,
+    "popTitle": m19,
     "postalCode": MessageLookupByLibrary.simpleMessage("Code postal"),
     "privacyPolicy": MessageLookupByLibrary.simpleMessage(
       "Politique de confidentialité",
@@ -725,7 +729,7 @@ class MessageLookup extends MessageLookupByLibrary {
     ),
     "resend": MessageLookupByLibrary.simpleMessage("Renvoyer"),
     "resendCode": MessageLookupByLibrary.simpleMessage("Renvoyer le code"),
-    "resendCodeWait": m19,
+    "resendCodeWait": m20,
     "reset": MessageLookupByLibrary.simpleMessage("Réinitialiser"),
     "retry": MessageLookupByLibrary.simpleMessage("Réessayer"),
     "returnToDashboard": MessageLookupByLibrary.simpleMessage(
@@ -735,7 +739,7 @@ class MessageLookup extends MessageLookupByLibrary {
       "Revenez à l\'application et appuyez sur le bouton Prêt",
     ),
     "role": MessageLookupByLibrary.simpleMessage("Rôle"),
-    "routeNotDefined": m20,
+    "routeNotDefined": m21,
     "rpc": MessageLookupByLibrary.simpleMessage("RPC"),
     "ruleChain": MessageLookupByLibrary.simpleMessage("Chaîne de règles"),
     "ruleNode": MessageLookupByLibrary.simpleMessage("Nœud de règle"),
@@ -748,7 +752,7 @@ class MessageLookup extends MessageLookupByLibrary {
     "searchResults": MessageLookupByLibrary.simpleMessage(
       "Résultats de recherche",
     ),
-    "searchUsers": m21,
+    "searchUsers": m22,
     "seconds": MessageLookupByLibrary.simpleMessage("secondes"),
     "security": MessageLookupByLibrary.simpleMessage("Sécurité"),
     "selectAll": MessageLookupByLibrary.simpleMessage("Tout sélectionner"),
@@ -781,7 +785,7 @@ class MessageLookup extends MessageLookupByLibrary {
     "severity": MessageLookupByLibrary.simpleMessage("Gravité"),
     "signIn": MessageLookupByLibrary.simpleMessage("Se connecter"),
     "signUp": MessageLookupByLibrary.simpleMessage("S\'inscrire"),
-    "smsAuthDescription": m22,
+    "smsAuthDescription": m23,
     "smsAuthPlaceholder": MessageLookupByLibrary.simpleMessage("Code SMS"),
     "smsSetupSuccessDescription": MessageLookupByLibrary.simpleMessage(
       "Lors de votre prochaine connexion, vous devrez saisir le code de sécurité envoyé au numéro de téléphone",
@@ -851,7 +855,7 @@ class MessageLookup extends MessageLookupByLibrary {
     "unableConnectToDevice": MessageLookupByLibrary.simpleMessage(
       "Impossible de se connecter à l\'appareil",
     ),
-    "unableConnectToWifiBecauseNetworksWasntFoundByDevice": m23,
+    "unableConnectToWifiBecauseNetworksWasntFoundByDevice": m24,
     "unableToUseCamera": MessageLookupByLibrary.simpleMessage(
       "Impossible d\'utiliser la caméra",
     ),
@@ -867,7 +871,7 @@ class MessageLookup extends MessageLookupByLibrary {
     "updateRequired": MessageLookupByLibrary.simpleMessage(
       "Mise à jour requise",
     ),
-    "updateTo": m24,
+    "updateTo": m25,
     "url": MessageLookupByLibrary.simpleMessage("URL"),
     "user": MessageLookupByLibrary.simpleMessage("Utilisateur"),
     "username": MessageLookupByLibrary.simpleMessage("nom d\'utilisateur"),
@@ -894,9 +898,9 @@ class MessageLookup extends MessageLookupByLibrary {
     "warning": MessageLookupByLibrary.simpleMessage("Avertissement"),
     "widgetType": MessageLookupByLibrary.simpleMessage("Type de widget"),
     "widgetsBundle": MessageLookupByLibrary.simpleMessage("Pack de widgets"),
-    "wifiHelpMessage": m25,
+    "wifiHelpMessage": m26,
     "wifiPassword": MessageLookupByLibrary.simpleMessage("Mot de passe Wi-Fi"),
-    "wifiPasswordMessage": m26,
+    "wifiPasswordMessage": m27,
     "yes": MessageLookupByLibrary.simpleMessage("Oui"),
     "yesDeactivate": MessageLookupByLibrary.simpleMessage("Oui, désactiver"),
     "yesDiscard": MessageLookupByLibrary.simpleMessage("Oui, annuler"),

--- a/lib/generated/intl/messages_fr_FR.dart
+++ b/lib/generated/intl/messages_fr_FR.dart
@@ -59,38 +59,40 @@ class MessageLookup extends MessageLookupByLibrary {
 
   static String m13(error) => "Erreur lors de l\'envoi du code : ${error}";
 
-  static String m14(count) =>
+  static String m14(count) => "${count} sélectionnés";
+
+  static String m15(count) =>
       "${Intl.plural(count, one: 'Notification', other: 'Notifications')}";
 
-  static String m15(permissions) =>
+  static String m16(permissions) =>
       "Vous n\'avez pas les autorisations nécessaires pour \"${permissions}\". Veuillez ouvrir les paramètres de l\'application, accorder les autorisations, puis appuyez sur \"Réessayer\".";
 
-  static String m16(permissions) =>
+  static String m17(permissions) =>
       "Vous n\'avez pas les autorisations nécessaires pour \"${permissions}\". Veuillez accorder les autorisations requises et appuyez sur \"Réessayer\".";
 
-  static String m17(deviceName) =>
+  static String m18(deviceName) =>
       "Saisissez le code PIN de ${deviceName} pour confirmer la preuve de possession";
 
-  static String m18(time) =>
+  static String m19(time) =>
       "Renvoyer le code dans ${Intl.plural(time, one: '1 seconde', other: '${time} secondes')}";
 
-  static String m19(name) => "Route non définie : ${name}";
+  static String m20(name) => "Route non définie : ${name}";
 
-  static String m20(count) =>
+  static String m21(count) =>
       "${Intl.plural(count, one: 'Rechercher un utilisateur', other: 'Rechercher des utilisateurs')}";
 
-  static String m21(contact) =>
+  static String m22(contact) =>
       "Un code de sécurité a été envoyé à votre téléphone au ${contact}.";
 
-  static String m22(name) =>
+  static String m23(name) =>
       "Impossible de se connecter au Wi-Fi car aucun réseau n\'a été trouvé par l\'appareil ${name}";
 
-  static String m23(version) => "Mettre à jour vers ${version}";
+  static String m24(version) => "Mettre à jour vers ${version}";
 
-  static String m24(deviceName) =>
+  static String m25(deviceName) =>
       "Pour continuer la configuration de votre appareil ${deviceName}, veuillez fournir les identifiants de votre réseau.";
 
-  static String m25(network) => "Saisir le mot de passe pour ${network}";
+  static String m26(network) => "Saisir le mot de passe pour ${network}";
 
   final messages = _notInlinedMessages(_notInlinedMessages);
   static Map<String, Function> _notInlinedMessages(_) => <String, Function>{
@@ -576,6 +578,7 @@ class MessageLookup extends MessageLookupByLibrary {
           "Le tableau de bord mobile doit être configuré dans le profil de l\'appareil !",
         ),
     "more": MessageLookupByLibrary.simpleMessage("Plus"),
+    "nSelected": m14,
     "newPassword": MessageLookupByLibrary.simpleMessage("Nouveau mot de passe"),
     "newPassword2": MessageLookupByLibrary.simpleMessage(
       "Confirmer le nouveau mot de passe",
@@ -622,12 +625,12 @@ class MessageLookup extends MessageLookupByLibrary {
     "notificationTemplate": MessageLookupByLibrary.simpleMessage(
       "Modèle de notification",
     ),
-    "notifications": m14,
+    "notifications": m15,
     "oauth2Client": MessageLookupByLibrary.simpleMessage("Client OAuth2"),
     "openAppSettings": MessageLookupByLibrary.simpleMessage(
       "Ouvrir les paramètres de l\'application",
     ),
-    "openAppSettingsToGrantPermissionMessage": m15,
+    "openAppSettingsToGrantPermissionMessage": m16,
     "openSettingsAndGrantAccessToCameraToContinue":
         MessageLookupByLibrary.simpleMessage(
           "Ouvrez les paramètres et accordez l\'accès à la caméra pour continuer",
@@ -662,7 +665,7 @@ class MessageLookup extends MessageLookupByLibrary {
       "Mot de passe changé avec succès",
     ),
     "permissions": MessageLookupByLibrary.simpleMessage("Autorisations"),
-    "permissionsNotEnoughMessage": m16,
+    "permissionsNotEnoughMessage": m17,
     "phone": MessageLookupByLibrary.simpleMessage("Téléphone"),
     "phoneIsInvalid": MessageLookupByLibrary.simpleMessage(
       "Le numéro de téléphone est invalide",
@@ -689,7 +692,7 @@ class MessageLookup extends MessageLookupByLibrary {
       "Veuillez scanner le code QR sur votre appareil",
     ),
     "plusAlarmType": MessageLookupByLibrary.simpleMessage("+ Type d\'alarme"),
-    "popTitle": m17,
+    "popTitle": m18,
     "postalCode": MessageLookupByLibrary.simpleMessage("Code postal"),
     "privacyPolicy": MessageLookupByLibrary.simpleMessage(
       "Politique de confidentialité",
@@ -722,7 +725,7 @@ class MessageLookup extends MessageLookupByLibrary {
     ),
     "resend": MessageLookupByLibrary.simpleMessage("Renvoyer"),
     "resendCode": MessageLookupByLibrary.simpleMessage("Renvoyer le code"),
-    "resendCodeWait": m18,
+    "resendCodeWait": m19,
     "reset": MessageLookupByLibrary.simpleMessage("Réinitialiser"),
     "retry": MessageLookupByLibrary.simpleMessage("Réessayer"),
     "returnToDashboard": MessageLookupByLibrary.simpleMessage(
@@ -732,7 +735,7 @@ class MessageLookup extends MessageLookupByLibrary {
       "Revenez à l\'application et appuyez sur le bouton Prêt",
     ),
     "role": MessageLookupByLibrary.simpleMessage("Rôle"),
-    "routeNotDefined": m19,
+    "routeNotDefined": m20,
     "rpc": MessageLookupByLibrary.simpleMessage("RPC"),
     "ruleChain": MessageLookupByLibrary.simpleMessage("Chaîne de règles"),
     "ruleNode": MessageLookupByLibrary.simpleMessage("Nœud de règle"),
@@ -745,9 +748,10 @@ class MessageLookup extends MessageLookupByLibrary {
     "searchResults": MessageLookupByLibrary.simpleMessage(
       "Résultats de recherche",
     ),
-    "searchUsers": m20,
+    "searchUsers": m21,
     "seconds": MessageLookupByLibrary.simpleMessage("secondes"),
     "security": MessageLookupByLibrary.simpleMessage("Sécurité"),
+    "selectAll": MessageLookupByLibrary.simpleMessage("Tout sélectionner"),
     "selectCountry": MessageLookupByLibrary.simpleMessage(
       "Sélectionner le pays",
     ),
@@ -777,7 +781,7 @@ class MessageLookup extends MessageLookupByLibrary {
     "severity": MessageLookupByLibrary.simpleMessage("Gravité"),
     "signIn": MessageLookupByLibrary.simpleMessage("Se connecter"),
     "signUp": MessageLookupByLibrary.simpleMessage("S\'inscrire"),
-    "smsAuthDescription": m21,
+    "smsAuthDescription": m22,
     "smsAuthPlaceholder": MessageLookupByLibrary.simpleMessage("Code SMS"),
     "smsSetupSuccessDescription": MessageLookupByLibrary.simpleMessage(
       "Lors de votre prochaine connexion, vous devrez saisir le code de sécurité envoyé au numéro de téléphone",
@@ -847,7 +851,7 @@ class MessageLookup extends MessageLookupByLibrary {
     "unableConnectToDevice": MessageLookupByLibrary.simpleMessage(
       "Impossible de se connecter à l\'appareil",
     ),
-    "unableConnectToWifiBecauseNetworksWasntFoundByDevice": m22,
+    "unableConnectToWifiBecauseNetworksWasntFoundByDevice": m23,
     "unableToUseCamera": MessageLookupByLibrary.simpleMessage(
       "Impossible d\'utiliser la caméra",
     ),
@@ -863,7 +867,7 @@ class MessageLookup extends MessageLookupByLibrary {
     "updateRequired": MessageLookupByLibrary.simpleMessage(
       "Mise à jour requise",
     ),
-    "updateTo": m23,
+    "updateTo": m24,
     "url": MessageLookupByLibrary.simpleMessage("URL"),
     "user": MessageLookupByLibrary.simpleMessage("Utilisateur"),
     "username": MessageLookupByLibrary.simpleMessage("nom d\'utilisateur"),
@@ -890,9 +894,9 @@ class MessageLookup extends MessageLookupByLibrary {
     "warning": MessageLookupByLibrary.simpleMessage("Avertissement"),
     "widgetType": MessageLookupByLibrary.simpleMessage("Type de widget"),
     "widgetsBundle": MessageLookupByLibrary.simpleMessage("Pack de widgets"),
-    "wifiHelpMessage": m24,
+    "wifiHelpMessage": m25,
     "wifiPassword": MessageLookupByLibrary.simpleMessage("Mot de passe Wi-Fi"),
-    "wifiPasswordMessage": m25,
+    "wifiPasswordMessage": m26,
     "yes": MessageLookupByLibrary.simpleMessage("Oui"),
     "yesDeactivate": MessageLookupByLibrary.simpleMessage("Oui, désactiver"),
     "yesDiscard": MessageLookupByLibrary.simpleMessage("Oui, annuler"),

--- a/lib/generated/intl/messages_fr_FR.dart
+++ b/lib/generated/intl/messages_fr_FR.dart
@@ -763,7 +763,9 @@ class MessageLookup extends MessageLookupByLibrary {
     "searchUsers": m24,
     "seconds": MessageLookupByLibrary.simpleMessage("secondes"),
     "security": MessageLookupByLibrary.simpleMessage("Sécurité"),
-    "selectAll": MessageLookupByLibrary.simpleMessage("Tout sélectionner"),
+    "selectAll": MessageLookupByLibrary.simpleMessage(
+      "Sélectionner tout le chargé",
+    ),
     "selectCountry": MessageLookupByLibrary.simpleMessage(
       "Sélectionner le pays",
     ),

--- a/lib/generated/intl/messages_it_IT.dart
+++ b/lib/generated/intl/messages_it_IT.dart
@@ -58,38 +58,40 @@ class MessageLookup extends MessageLookupByLibrary {
 
   static String m13(error) => "Errore nell\'invio del codice: ${error}";
 
-  static String m14(count) =>
+  static String m14(count) => "${count} selezionati";
+
+  static String m15(count) =>
       "${Intl.plural(count, one: 'Notifica', other: 'Notifiche')}";
 
-  static String m15(permissions) =>
+  static String m16(permissions) =>
       "Non hai i permessi necessari per \"${permissions}\" per procedere. Apri le impostazioni dell\'app, concedi i permessi e tocca \"Riprova\".";
 
-  static String m16(permissions) =>
+  static String m17(permissions) =>
       "Non hai i permessi necessari per \"${permissions}\" per procedere. Concedi i permessi richiesti e tocca \"Riprova\".";
 
-  static String m17(deviceName) =>
+  static String m18(deviceName) =>
       "Inserisci il PIN di ${deviceName} per confermare la prova di possesso";
 
-  static String m18(time) =>
+  static String m19(time) =>
       "Reinvia codice tra ${Intl.plural(time, one: '1 secondo', other: '${time} secondi')}";
 
-  static String m19(name) => "Percorso non definito: ${name}";
+  static String m20(name) => "Percorso non definito: ${name}";
 
-  static String m20(count) =>
+  static String m21(count) =>
       "${Intl.plural(count, one: 'Cerca utente', other: 'Cerca utenti')}";
 
-  static String m21(contact) =>
+  static String m22(contact) =>
       "Un codice di sicurezza è stato inviato al tuo telefono al numero ${contact}.";
 
-  static String m22(name) =>
+  static String m23(name) =>
       "Impossibile connettersi al Wi-Fi perché il dispositivo ${name} non ha trovato reti";
 
-  static String m23(version) => "Aggiorna a ${version}";
+  static String m24(version) => "Aggiorna a ${version}";
 
-  static String m24(deviceName) =>
+  static String m25(deviceName) =>
       "Per continuare la configurazione del dispositivo ${deviceName}, fornisci le credenziali della tua rete.";
 
-  static String m25(network) => "Inserisci la password per ${network}";
+  static String m26(network) => "Inserisci la password per ${network}";
 
   final messages = _notInlinedMessages(_notInlinedMessages);
   static Map<String, Function> _notInlinedMessages(_) => <String, Function>{
@@ -553,6 +555,7 @@ class MessageLookup extends MessageLookupByLibrary {
           "La dashboard mobile deve essere configurata nel profilo del dispositivo!",
         ),
     "more": MessageLookupByLibrary.simpleMessage("Altro"),
+    "nSelected": m14,
     "newPassword": MessageLookupByLibrary.simpleMessage("Nuova password"),
     "newPassword2": MessageLookupByLibrary.simpleMessage(
       "Conferma nuova password",
@@ -599,12 +602,12 @@ class MessageLookup extends MessageLookupByLibrary {
     "notificationTemplate": MessageLookupByLibrary.simpleMessage(
       "Modello di notifica",
     ),
-    "notifications": m14,
+    "notifications": m15,
     "oauth2Client": MessageLookupByLibrary.simpleMessage("Client OAuth2"),
     "openAppSettings": MessageLookupByLibrary.simpleMessage(
       "Apri impostazioni app",
     ),
-    "openAppSettingsToGrantPermissionMessage": m15,
+    "openAppSettingsToGrantPermissionMessage": m16,
     "openSettingsAndGrantAccessToCameraToContinue":
         MessageLookupByLibrary.simpleMessage(
           "Apri le impostazioni e concedi l\'accesso alla fotocamera per continuare",
@@ -637,7 +640,7 @@ class MessageLookup extends MessageLookupByLibrary {
       "Password cambiata con successo",
     ),
     "permissions": MessageLookupByLibrary.simpleMessage("Permessi"),
-    "permissionsNotEnoughMessage": m16,
+    "permissionsNotEnoughMessage": m17,
     "phone": MessageLookupByLibrary.simpleMessage("Telefono"),
     "phoneIsInvalid": MessageLookupByLibrary.simpleMessage(
       "Il numero di telefono non è valido",
@@ -664,7 +667,7 @@ class MessageLookup extends MessageLookupByLibrary {
       "Scansiona il codice QR sul tuo dispositivo",
     ),
     "plusAlarmType": MessageLookupByLibrary.simpleMessage("+ Tipo di allarme"),
-    "popTitle": m17,
+    "popTitle": m18,
     "postalCode": MessageLookupByLibrary.simpleMessage("CAP / Codice postale"),
     "privacyPolicy": MessageLookupByLibrary.simpleMessage(
       "Informativa sulla privacy",
@@ -695,7 +698,7 @@ class MessageLookup extends MessageLookupByLibrary {
     ),
     "resend": MessageLookupByLibrary.simpleMessage("Reinvia"),
     "resendCode": MessageLookupByLibrary.simpleMessage("Reinvia codice"),
-    "resendCodeWait": m18,
+    "resendCodeWait": m19,
     "reset": MessageLookupByLibrary.simpleMessage("Reimposta"),
     "retry": MessageLookupByLibrary.simpleMessage("Riprova"),
     "returnToDashboard": MessageLookupByLibrary.simpleMessage(
@@ -705,7 +708,7 @@ class MessageLookup extends MessageLookupByLibrary {
       "Torna all\'app e tocca il pulsante Pronto",
     ),
     "role": MessageLookupByLibrary.simpleMessage("Ruolo"),
-    "routeNotDefined": m19,
+    "routeNotDefined": m20,
     "rpc": MessageLookupByLibrary.simpleMessage("RPC"),
     "ruleChain": MessageLookupByLibrary.simpleMessage("Catena di regole"),
     "ruleNode": MessageLookupByLibrary.simpleMessage("Nodo di regole"),
@@ -718,9 +721,10 @@ class MessageLookup extends MessageLookupByLibrary {
     "searchResults": MessageLookupByLibrary.simpleMessage(
       "Risultati della ricerca",
     ),
-    "searchUsers": m20,
+    "searchUsers": m21,
     "seconds": MessageLookupByLibrary.simpleMessage("secondi"),
     "security": MessageLookupByLibrary.simpleMessage("Sicurezza"),
+    "selectAll": MessageLookupByLibrary.simpleMessage("Seleziona tutto"),
     "selectCountry": MessageLookupByLibrary.simpleMessage("Seleziona paese"),
     "selectRegion": MessageLookupByLibrary.simpleMessage("Seleziona regione"),
     "selectUser": MessageLookupByLibrary.simpleMessage("Seleziona utenti"),
@@ -744,7 +748,7 @@ class MessageLookup extends MessageLookupByLibrary {
     "severity": MessageLookupByLibrary.simpleMessage("Gravità"),
     "signIn": MessageLookupByLibrary.simpleMessage("Accedi"),
     "signUp": MessageLookupByLibrary.simpleMessage("Registrati"),
-    "smsAuthDescription": m21,
+    "smsAuthDescription": m22,
     "smsAuthPlaceholder": MessageLookupByLibrary.simpleMessage("Codice SMS"),
     "smsSetupSuccessDescription": MessageLookupByLibrary.simpleMessage(
       "Al prossimo accesso ti verrà chiesto di inserire il codice di sicurezza inviato al numero di telefono",
@@ -812,7 +816,7 @@ class MessageLookup extends MessageLookupByLibrary {
     "unableConnectToDevice": MessageLookupByLibrary.simpleMessage(
       "Impossibile connettersi al dispositivo",
     ),
-    "unableConnectToWifiBecauseNetworksWasntFoundByDevice": m22,
+    "unableConnectToWifiBecauseNetworksWasntFoundByDevice": m23,
     "unableToUseCamera": MessageLookupByLibrary.simpleMessage(
       "Impossibile usare la fotocamera",
     ),
@@ -828,7 +832,7 @@ class MessageLookup extends MessageLookupByLibrary {
     "updateRequired": MessageLookupByLibrary.simpleMessage(
       "Aggiornamento richiesto",
     ),
-    "updateTo": m23,
+    "updateTo": m24,
     "url": MessageLookupByLibrary.simpleMessage("URL"),
     "user": MessageLookupByLibrary.simpleMessage("Utente"),
     "username": MessageLookupByLibrary.simpleMessage("nome utente"),
@@ -855,9 +859,9 @@ class MessageLookup extends MessageLookupByLibrary {
     "warning": MessageLookupByLibrary.simpleMessage("Avviso"),
     "widgetType": MessageLookupByLibrary.simpleMessage("Tipo di widget"),
     "widgetsBundle": MessageLookupByLibrary.simpleMessage("Pacchetto widget"),
-    "wifiHelpMessage": m24,
+    "wifiHelpMessage": m25,
     "wifiPassword": MessageLookupByLibrary.simpleMessage("Password Wi-Fi"),
-    "wifiPasswordMessage": m25,
+    "wifiPasswordMessage": m26,
     "yes": MessageLookupByLibrary.simpleMessage("Sì"),
     "yesDeactivate": MessageLookupByLibrary.simpleMessage("Sì, disattiva"),
     "yesDiscard": MessageLookupByLibrary.simpleMessage("Sì, annulla"),

--- a/lib/generated/intl/messages_it_IT.dart
+++ b/lib/generated/intl/messages_it_IT.dart
@@ -58,40 +58,43 @@ class MessageLookup extends MessageLookupByLibrary {
 
   static String m13(error) => "Errore nell\'invio del codice: ${error}";
 
-  static String m14(count) => "${count} selezionati";
+  static String m14(count) =>
+      "${Intl.plural(count, one: '1 operazione non riuscita', other: '${count} operazioni non riuscite')}";
 
-  static String m15(count) =>
+  static String m15(count) => "${count} selezionati";
+
+  static String m16(count) =>
       "${Intl.plural(count, one: 'Notifica', other: 'Notifiche')}";
 
-  static String m16(permissions) =>
+  static String m17(permissions) =>
       "Non hai i permessi necessari per \"${permissions}\" per procedere. Apri le impostazioni dell\'app, concedi i permessi e tocca \"Riprova\".";
 
-  static String m17(permissions) =>
+  static String m18(permissions) =>
       "Non hai i permessi necessari per \"${permissions}\" per procedere. Concedi i permessi richiesti e tocca \"Riprova\".";
 
-  static String m18(deviceName) =>
+  static String m19(deviceName) =>
       "Inserisci il PIN di ${deviceName} per confermare la prova di possesso";
 
-  static String m19(time) =>
+  static String m20(time) =>
       "Reinvia codice tra ${Intl.plural(time, one: '1 secondo', other: '${time} secondi')}";
 
-  static String m20(name) => "Percorso non definito: ${name}";
+  static String m21(name) => "Percorso non definito: ${name}";
 
-  static String m21(count) =>
+  static String m22(count) =>
       "${Intl.plural(count, one: 'Cerca utente', other: 'Cerca utenti')}";
 
-  static String m22(contact) =>
+  static String m23(contact) =>
       "Un codice di sicurezza è stato inviato al tuo telefono al numero ${contact}.";
 
-  static String m23(name) =>
+  static String m24(name) =>
       "Impossibile connettersi al Wi-Fi perché il dispositivo ${name} non ha trovato reti";
 
-  static String m24(version) => "Aggiorna a ${version}";
+  static String m25(version) => "Aggiorna a ${version}";
 
-  static String m25(deviceName) =>
+  static String m26(deviceName) =>
       "Per continuare la configurazione del dispositivo ${deviceName}, fornisci le credenziali della tua rete.";
 
-  static String m26(network) => "Inserisci la password per ${network}";
+  static String m27(network) => "Inserisci la password per ${network}";
 
   final messages = _notInlinedMessages(_notInlinedMessages);
   static Map<String, Function> _notInlinedMessages(_) => <String, Function>{
@@ -454,6 +457,7 @@ class MessageLookup extends MessageLookupByLibrary {
     "failedToLoadTheList": MessageLookupByLibrary.simpleMessage(
       "Impossibile caricare l\'elenco",
     ),
+    "failedToPerformOperation": m14,
     "failedToSaveImage": MessageLookupByLibrary.simpleMessage(
       "Impossibile salvare l\'immagine",
     ),
@@ -555,7 +559,7 @@ class MessageLookup extends MessageLookupByLibrary {
           "La dashboard mobile deve essere configurata nel profilo del dispositivo!",
         ),
     "more": MessageLookupByLibrary.simpleMessage("Altro"),
-    "nSelected": m14,
+    "nSelected": m15,
     "newPassword": MessageLookupByLibrary.simpleMessage("Nuova password"),
     "newPassword2": MessageLookupByLibrary.simpleMessage(
       "Conferma nuova password",
@@ -602,12 +606,12 @@ class MessageLookup extends MessageLookupByLibrary {
     "notificationTemplate": MessageLookupByLibrary.simpleMessage(
       "Modello di notifica",
     ),
-    "notifications": m15,
+    "notifications": m16,
     "oauth2Client": MessageLookupByLibrary.simpleMessage("Client OAuth2"),
     "openAppSettings": MessageLookupByLibrary.simpleMessage(
       "Apri impostazioni app",
     ),
-    "openAppSettingsToGrantPermissionMessage": m16,
+    "openAppSettingsToGrantPermissionMessage": m17,
     "openSettingsAndGrantAccessToCameraToContinue":
         MessageLookupByLibrary.simpleMessage(
           "Apri le impostazioni e concedi l\'accesso alla fotocamera per continuare",
@@ -640,7 +644,7 @@ class MessageLookup extends MessageLookupByLibrary {
       "Password cambiata con successo",
     ),
     "permissions": MessageLookupByLibrary.simpleMessage("Permessi"),
-    "permissionsNotEnoughMessage": m17,
+    "permissionsNotEnoughMessage": m18,
     "phone": MessageLookupByLibrary.simpleMessage("Telefono"),
     "phoneIsInvalid": MessageLookupByLibrary.simpleMessage(
       "Il numero di telefono non è valido",
@@ -667,7 +671,7 @@ class MessageLookup extends MessageLookupByLibrary {
       "Scansiona il codice QR sul tuo dispositivo",
     ),
     "plusAlarmType": MessageLookupByLibrary.simpleMessage("+ Tipo di allarme"),
-    "popTitle": m18,
+    "popTitle": m19,
     "postalCode": MessageLookupByLibrary.simpleMessage("CAP / Codice postale"),
     "privacyPolicy": MessageLookupByLibrary.simpleMessage(
       "Informativa sulla privacy",
@@ -698,7 +702,7 @@ class MessageLookup extends MessageLookupByLibrary {
     ),
     "resend": MessageLookupByLibrary.simpleMessage("Reinvia"),
     "resendCode": MessageLookupByLibrary.simpleMessage("Reinvia codice"),
-    "resendCodeWait": m19,
+    "resendCodeWait": m20,
     "reset": MessageLookupByLibrary.simpleMessage("Reimposta"),
     "retry": MessageLookupByLibrary.simpleMessage("Riprova"),
     "returnToDashboard": MessageLookupByLibrary.simpleMessage(
@@ -708,7 +712,7 @@ class MessageLookup extends MessageLookupByLibrary {
       "Torna all\'app e tocca il pulsante Pronto",
     ),
     "role": MessageLookupByLibrary.simpleMessage("Ruolo"),
-    "routeNotDefined": m20,
+    "routeNotDefined": m21,
     "rpc": MessageLookupByLibrary.simpleMessage("RPC"),
     "ruleChain": MessageLookupByLibrary.simpleMessage("Catena di regole"),
     "ruleNode": MessageLookupByLibrary.simpleMessage("Nodo di regole"),
@@ -721,7 +725,7 @@ class MessageLookup extends MessageLookupByLibrary {
     "searchResults": MessageLookupByLibrary.simpleMessage(
       "Risultati della ricerca",
     ),
-    "searchUsers": m21,
+    "searchUsers": m22,
     "seconds": MessageLookupByLibrary.simpleMessage("secondi"),
     "security": MessageLookupByLibrary.simpleMessage("Sicurezza"),
     "selectAll": MessageLookupByLibrary.simpleMessage("Seleziona tutto"),
@@ -748,7 +752,7 @@ class MessageLookup extends MessageLookupByLibrary {
     "severity": MessageLookupByLibrary.simpleMessage("Gravità"),
     "signIn": MessageLookupByLibrary.simpleMessage("Accedi"),
     "signUp": MessageLookupByLibrary.simpleMessage("Registrati"),
-    "smsAuthDescription": m22,
+    "smsAuthDescription": m23,
     "smsAuthPlaceholder": MessageLookupByLibrary.simpleMessage("Codice SMS"),
     "smsSetupSuccessDescription": MessageLookupByLibrary.simpleMessage(
       "Al prossimo accesso ti verrà chiesto di inserire il codice di sicurezza inviato al numero di telefono",
@@ -816,7 +820,7 @@ class MessageLookup extends MessageLookupByLibrary {
     "unableConnectToDevice": MessageLookupByLibrary.simpleMessage(
       "Impossibile connettersi al dispositivo",
     ),
-    "unableConnectToWifiBecauseNetworksWasntFoundByDevice": m23,
+    "unableConnectToWifiBecauseNetworksWasntFoundByDevice": m24,
     "unableToUseCamera": MessageLookupByLibrary.simpleMessage(
       "Impossibile usare la fotocamera",
     ),
@@ -832,7 +836,7 @@ class MessageLookup extends MessageLookupByLibrary {
     "updateRequired": MessageLookupByLibrary.simpleMessage(
       "Aggiornamento richiesto",
     ),
-    "updateTo": m24,
+    "updateTo": m25,
     "url": MessageLookupByLibrary.simpleMessage("URL"),
     "user": MessageLookupByLibrary.simpleMessage("Utente"),
     "username": MessageLookupByLibrary.simpleMessage("nome utente"),
@@ -859,9 +863,9 @@ class MessageLookup extends MessageLookupByLibrary {
     "warning": MessageLookupByLibrary.simpleMessage("Avviso"),
     "widgetType": MessageLookupByLibrary.simpleMessage("Tipo di widget"),
     "widgetsBundle": MessageLookupByLibrary.simpleMessage("Pacchetto widget"),
-    "wifiHelpMessage": m25,
+    "wifiHelpMessage": m26,
     "wifiPassword": MessageLookupByLibrary.simpleMessage("Password Wi-Fi"),
-    "wifiPasswordMessage": m26,
+    "wifiPasswordMessage": m27,
     "yes": MessageLookupByLibrary.simpleMessage("Sì"),
     "yesDeactivate": MessageLookupByLibrary.simpleMessage("Sì, disattiva"),
     "yesDiscard": MessageLookupByLibrary.simpleMessage("Sì, annulla"),

--- a/lib/generated/intl/messages_it_IT.dart
+++ b/lib/generated/intl/messages_it_IT.dart
@@ -46,55 +46,61 @@ class MessageLookup extends MessageLookupByLibrary {
       "${Intl.plural(count, one: 'Dashboard', other: 'Dashboard')}";
 
   static String m9(count) =>
-      "${Intl.plural(count, one: 'Dispositivo', other: 'Dispositivi')}";
+      "${Intl.plural(count, one: 'Eliminare 1 notifica?', other: 'Eliminare ${count} notifiche?')}";
 
   static String m10(count) =>
+      "${Intl.plural(count, one: 'Dispositivo', other: 'Dispositivi')}";
+
+  static String m11(count) =>
       "Codice a ${count} ${Intl.plural(count, one: 'cifra', other: 'cifre')}";
 
-  static String m11(contact) =>
+  static String m12(contact) =>
       "Un codice di sicurezza è stato inviato alla tua email all\'indirizzo ${contact}.";
 
-  static String m12(e) => "Errore verificatosi: ${e}";
+  static String m13(e) => "Errore verificatosi: ${e}";
 
-  static String m13(error) => "Errore nell\'invio del codice: ${error}";
+  static String m14(error) => "Errore nell\'invio del codice: ${error}";
 
-  static String m14(count) =>
+  static String m15(count) =>
       "${Intl.plural(count, one: '1 operazione non riuscita', other: '${count} operazioni non riuscite')}";
 
-  static String m15(count) => "${count} selezionati";
-
   static String m16(count) =>
+      "${Intl.plural(count, one: 'Segnare 1 notifica come letta?', other: 'Segnare ${count} notifiche come lette?')}";
+
+  static String m17(count) => "${count} selezionati";
+
+  static String m18(count) =>
       "${Intl.plural(count, one: 'Notifica', other: 'Notifiche')}";
 
-  static String m17(permissions) =>
+  static String m19(permissions) =>
       "Non hai i permessi necessari per \"${permissions}\" per procedere. Apri le impostazioni dell\'app, concedi i permessi e tocca \"Riprova\".";
 
-  static String m18(permissions) =>
+  static String m20(permissions) =>
       "Non hai i permessi necessari per \"${permissions}\" per procedere. Concedi i permessi richiesti e tocca \"Riprova\".";
 
-  static String m19(deviceName) =>
+  static String m21(deviceName) =>
       "Inserisci il PIN di ${deviceName} per confermare la prova di possesso";
 
-  static String m20(time) =>
+  static String m22(time) =>
       "Reinvia codice tra ${Intl.plural(time, one: '1 secondo', other: '${time} secondi')}";
 
-  static String m21(name) => "Percorso non definito: ${name}";
+  static String m23(name) => "Percorso non definito: ${name}";
 
-  static String m22(count) =>
+  static String m24(count) =>
       "${Intl.plural(count, one: 'Cerca utente', other: 'Cerca utenti')}";
 
-  static String m23(contact) =>
+  static String m25(contact) =>
       "Un codice di sicurezza è stato inviato al tuo telefono al numero ${contact}.";
 
-  static String m24(name) =>
+  static String m26(name) =>
       "Impossibile connettersi al Wi-Fi perché il dispositivo ${name} non ha trovato reti";
 
-  static String m25(version) => "Aggiorna a ${version}";
+  static String m27(version) => "Aggiorna a ${version}";
 
-  static String m26(deviceName) =>
+  static String m28(deviceName) =>
       "Per continuare la configurazione del dispositivo ${deviceName}, fornisci le credenziali della tua rete.";
 
-  static String m27(network) => "Inserisci la password per ${network}";
+  static String m29(network) => "Inserisci la password per ${network}";
 
   final messages = _notInlinedMessages(_notInlinedMessages);
   static Map<String, Function> _notInlinedMessages(_) => <String, Function>{
@@ -378,6 +384,7 @@ class MessageLookup extends MessageLookupByLibrary {
     "delete": MessageLookupByLibrary.simpleMessage("Elimina"),
     "deleteAccount": MessageLookupByLibrary.simpleMessage("Elimina account"),
     "deleteComment": MessageLookupByLibrary.simpleMessage("Elimina commento"),
+    "deleteSelectedNotifications": m9,
     "details": MessageLookupByLibrary.simpleMessage("Dettagli"),
     "deviceList": MessageLookupByLibrary.simpleMessage("Elenco dispositivi"),
     "deviceNotAbleToFindWifiNearby": MessageLookupByLibrary.simpleMessage(
@@ -392,8 +399,8 @@ class MessageLookup extends MessageLookupByLibrary {
     "deviceProvisioning": MessageLookupByLibrary.simpleMessage(
       "Provisioning del dispositivo",
     ),
-    "devices": m9,
-    "digitsCode": m10,
+    "devices": m10,
+    "digitsCode": m11,
     "discardChanges": MessageLookupByLibrary.simpleMessage("Annulla modifiche"),
     "domain": MessageLookupByLibrary.simpleMessage("Dominio"),
     "done": MessageLookupByLibrary.simpleMessage("Fatto"),
@@ -402,7 +409,7 @@ class MessageLookup extends MessageLookupByLibrary {
     "edit": MessageLookupByLibrary.simpleMessage("Modifica"),
     "edited": MessageLookupByLibrary.simpleMessage("Modificato"),
     "email": MessageLookupByLibrary.simpleMessage("Email"),
-    "emailAuthDescription": m11,
+    "emailAuthDescription": m12,
     "emailAuthPlaceholder": MessageLookupByLibrary.simpleMessage(
       "Codice email",
     ),
@@ -441,8 +448,8 @@ class MessageLookup extends MessageLookupByLibrary {
     "entityGroup": MessageLookupByLibrary.simpleMessage("Gruppo di entità"),
     "entityType": MessageLookupByLibrary.simpleMessage("Tipo di entità"),
     "entityView": MessageLookupByLibrary.simpleMessage("Vista entità"),
-    "errorOccured": m12,
-    "errorSendingCode": m13,
+    "errorOccured": m13,
+    "errorSendingCode": m14,
     "europe": MessageLookupByLibrary.simpleMessage("Europa"),
     "europeRegionShort": MessageLookupByLibrary.simpleMessage("Francoforte"),
     "exitDeviceProvisioning": MessageLookupByLibrary.simpleMessage(
@@ -457,7 +464,7 @@ class MessageLookup extends MessageLookupByLibrary {
     "failedToLoadTheList": MessageLookupByLibrary.simpleMessage(
       "Impossibile caricare l\'elenco",
     ),
-    "failedToPerformOperation": m14,
+    "failedToPerformOperation": m15,
     "failedToSaveImage": MessageLookupByLibrary.simpleMessage(
       "Impossibile salvare l\'immagine",
     ),
@@ -539,6 +546,7 @@ class MessageLookup extends MessageLookupByLibrary {
       "Segna tutto come letto",
     ),
     "markAsRead": MessageLookupByLibrary.simpleMessage("Segna come letto"),
+    "markSelectedNotificationsAsRead": m16,
     "metricUnitSystem": MessageLookupByLibrary.simpleMessage("Metrico"),
     "mfaProviderBackupCode": MessageLookupByLibrary.simpleMessage(
       "Codice di backup",
@@ -559,7 +567,7 @@ class MessageLookup extends MessageLookupByLibrary {
           "La dashboard mobile deve essere configurata nel profilo del dispositivo!",
         ),
     "more": MessageLookupByLibrary.simpleMessage("Altro"),
-    "nSelected": m15,
+    "nSelected": m17,
     "newPassword": MessageLookupByLibrary.simpleMessage("Nuova password"),
     "newPassword2": MessageLookupByLibrary.simpleMessage(
       "Conferma nuova password",
@@ -606,12 +614,12 @@ class MessageLookup extends MessageLookupByLibrary {
     "notificationTemplate": MessageLookupByLibrary.simpleMessage(
       "Modello di notifica",
     ),
-    "notifications": m16,
+    "notifications": m18,
     "oauth2Client": MessageLookupByLibrary.simpleMessage("Client OAuth2"),
     "openAppSettings": MessageLookupByLibrary.simpleMessage(
       "Apri impostazioni app",
     ),
-    "openAppSettingsToGrantPermissionMessage": m17,
+    "openAppSettingsToGrantPermissionMessage": m19,
     "openSettingsAndGrantAccessToCameraToContinue":
         MessageLookupByLibrary.simpleMessage(
           "Apri le impostazioni e concedi l\'accesso alla fotocamera per continuare",
@@ -644,7 +652,7 @@ class MessageLookup extends MessageLookupByLibrary {
       "Password cambiata con successo",
     ),
     "permissions": MessageLookupByLibrary.simpleMessage("Permessi"),
-    "permissionsNotEnoughMessage": m18,
+    "permissionsNotEnoughMessage": m20,
     "phone": MessageLookupByLibrary.simpleMessage("Telefono"),
     "phoneIsInvalid": MessageLookupByLibrary.simpleMessage(
       "Il numero di telefono non è valido",
@@ -671,7 +679,7 @@ class MessageLookup extends MessageLookupByLibrary {
       "Scansiona il codice QR sul tuo dispositivo",
     ),
     "plusAlarmType": MessageLookupByLibrary.simpleMessage("+ Tipo di allarme"),
-    "popTitle": m19,
+    "popTitle": m21,
     "postalCode": MessageLookupByLibrary.simpleMessage("CAP / Codice postale"),
     "privacyPolicy": MessageLookupByLibrary.simpleMessage(
       "Informativa sulla privacy",
@@ -702,7 +710,7 @@ class MessageLookup extends MessageLookupByLibrary {
     ),
     "resend": MessageLookupByLibrary.simpleMessage("Reinvia"),
     "resendCode": MessageLookupByLibrary.simpleMessage("Reinvia codice"),
-    "resendCodeWait": m20,
+    "resendCodeWait": m22,
     "reset": MessageLookupByLibrary.simpleMessage("Reimposta"),
     "retry": MessageLookupByLibrary.simpleMessage("Riprova"),
     "returnToDashboard": MessageLookupByLibrary.simpleMessage(
@@ -712,7 +720,7 @@ class MessageLookup extends MessageLookupByLibrary {
       "Torna all\'app e tocca il pulsante Pronto",
     ),
     "role": MessageLookupByLibrary.simpleMessage("Ruolo"),
-    "routeNotDefined": m21,
+    "routeNotDefined": m23,
     "rpc": MessageLookupByLibrary.simpleMessage("RPC"),
     "ruleChain": MessageLookupByLibrary.simpleMessage("Catena di regole"),
     "ruleNode": MessageLookupByLibrary.simpleMessage("Nodo di regole"),
@@ -725,7 +733,7 @@ class MessageLookup extends MessageLookupByLibrary {
     "searchResults": MessageLookupByLibrary.simpleMessage(
       "Risultati della ricerca",
     ),
-    "searchUsers": m22,
+    "searchUsers": m24,
     "seconds": MessageLookupByLibrary.simpleMessage("secondi"),
     "security": MessageLookupByLibrary.simpleMessage("Sicurezza"),
     "selectAll": MessageLookupByLibrary.simpleMessage("Seleziona tutto"),
@@ -752,7 +760,7 @@ class MessageLookup extends MessageLookupByLibrary {
     "severity": MessageLookupByLibrary.simpleMessage("Gravità"),
     "signIn": MessageLookupByLibrary.simpleMessage("Accedi"),
     "signUp": MessageLookupByLibrary.simpleMessage("Registrati"),
-    "smsAuthDescription": m23,
+    "smsAuthDescription": m25,
     "smsAuthPlaceholder": MessageLookupByLibrary.simpleMessage("Codice SMS"),
     "smsSetupSuccessDescription": MessageLookupByLibrary.simpleMessage(
       "Al prossimo accesso ti verrà chiesto di inserire il codice di sicurezza inviato al numero di telefono",
@@ -820,7 +828,7 @@ class MessageLookup extends MessageLookupByLibrary {
     "unableConnectToDevice": MessageLookupByLibrary.simpleMessage(
       "Impossibile connettersi al dispositivo",
     ),
-    "unableConnectToWifiBecauseNetworksWasntFoundByDevice": m24,
+    "unableConnectToWifiBecauseNetworksWasntFoundByDevice": m26,
     "unableToUseCamera": MessageLookupByLibrary.simpleMessage(
       "Impossibile usare la fotocamera",
     ),
@@ -836,7 +844,7 @@ class MessageLookup extends MessageLookupByLibrary {
     "updateRequired": MessageLookupByLibrary.simpleMessage(
       "Aggiornamento richiesto",
     ),
-    "updateTo": m25,
+    "updateTo": m27,
     "url": MessageLookupByLibrary.simpleMessage("URL"),
     "user": MessageLookupByLibrary.simpleMessage("Utente"),
     "username": MessageLookupByLibrary.simpleMessage("nome utente"),
@@ -863,9 +871,9 @@ class MessageLookup extends MessageLookupByLibrary {
     "warning": MessageLookupByLibrary.simpleMessage("Avviso"),
     "widgetType": MessageLookupByLibrary.simpleMessage("Tipo di widget"),
     "widgetsBundle": MessageLookupByLibrary.simpleMessage("Pacchetto widget"),
-    "wifiHelpMessage": m26,
+    "wifiHelpMessage": m28,
     "wifiPassword": MessageLookupByLibrary.simpleMessage("Password Wi-Fi"),
-    "wifiPasswordMessage": m27,
+    "wifiPasswordMessage": m29,
     "yes": MessageLookupByLibrary.simpleMessage("Sì"),
     "yesDeactivate": MessageLookupByLibrary.simpleMessage("Sì, disattiva"),
     "yesDiscard": MessageLookupByLibrary.simpleMessage("Sì, annulla"),

--- a/lib/generated/intl/messages_it_IT.dart
+++ b/lib/generated/intl/messages_it_IT.dart
@@ -736,7 +736,9 @@ class MessageLookup extends MessageLookupByLibrary {
     "searchUsers": m24,
     "seconds": MessageLookupByLibrary.simpleMessage("secondi"),
     "security": MessageLookupByLibrary.simpleMessage("Sicurezza"),
-    "selectAll": MessageLookupByLibrary.simpleMessage("Seleziona tutto"),
+    "selectAll": MessageLookupByLibrary.simpleMessage(
+      "Seleziona tutti i caricati",
+    ),
     "selectCountry": MessageLookupByLibrary.simpleMessage("Seleziona paese"),
     "selectRegion": MessageLookupByLibrary.simpleMessage("Seleziona regione"),
     "selectUser": MessageLookupByLibrary.simpleMessage("Seleziona utenti"),

--- a/lib/generated/intl/messages_nl_NL.dart
+++ b/lib/generated/intl/messages_nl_NL.dart
@@ -47,55 +47,61 @@ class MessageLookup extends MessageLookupByLibrary {
       "${Intl.plural(count, one: 'Dashboard', other: 'Dashboards')}";
 
   static String m9(count) =>
-      "${Intl.plural(count, one: 'Apparaat', other: 'Apparaten')}";
+      "${Intl.plural(count, one: '1 melding verwijderen?', other: '${count} meldingen verwijderen?')}";
 
   static String m10(count) =>
+      "${Intl.plural(count, one: 'Apparaat', other: 'Apparaten')}";
+
+  static String m11(count) =>
       "${count}-${Intl.plural(count, one: 'cijferige', other: 'cijferige')} code";
 
-  static String m11(contact) =>
+  static String m12(contact) =>
       "Er is een beveiligingscode verzonden naar uw e-mailadres op ${contact}.";
 
-  static String m12(e) => "Fout opgetreden: ${e}";
+  static String m13(e) => "Fout opgetreden: ${e}";
 
-  static String m13(error) => "Fout bij het verzenden van de code: ${error}";
+  static String m14(error) => "Fout bij het verzenden van de code: ${error}";
 
-  static String m14(count) =>
+  static String m15(count) =>
       "${Intl.plural(count, one: '1 bewerking mislukt', other: '${count} bewerkingen mislukt')}";
 
-  static String m15(count) => "${count} geselecteerd";
-
   static String m16(count) =>
+      "${Intl.plural(count, one: '1 melding als gelezen markeren?', other: '${count} meldingen als gelezen markeren?')}";
+
+  static String m17(count) => "${count} geselecteerd";
+
+  static String m18(count) =>
       "${Intl.plural(count, one: 'Melding', other: 'Meldingen')}";
 
-  static String m17(permissions) =>
+  static String m19(permissions) =>
       "U heeft onvoldoende rechten voor \"${permissions}\" om door te gaan. Open de app-instellingen, verleen de rechten en tik op \"Opnieuw proberen\".";
 
-  static String m18(permissions) =>
+  static String m20(permissions) =>
       "U heeft onvoldoende rechten voor \"${permissions}\" om door te gaan. Verleen de vereiste rechten en tik op \"Opnieuw proberen\".";
 
-  static String m19(deviceName) =>
+  static String m21(deviceName) =>
       "Voer de pincode van ${deviceName} in om eigendomsbewijs te bevestigen";
 
-  static String m20(time) =>
+  static String m22(time) =>
       "Code opnieuw verzenden in ${Intl.plural(time, one: '1 seconde', other: '${time} seconden')}";
 
-  static String m21(name) => "Route niet gedefinieerd: ${name}";
+  static String m23(name) => "Route niet gedefinieerd: ${name}";
 
-  static String m22(count) =>
+  static String m24(count) =>
       "${Intl.plural(count, one: 'Gebruiker zoeken', other: 'Gebruikers zoeken')}";
 
-  static String m23(contact) =>
+  static String m25(contact) =>
       "Er is een beveiligingscode verzonden naar uw telefoon op ${contact}.";
 
-  static String m24(name) =>
+  static String m26(name) =>
       "Kan niet verbinden met Wi-Fi omdat het apparaat ${name} geen netwerken heeft gevonden";
 
-  static String m25(version) => "Updaten naar ${version}";
+  static String m27(version) => "Updaten naar ${version}";
 
-  static String m26(deviceName) =>
+  static String m28(deviceName) =>
       "Om de installatie van uw apparaat ${deviceName} voort te zetten, geef de netwerkgegevens op.";
 
-  static String m27(network) => "Voer het wachtwoord in voor ${network}";
+  static String m29(network) => "Voer het wachtwoord in voor ${network}";
 
   final messages = _notInlinedMessages(_notInlinedMessages);
   static Map<String, Function> _notInlinedMessages(_) => <String, Function>{
@@ -383,6 +389,7 @@ class MessageLookup extends MessageLookupByLibrary {
     "deleteComment": MessageLookupByLibrary.simpleMessage(
       "Opmerking verwijderen",
     ),
+    "deleteSelectedNotifications": m9,
     "details": MessageLookupByLibrary.simpleMessage("Details"),
     "deviceList": MessageLookupByLibrary.simpleMessage("Apparatenlijst"),
     "deviceNotAbleToFindWifiNearby": MessageLookupByLibrary.simpleMessage(
@@ -395,8 +402,8 @@ class MessageLookup extends MessageLookupByLibrary {
     "deviceProvisioning": MessageLookupByLibrary.simpleMessage(
       "Apparaatprovisioning",
     ),
-    "devices": m9,
-    "digitsCode": m10,
+    "devices": m10,
+    "digitsCode": m11,
     "discardChanges": MessageLookupByLibrary.simpleMessage(
       "Wijzigingen verwerpen",
     ),
@@ -407,7 +414,7 @@ class MessageLookup extends MessageLookupByLibrary {
     "edit": MessageLookupByLibrary.simpleMessage("Bewerken"),
     "edited": MessageLookupByLibrary.simpleMessage("Bewerkt"),
     "email": MessageLookupByLibrary.simpleMessage("E-mail"),
-    "emailAuthDescription": m11,
+    "emailAuthDescription": m12,
     "emailAuthPlaceholder": MessageLookupByLibrary.simpleMessage("E-mailcode"),
     "emailInvalidText": MessageLookupByLibrary.simpleMessage(
       "Ongeldig e-mailformaat.",
@@ -448,8 +455,8 @@ class MessageLookup extends MessageLookupByLibrary {
     "entityGroup": MessageLookupByLibrary.simpleMessage("Entiteitsgroep"),
     "entityType": MessageLookupByLibrary.simpleMessage("Entiteitstype"),
     "entityView": MessageLookupByLibrary.simpleMessage("Entiteitsweergave"),
-    "errorOccured": m12,
-    "errorSendingCode": m13,
+    "errorOccured": m13,
+    "errorSendingCode": m14,
     "europe": MessageLookupByLibrary.simpleMessage("Europa"),
     "europeRegionShort": MessageLookupByLibrary.simpleMessage("Frankfurt"),
     "exitDeviceProvisioning": MessageLookupByLibrary.simpleMessage(
@@ -464,7 +471,7 @@ class MessageLookup extends MessageLookupByLibrary {
     "failedToLoadTheList": MessageLookupByLibrary.simpleMessage(
       "Laden van de lijst mislukt",
     ),
-    "failedToPerformOperation": m14,
+    "failedToPerformOperation": m15,
     "failedToSaveImage": MessageLookupByLibrary.simpleMessage(
       "Kan afbeelding niet opslaan",
     ),
@@ -542,6 +549,7 @@ class MessageLookup extends MessageLookupByLibrary {
       "Alles als gelezen markeren",
     ),
     "markAsRead": MessageLookupByLibrary.simpleMessage("Markeer als gelezen"),
+    "markSelectedNotificationsAsRead": m16,
     "metricUnitSystem": MessageLookupByLibrary.simpleMessage("Metrisch"),
     "mfaProviderBackupCode": MessageLookupByLibrary.simpleMessage(
       "Back-upcode",
@@ -562,7 +570,7 @@ class MessageLookup extends MessageLookupByLibrary {
           "Het mobiele dashboard moet worden geconfigureerd in het apparaatprofiel!",
         ),
     "more": MessageLookupByLibrary.simpleMessage("Meer"),
-    "nSelected": m15,
+    "nSelected": m17,
     "newPassword": MessageLookupByLibrary.simpleMessage("Nieuw wachtwoord"),
     "newPassword2": MessageLookupByLibrary.simpleMessage(
       "Bevestig nieuw wachtwoord",
@@ -607,12 +615,12 @@ class MessageLookup extends MessageLookupByLibrary {
     "notificationTemplate": MessageLookupByLibrary.simpleMessage(
       "Meldingssjabloon",
     ),
-    "notifications": m16,
+    "notifications": m18,
     "oauth2Client": MessageLookupByLibrary.simpleMessage("OAuth2-client"),
     "openAppSettings": MessageLookupByLibrary.simpleMessage(
       "App-instellingen openen",
     ),
-    "openAppSettingsToGrantPermissionMessage": m17,
+    "openAppSettingsToGrantPermissionMessage": m19,
     "openSettingsAndGrantAccessToCameraToContinue":
         MessageLookupByLibrary.simpleMessage(
           "Open instellingen en geef cameratoegang om door te gaan",
@@ -647,7 +655,7 @@ class MessageLookup extends MessageLookupByLibrary {
       "Wachtwoord succesvol gewijzigd",
     ),
     "permissions": MessageLookupByLibrary.simpleMessage("Rechten"),
-    "permissionsNotEnoughMessage": m18,
+    "permissionsNotEnoughMessage": m20,
     "phone": MessageLookupByLibrary.simpleMessage("Telefoon"),
     "phoneIsInvalid": MessageLookupByLibrary.simpleMessage(
       "Telefoonnummer is ongeldig",
@@ -674,7 +682,7 @@ class MessageLookup extends MessageLookupByLibrary {
       "Scan de QR-code op uw apparaat",
     ),
     "plusAlarmType": MessageLookupByLibrary.simpleMessage("+ Alarmtype"),
-    "popTitle": m19,
+    "popTitle": m21,
     "postalCode": MessageLookupByLibrary.simpleMessage("Postcode"),
     "privacyPolicy": MessageLookupByLibrary.simpleMessage("Privacybeleid"),
     "profile": MessageLookupByLibrary.simpleMessage("Profiel"),
@@ -705,7 +713,7 @@ class MessageLookup extends MessageLookupByLibrary {
     "resendCode": MessageLookupByLibrary.simpleMessage(
       "Code opnieuw verzenden",
     ),
-    "resendCodeWait": m20,
+    "resendCodeWait": m22,
     "reset": MessageLookupByLibrary.simpleMessage("Herstellen"),
     "retry": MessageLookupByLibrary.simpleMessage("Opnieuw proberen"),
     "returnToDashboard": MessageLookupByLibrary.simpleMessage(
@@ -715,7 +723,7 @@ class MessageLookup extends MessageLookupByLibrary {
       "Ga terug naar de app en tik op de knop Gereed",
     ),
     "role": MessageLookupByLibrary.simpleMessage("Rol"),
-    "routeNotDefined": m21,
+    "routeNotDefined": m23,
     "rpc": MessageLookupByLibrary.simpleMessage("RPC"),
     "ruleChain": MessageLookupByLibrary.simpleMessage("Regelketen"),
     "ruleNode": MessageLookupByLibrary.simpleMessage("Regelknooppunt"),
@@ -724,7 +732,7 @@ class MessageLookup extends MessageLookupByLibrary {
     "schedulerEvent": MessageLookupByLibrary.simpleMessage("Planner-evenement"),
     "search": MessageLookupByLibrary.simpleMessage("Zoeken"),
     "searchResults": MessageLookupByLibrary.simpleMessage("Zoekresultaten"),
-    "searchUsers": m22,
+    "searchUsers": m24,
     "seconds": MessageLookupByLibrary.simpleMessage("seconden"),
     "security": MessageLookupByLibrary.simpleMessage("Beveiliging"),
     "selectAll": MessageLookupByLibrary.simpleMessage("Alles selecteren"),
@@ -751,7 +759,7 @@ class MessageLookup extends MessageLookupByLibrary {
     "severity": MessageLookupByLibrary.simpleMessage("Ernst"),
     "signIn": MessageLookupByLibrary.simpleMessage("Inloggen"),
     "signUp": MessageLookupByLibrary.simpleMessage("Registreren"),
-    "smsAuthDescription": m23,
+    "smsAuthDescription": m25,
     "smsAuthPlaceholder": MessageLookupByLibrary.simpleMessage("SMS-code"),
     "smsSetupSuccessDescription": MessageLookupByLibrary.simpleMessage(
       "De volgende keer dat u inlogt, wordt u gevraagd de beveiligingscode in te voeren die naar uw telefoonnummer wordt gestuurd",
@@ -817,7 +825,7 @@ class MessageLookup extends MessageLookupByLibrary {
     "unableConnectToDevice": MessageLookupByLibrary.simpleMessage(
       "Kan niet verbinden met apparaat",
     ),
-    "unableConnectToWifiBecauseNetworksWasntFoundByDevice": m24,
+    "unableConnectToWifiBecauseNetworksWasntFoundByDevice": m26,
     "unableToUseCamera": MessageLookupByLibrary.simpleMessage(
       "Kan camera niet gebruiken",
     ),
@@ -831,7 +839,7 @@ class MessageLookup extends MessageLookupByLibrary {
     ),
     "update": MessageLookupByLibrary.simpleMessage("Bijwerken"),
     "updateRequired": MessageLookupByLibrary.simpleMessage("Update vereist"),
-    "updateTo": m25,
+    "updateTo": m27,
     "url": MessageLookupByLibrary.simpleMessage("URL"),
     "user": MessageLookupByLibrary.simpleMessage("Gebruiker"),
     "username": MessageLookupByLibrary.simpleMessage("gebruikersnaam"),
@@ -856,9 +864,9 @@ class MessageLookup extends MessageLookupByLibrary {
     "warning": MessageLookupByLibrary.simpleMessage("Waarschuwing"),
     "widgetType": MessageLookupByLibrary.simpleMessage("Widgettype"),
     "widgetsBundle": MessageLookupByLibrary.simpleMessage("Widgetpakket"),
-    "wifiHelpMessage": m26,
+    "wifiHelpMessage": m28,
     "wifiPassword": MessageLookupByLibrary.simpleMessage("Wi-Fi-wachtwoord"),
-    "wifiPasswordMessage": m27,
+    "wifiPasswordMessage": m29,
     "yes": MessageLookupByLibrary.simpleMessage("Ja"),
     "yesDeactivate": MessageLookupByLibrary.simpleMessage("Ja, deactiveren"),
     "yesDiscard": MessageLookupByLibrary.simpleMessage("Ja, verwerpen"),

--- a/lib/generated/intl/messages_nl_NL.dart
+++ b/lib/generated/intl/messages_nl_NL.dart
@@ -59,40 +59,43 @@ class MessageLookup extends MessageLookupByLibrary {
 
   static String m13(error) => "Fout bij het verzenden van de code: ${error}";
 
-  static String m14(count) => "${count} geselecteerd";
+  static String m14(count) =>
+      "${Intl.plural(count, one: '1 bewerking mislukt', other: '${count} bewerkingen mislukt')}";
 
-  static String m15(count) =>
+  static String m15(count) => "${count} geselecteerd";
+
+  static String m16(count) =>
       "${Intl.plural(count, one: 'Melding', other: 'Meldingen')}";
 
-  static String m16(permissions) =>
+  static String m17(permissions) =>
       "U heeft onvoldoende rechten voor \"${permissions}\" om door te gaan. Open de app-instellingen, verleen de rechten en tik op \"Opnieuw proberen\".";
 
-  static String m17(permissions) =>
+  static String m18(permissions) =>
       "U heeft onvoldoende rechten voor \"${permissions}\" om door te gaan. Verleen de vereiste rechten en tik op \"Opnieuw proberen\".";
 
-  static String m18(deviceName) =>
+  static String m19(deviceName) =>
       "Voer de pincode van ${deviceName} in om eigendomsbewijs te bevestigen";
 
-  static String m19(time) =>
+  static String m20(time) =>
       "Code opnieuw verzenden in ${Intl.plural(time, one: '1 seconde', other: '${time} seconden')}";
 
-  static String m20(name) => "Route niet gedefinieerd: ${name}";
+  static String m21(name) => "Route niet gedefinieerd: ${name}";
 
-  static String m21(count) =>
+  static String m22(count) =>
       "${Intl.plural(count, one: 'Gebruiker zoeken', other: 'Gebruikers zoeken')}";
 
-  static String m22(contact) =>
+  static String m23(contact) =>
       "Er is een beveiligingscode verzonden naar uw telefoon op ${contact}.";
 
-  static String m23(name) =>
+  static String m24(name) =>
       "Kan niet verbinden met Wi-Fi omdat het apparaat ${name} geen netwerken heeft gevonden";
 
-  static String m24(version) => "Updaten naar ${version}";
+  static String m25(version) => "Updaten naar ${version}";
 
-  static String m25(deviceName) =>
+  static String m26(deviceName) =>
       "Om de installatie van uw apparaat ${deviceName} voort te zetten, geef de netwerkgegevens op.";
 
-  static String m26(network) => "Voer het wachtwoord in voor ${network}";
+  static String m27(network) => "Voer het wachtwoord in voor ${network}";
 
   final messages = _notInlinedMessages(_notInlinedMessages);
   static Map<String, Function> _notInlinedMessages(_) => <String, Function>{
@@ -461,6 +464,7 @@ class MessageLookup extends MessageLookupByLibrary {
     "failedToLoadTheList": MessageLookupByLibrary.simpleMessage(
       "Laden van de lijst mislukt",
     ),
+    "failedToPerformOperation": m14,
     "failedToSaveImage": MessageLookupByLibrary.simpleMessage(
       "Kan afbeelding niet opslaan",
     ),
@@ -558,7 +562,7 @@ class MessageLookup extends MessageLookupByLibrary {
           "Het mobiele dashboard moet worden geconfigureerd in het apparaatprofiel!",
         ),
     "more": MessageLookupByLibrary.simpleMessage("Meer"),
-    "nSelected": m14,
+    "nSelected": m15,
     "newPassword": MessageLookupByLibrary.simpleMessage("Nieuw wachtwoord"),
     "newPassword2": MessageLookupByLibrary.simpleMessage(
       "Bevestig nieuw wachtwoord",
@@ -603,12 +607,12 @@ class MessageLookup extends MessageLookupByLibrary {
     "notificationTemplate": MessageLookupByLibrary.simpleMessage(
       "Meldingssjabloon",
     ),
-    "notifications": m15,
+    "notifications": m16,
     "oauth2Client": MessageLookupByLibrary.simpleMessage("OAuth2-client"),
     "openAppSettings": MessageLookupByLibrary.simpleMessage(
       "App-instellingen openen",
     ),
-    "openAppSettingsToGrantPermissionMessage": m16,
+    "openAppSettingsToGrantPermissionMessage": m17,
     "openSettingsAndGrantAccessToCameraToContinue":
         MessageLookupByLibrary.simpleMessage(
           "Open instellingen en geef cameratoegang om door te gaan",
@@ -643,7 +647,7 @@ class MessageLookup extends MessageLookupByLibrary {
       "Wachtwoord succesvol gewijzigd",
     ),
     "permissions": MessageLookupByLibrary.simpleMessage("Rechten"),
-    "permissionsNotEnoughMessage": m17,
+    "permissionsNotEnoughMessage": m18,
     "phone": MessageLookupByLibrary.simpleMessage("Telefoon"),
     "phoneIsInvalid": MessageLookupByLibrary.simpleMessage(
       "Telefoonnummer is ongeldig",
@@ -670,7 +674,7 @@ class MessageLookup extends MessageLookupByLibrary {
       "Scan de QR-code op uw apparaat",
     ),
     "plusAlarmType": MessageLookupByLibrary.simpleMessage("+ Alarmtype"),
-    "popTitle": m18,
+    "popTitle": m19,
     "postalCode": MessageLookupByLibrary.simpleMessage("Postcode"),
     "privacyPolicy": MessageLookupByLibrary.simpleMessage("Privacybeleid"),
     "profile": MessageLookupByLibrary.simpleMessage("Profiel"),
@@ -701,7 +705,7 @@ class MessageLookup extends MessageLookupByLibrary {
     "resendCode": MessageLookupByLibrary.simpleMessage(
       "Code opnieuw verzenden",
     ),
-    "resendCodeWait": m19,
+    "resendCodeWait": m20,
     "reset": MessageLookupByLibrary.simpleMessage("Herstellen"),
     "retry": MessageLookupByLibrary.simpleMessage("Opnieuw proberen"),
     "returnToDashboard": MessageLookupByLibrary.simpleMessage(
@@ -711,7 +715,7 @@ class MessageLookup extends MessageLookupByLibrary {
       "Ga terug naar de app en tik op de knop Gereed",
     ),
     "role": MessageLookupByLibrary.simpleMessage("Rol"),
-    "routeNotDefined": m20,
+    "routeNotDefined": m21,
     "rpc": MessageLookupByLibrary.simpleMessage("RPC"),
     "ruleChain": MessageLookupByLibrary.simpleMessage("Regelketen"),
     "ruleNode": MessageLookupByLibrary.simpleMessage("Regelknooppunt"),
@@ -720,7 +724,7 @@ class MessageLookup extends MessageLookupByLibrary {
     "schedulerEvent": MessageLookupByLibrary.simpleMessage("Planner-evenement"),
     "search": MessageLookupByLibrary.simpleMessage("Zoeken"),
     "searchResults": MessageLookupByLibrary.simpleMessage("Zoekresultaten"),
-    "searchUsers": m21,
+    "searchUsers": m22,
     "seconds": MessageLookupByLibrary.simpleMessage("seconden"),
     "security": MessageLookupByLibrary.simpleMessage("Beveiliging"),
     "selectAll": MessageLookupByLibrary.simpleMessage("Alles selecteren"),
@@ -747,7 +751,7 @@ class MessageLookup extends MessageLookupByLibrary {
     "severity": MessageLookupByLibrary.simpleMessage("Ernst"),
     "signIn": MessageLookupByLibrary.simpleMessage("Inloggen"),
     "signUp": MessageLookupByLibrary.simpleMessage("Registreren"),
-    "smsAuthDescription": m22,
+    "smsAuthDescription": m23,
     "smsAuthPlaceholder": MessageLookupByLibrary.simpleMessage("SMS-code"),
     "smsSetupSuccessDescription": MessageLookupByLibrary.simpleMessage(
       "De volgende keer dat u inlogt, wordt u gevraagd de beveiligingscode in te voeren die naar uw telefoonnummer wordt gestuurd",
@@ -813,7 +817,7 @@ class MessageLookup extends MessageLookupByLibrary {
     "unableConnectToDevice": MessageLookupByLibrary.simpleMessage(
       "Kan niet verbinden met apparaat",
     ),
-    "unableConnectToWifiBecauseNetworksWasntFoundByDevice": m23,
+    "unableConnectToWifiBecauseNetworksWasntFoundByDevice": m24,
     "unableToUseCamera": MessageLookupByLibrary.simpleMessage(
       "Kan camera niet gebruiken",
     ),
@@ -827,7 +831,7 @@ class MessageLookup extends MessageLookupByLibrary {
     ),
     "update": MessageLookupByLibrary.simpleMessage("Bijwerken"),
     "updateRequired": MessageLookupByLibrary.simpleMessage("Update vereist"),
-    "updateTo": m24,
+    "updateTo": m25,
     "url": MessageLookupByLibrary.simpleMessage("URL"),
     "user": MessageLookupByLibrary.simpleMessage("Gebruiker"),
     "username": MessageLookupByLibrary.simpleMessage("gebruikersnaam"),
@@ -852,9 +856,9 @@ class MessageLookup extends MessageLookupByLibrary {
     "warning": MessageLookupByLibrary.simpleMessage("Waarschuwing"),
     "widgetType": MessageLookupByLibrary.simpleMessage("Widgettype"),
     "widgetsBundle": MessageLookupByLibrary.simpleMessage("Widgetpakket"),
-    "wifiHelpMessage": m25,
+    "wifiHelpMessage": m26,
     "wifiPassword": MessageLookupByLibrary.simpleMessage("Wi-Fi-wachtwoord"),
-    "wifiPasswordMessage": m26,
+    "wifiPasswordMessage": m27,
     "yes": MessageLookupByLibrary.simpleMessage("Ja"),
     "yesDeactivate": MessageLookupByLibrary.simpleMessage("Ja, deactiveren"),
     "yesDiscard": MessageLookupByLibrary.simpleMessage("Ja, verwerpen"),

--- a/lib/generated/intl/messages_nl_NL.dart
+++ b/lib/generated/intl/messages_nl_NL.dart
@@ -735,7 +735,9 @@ class MessageLookup extends MessageLookupByLibrary {
     "searchUsers": m24,
     "seconds": MessageLookupByLibrary.simpleMessage("seconden"),
     "security": MessageLookupByLibrary.simpleMessage("Beveiliging"),
-    "selectAll": MessageLookupByLibrary.simpleMessage("Alles selecteren"),
+    "selectAll": MessageLookupByLibrary.simpleMessage(
+      "Alle geladen selecteren",
+    ),
     "selectCountry": MessageLookupByLibrary.simpleMessage("Land selecteren"),
     "selectRegion": MessageLookupByLibrary.simpleMessage("Selecteer regio"),
     "selectUser": MessageLookupByLibrary.simpleMessage("Gebruikers selecteren"),

--- a/lib/generated/intl/messages_nl_NL.dart
+++ b/lib/generated/intl/messages_nl_NL.dart
@@ -59,38 +59,40 @@ class MessageLookup extends MessageLookupByLibrary {
 
   static String m13(error) => "Fout bij het verzenden van de code: ${error}";
 
-  static String m14(count) =>
+  static String m14(count) => "${count} geselecteerd";
+
+  static String m15(count) =>
       "${Intl.plural(count, one: 'Melding', other: 'Meldingen')}";
 
-  static String m15(permissions) =>
+  static String m16(permissions) =>
       "U heeft onvoldoende rechten voor \"${permissions}\" om door te gaan. Open de app-instellingen, verleen de rechten en tik op \"Opnieuw proberen\".";
 
-  static String m16(permissions) =>
+  static String m17(permissions) =>
       "U heeft onvoldoende rechten voor \"${permissions}\" om door te gaan. Verleen de vereiste rechten en tik op \"Opnieuw proberen\".";
 
-  static String m17(deviceName) =>
+  static String m18(deviceName) =>
       "Voer de pincode van ${deviceName} in om eigendomsbewijs te bevestigen";
 
-  static String m18(time) =>
+  static String m19(time) =>
       "Code opnieuw verzenden in ${Intl.plural(time, one: '1 seconde', other: '${time} seconden')}";
 
-  static String m19(name) => "Route niet gedefinieerd: ${name}";
+  static String m20(name) => "Route niet gedefinieerd: ${name}";
 
-  static String m20(count) =>
+  static String m21(count) =>
       "${Intl.plural(count, one: 'Gebruiker zoeken', other: 'Gebruikers zoeken')}";
 
-  static String m21(contact) =>
+  static String m22(contact) =>
       "Er is een beveiligingscode verzonden naar uw telefoon op ${contact}.";
 
-  static String m22(name) =>
+  static String m23(name) =>
       "Kan niet verbinden met Wi-Fi omdat het apparaat ${name} geen netwerken heeft gevonden";
 
-  static String m23(version) => "Updaten naar ${version}";
+  static String m24(version) => "Updaten naar ${version}";
 
-  static String m24(deviceName) =>
+  static String m25(deviceName) =>
       "Om de installatie van uw apparaat ${deviceName} voort te zetten, geef de netwerkgegevens op.";
 
-  static String m25(network) => "Voer het wachtwoord in voor ${network}";
+  static String m26(network) => "Voer het wachtwoord in voor ${network}";
 
   final messages = _notInlinedMessages(_notInlinedMessages);
   static Map<String, Function> _notInlinedMessages(_) => <String, Function>{
@@ -556,6 +558,7 @@ class MessageLookup extends MessageLookupByLibrary {
           "Het mobiele dashboard moet worden geconfigureerd in het apparaatprofiel!",
         ),
     "more": MessageLookupByLibrary.simpleMessage("Meer"),
+    "nSelected": m14,
     "newPassword": MessageLookupByLibrary.simpleMessage("Nieuw wachtwoord"),
     "newPassword2": MessageLookupByLibrary.simpleMessage(
       "Bevestig nieuw wachtwoord",
@@ -600,12 +603,12 @@ class MessageLookup extends MessageLookupByLibrary {
     "notificationTemplate": MessageLookupByLibrary.simpleMessage(
       "Meldingssjabloon",
     ),
-    "notifications": m14,
+    "notifications": m15,
     "oauth2Client": MessageLookupByLibrary.simpleMessage("OAuth2-client"),
     "openAppSettings": MessageLookupByLibrary.simpleMessage(
       "App-instellingen openen",
     ),
-    "openAppSettingsToGrantPermissionMessage": m15,
+    "openAppSettingsToGrantPermissionMessage": m16,
     "openSettingsAndGrantAccessToCameraToContinue":
         MessageLookupByLibrary.simpleMessage(
           "Open instellingen en geef cameratoegang om door te gaan",
@@ -640,7 +643,7 @@ class MessageLookup extends MessageLookupByLibrary {
       "Wachtwoord succesvol gewijzigd",
     ),
     "permissions": MessageLookupByLibrary.simpleMessage("Rechten"),
-    "permissionsNotEnoughMessage": m16,
+    "permissionsNotEnoughMessage": m17,
     "phone": MessageLookupByLibrary.simpleMessage("Telefoon"),
     "phoneIsInvalid": MessageLookupByLibrary.simpleMessage(
       "Telefoonnummer is ongeldig",
@@ -667,7 +670,7 @@ class MessageLookup extends MessageLookupByLibrary {
       "Scan de QR-code op uw apparaat",
     ),
     "plusAlarmType": MessageLookupByLibrary.simpleMessage("+ Alarmtype"),
-    "popTitle": m17,
+    "popTitle": m18,
     "postalCode": MessageLookupByLibrary.simpleMessage("Postcode"),
     "privacyPolicy": MessageLookupByLibrary.simpleMessage("Privacybeleid"),
     "profile": MessageLookupByLibrary.simpleMessage("Profiel"),
@@ -698,7 +701,7 @@ class MessageLookup extends MessageLookupByLibrary {
     "resendCode": MessageLookupByLibrary.simpleMessage(
       "Code opnieuw verzenden",
     ),
-    "resendCodeWait": m18,
+    "resendCodeWait": m19,
     "reset": MessageLookupByLibrary.simpleMessage("Herstellen"),
     "retry": MessageLookupByLibrary.simpleMessage("Opnieuw proberen"),
     "returnToDashboard": MessageLookupByLibrary.simpleMessage(
@@ -708,7 +711,7 @@ class MessageLookup extends MessageLookupByLibrary {
       "Ga terug naar de app en tik op de knop Gereed",
     ),
     "role": MessageLookupByLibrary.simpleMessage("Rol"),
-    "routeNotDefined": m19,
+    "routeNotDefined": m20,
     "rpc": MessageLookupByLibrary.simpleMessage("RPC"),
     "ruleChain": MessageLookupByLibrary.simpleMessage("Regelketen"),
     "ruleNode": MessageLookupByLibrary.simpleMessage("Regelknooppunt"),
@@ -717,9 +720,10 @@ class MessageLookup extends MessageLookupByLibrary {
     "schedulerEvent": MessageLookupByLibrary.simpleMessage("Planner-evenement"),
     "search": MessageLookupByLibrary.simpleMessage("Zoeken"),
     "searchResults": MessageLookupByLibrary.simpleMessage("Zoekresultaten"),
-    "searchUsers": m20,
+    "searchUsers": m21,
     "seconds": MessageLookupByLibrary.simpleMessage("seconden"),
     "security": MessageLookupByLibrary.simpleMessage("Beveiliging"),
+    "selectAll": MessageLookupByLibrary.simpleMessage("Alles selecteren"),
     "selectCountry": MessageLookupByLibrary.simpleMessage("Land selecteren"),
     "selectRegion": MessageLookupByLibrary.simpleMessage("Selecteer regio"),
     "selectUser": MessageLookupByLibrary.simpleMessage("Gebruikers selecteren"),
@@ -743,7 +747,7 @@ class MessageLookup extends MessageLookupByLibrary {
     "severity": MessageLookupByLibrary.simpleMessage("Ernst"),
     "signIn": MessageLookupByLibrary.simpleMessage("Inloggen"),
     "signUp": MessageLookupByLibrary.simpleMessage("Registreren"),
-    "smsAuthDescription": m21,
+    "smsAuthDescription": m22,
     "smsAuthPlaceholder": MessageLookupByLibrary.simpleMessage("SMS-code"),
     "smsSetupSuccessDescription": MessageLookupByLibrary.simpleMessage(
       "De volgende keer dat u inlogt, wordt u gevraagd de beveiligingscode in te voeren die naar uw telefoonnummer wordt gestuurd",
@@ -809,7 +813,7 @@ class MessageLookup extends MessageLookupByLibrary {
     "unableConnectToDevice": MessageLookupByLibrary.simpleMessage(
       "Kan niet verbinden met apparaat",
     ),
-    "unableConnectToWifiBecauseNetworksWasntFoundByDevice": m22,
+    "unableConnectToWifiBecauseNetworksWasntFoundByDevice": m23,
     "unableToUseCamera": MessageLookupByLibrary.simpleMessage(
       "Kan camera niet gebruiken",
     ),
@@ -823,7 +827,7 @@ class MessageLookup extends MessageLookupByLibrary {
     ),
     "update": MessageLookupByLibrary.simpleMessage("Bijwerken"),
     "updateRequired": MessageLookupByLibrary.simpleMessage("Update vereist"),
-    "updateTo": m23,
+    "updateTo": m24,
     "url": MessageLookupByLibrary.simpleMessage("URL"),
     "user": MessageLookupByLibrary.simpleMessage("Gebruiker"),
     "username": MessageLookupByLibrary.simpleMessage("gebruikersnaam"),
@@ -848,9 +852,9 @@ class MessageLookup extends MessageLookupByLibrary {
     "warning": MessageLookupByLibrary.simpleMessage("Waarschuwing"),
     "widgetType": MessageLookupByLibrary.simpleMessage("Widgettype"),
     "widgetsBundle": MessageLookupByLibrary.simpleMessage("Widgetpakket"),
-    "wifiHelpMessage": m24,
+    "wifiHelpMessage": m25,
     "wifiPassword": MessageLookupByLibrary.simpleMessage("Wi-Fi-wachtwoord"),
-    "wifiPasswordMessage": m25,
+    "wifiPasswordMessage": m26,
     "yes": MessageLookupByLibrary.simpleMessage("Ja"),
     "yesDeactivate": MessageLookupByLibrary.simpleMessage("Ja, deactiveren"),
     "yesDiscard": MessageLookupByLibrary.simpleMessage("Ja, verwerpen"),

--- a/lib/generated/intl/messages_no_NO.dart
+++ b/lib/generated/intl/messages_no_NO.dart
@@ -716,7 +716,7 @@ class MessageLookup extends MessageLookupByLibrary {
     "searchUsers": m24,
     "seconds": MessageLookupByLibrary.simpleMessage("sekunder"),
     "security": MessageLookupByLibrary.simpleMessage("Sikkerhet"),
-    "selectAll": MessageLookupByLibrary.simpleMessage("Velg alle"),
+    "selectAll": MessageLookupByLibrary.simpleMessage("Velg alle lastede"),
     "selectCountry": MessageLookupByLibrary.simpleMessage("Velg land"),
     "selectRegion": MessageLookupByLibrary.simpleMessage("Velg region"),
     "selectUser": MessageLookupByLibrary.simpleMessage("Velg brukere"),

--- a/lib/generated/intl/messages_no_NO.dart
+++ b/lib/generated/intl/messages_no_NO.dart
@@ -46,55 +46,61 @@ class MessageLookup extends MessageLookupByLibrary {
       "${Intl.plural(count, one: 'Dashbord', other: 'Dashbord')}";
 
   static String m9(count) =>
-      "${Intl.plural(count, one: 'Enhet', other: 'Enheter')}";
+      "${Intl.plural(count, one: 'Slette 1 varsling?', other: 'Slette ${count} varslinger?')}";
 
   static String m10(count) =>
+      "${Intl.plural(count, one: 'Enhet', other: 'Enheter')}";
+
+  static String m11(count) =>
       "${count}-${Intl.plural(count, one: 'sifret', other: 'sifret')} kode";
 
-  static String m11(contact) =>
+  static String m12(contact) =>
       "En sikkerhetskode har blitt sendt til e-postadressen din på ${contact}.";
 
-  static String m12(e) => "Feil oppstod: ${e}";
+  static String m13(e) => "Feil oppstod: ${e}";
 
-  static String m13(error) => "Feil ved sending av kode: ${error}";
+  static String m14(error) => "Feil ved sending av kode: ${error}";
 
-  static String m14(count) =>
+  static String m15(count) =>
       "${Intl.plural(count, one: '1 handling mislyktes', other: '${count} handlinger mislyktes')}";
 
-  static String m15(count) => "${count} valgt";
-
   static String m16(count) =>
+      "${Intl.plural(count, one: 'Markere 1 varsling som lest?', other: 'Markere ${count} varslinger som lest?')}";
+
+  static String m17(count) => "${count} valgt";
+
+  static String m18(count) =>
       "${Intl.plural(count, one: 'Varsel', other: 'Varsler')}";
 
-  static String m17(permissions) =>
+  static String m19(permissions) =>
       "Du har ikke tilstrekkelige tillatelser for \"${permissions}\" til å fortsette. Åpne appinnstillingene, gi nødvendige tillatelser og trykk \"Prøv igjen\".";
 
-  static String m18(permissions) =>
+  static String m20(permissions) =>
       "Du har ikke tilstrekkelige tillatelser for \"${permissions}\" til å fortsette. Gi nødvendige tillatelser og trykk \"Prøv igjen\".";
 
-  static String m19(deviceName) =>
+  static String m21(deviceName) =>
       "Skriv inn PIN for ${deviceName} for å bekrefte eierskapsbevis";
 
-  static String m20(time) =>
+  static String m22(time) =>
       "Send koden på nytt om ${Intl.plural(time, one: '1 sekund', other: '${time} sekunder')}";
 
-  static String m21(name) => "Rute ikke definert: ${name}";
+  static String m23(name) => "Rute ikke definert: ${name}";
 
-  static String m22(count) =>
+  static String m24(count) =>
       "${Intl.plural(count, one: 'Søk bruker', other: 'Søk brukere')}";
 
-  static String m23(contact) =>
+  static String m25(contact) =>
       "En sikkerhetskode har blitt sendt til telefonen din på ${contact}.";
 
-  static String m24(name) =>
+  static String m26(name) =>
       "Kan ikke koble til Wi-Fi fordi enheten ${name} ikke fant nettverk";
 
-  static String m25(version) => "Oppdater til ${version}";
+  static String m27(version) => "Oppdater til ${version}";
 
-  static String m26(deviceName) =>
+  static String m28(deviceName) =>
       "For å fortsette oppsettet av enheten din ${deviceName}, vennligst oppgi nettverksinformasjonen din.";
 
-  static String m27(network) => "Skriv inn passordet for ${network}";
+  static String m29(network) => "Skriv inn passordet for ${network}";
 
   final messages = _notInlinedMessages(_notInlinedMessages);
   static Map<String, Function> _notInlinedMessages(_) => <String, Function>{
@@ -372,6 +378,7 @@ class MessageLookup extends MessageLookupByLibrary {
     "delete": MessageLookupByLibrary.simpleMessage("Slett"),
     "deleteAccount": MessageLookupByLibrary.simpleMessage("Slett konto"),
     "deleteComment": MessageLookupByLibrary.simpleMessage("Slett kommentar"),
+    "deleteSelectedNotifications": m9,
     "details": MessageLookupByLibrary.simpleMessage("Detaljer"),
     "deviceList": MessageLookupByLibrary.simpleMessage("Enhetsliste"),
     "deviceNotAbleToFindWifiNearby": MessageLookupByLibrary.simpleMessage(
@@ -384,8 +391,8 @@ class MessageLookup extends MessageLookupByLibrary {
     "deviceProvisioning": MessageLookupByLibrary.simpleMessage(
       "Enhetsklargjøring",
     ),
-    "devices": m9,
-    "digitsCode": m10,
+    "devices": m10,
+    "digitsCode": m11,
     "discardChanges": MessageLookupByLibrary.simpleMessage("Forkast endringer"),
     "domain": MessageLookupByLibrary.simpleMessage("Domene"),
     "done": MessageLookupByLibrary.simpleMessage("Ferdig"),
@@ -394,7 +401,7 @@ class MessageLookup extends MessageLookupByLibrary {
     "edit": MessageLookupByLibrary.simpleMessage("Rediger"),
     "edited": MessageLookupByLibrary.simpleMessage("Redigert"),
     "email": MessageLookupByLibrary.simpleMessage("E-post"),
-    "emailAuthDescription": m11,
+    "emailAuthDescription": m12,
     "emailAuthPlaceholder": MessageLookupByLibrary.simpleMessage("E-postkode"),
     "emailInvalidText": MessageLookupByLibrary.simpleMessage(
       "Ugyldig e-postformat.",
@@ -433,8 +440,8 @@ class MessageLookup extends MessageLookupByLibrary {
     "entityGroup": MessageLookupByLibrary.simpleMessage("Entitetsgruppe"),
     "entityType": MessageLookupByLibrary.simpleMessage("Enhetstype"),
     "entityView": MessageLookupByLibrary.simpleMessage("Enhetsvisning"),
-    "errorOccured": m12,
-    "errorSendingCode": m13,
+    "errorOccured": m13,
+    "errorSendingCode": m14,
     "europe": MessageLookupByLibrary.simpleMessage("Europa"),
     "europeRegionShort": MessageLookupByLibrary.simpleMessage("Frankfurt"),
     "exitDeviceProvisioning": MessageLookupByLibrary.simpleMessage(
@@ -449,7 +456,7 @@ class MessageLookup extends MessageLookupByLibrary {
     "failedToLoadTheList": MessageLookupByLibrary.simpleMessage(
       "Kunne ikke laste listen",
     ),
-    "failedToPerformOperation": m14,
+    "failedToPerformOperation": m15,
     "failedToSaveImage": MessageLookupByLibrary.simpleMessage(
       "Kunne ikke lagre bildet",
     ),
@@ -523,6 +530,7 @@ class MessageLookup extends MessageLookupByLibrary {
     "major": MessageLookupByLibrary.simpleMessage("Alvorlig"),
     "markAllAsRead": MessageLookupByLibrary.simpleMessage("Merk alle som lest"),
     "markAsRead": MessageLookupByLibrary.simpleMessage("Merk som lest"),
+    "markSelectedNotificationsAsRead": m16,
     "metricUnitSystem": MessageLookupByLibrary.simpleMessage("Metrisk"),
     "mfaProviderBackupCode": MessageLookupByLibrary.simpleMessage(
       "Reservekode",
@@ -541,7 +549,7 @@ class MessageLookup extends MessageLookupByLibrary {
           "Mobilt dashbord må konfigureres i enhetsprofilen!",
         ),
     "more": MessageLookupByLibrary.simpleMessage("Mer"),
-    "nSelected": m15,
+    "nSelected": m17,
     "newPassword": MessageLookupByLibrary.simpleMessage("Nytt passord"),
     "newPassword2": MessageLookupByLibrary.simpleMessage(
       "Bekreft nytt passord",
@@ -586,12 +594,12 @@ class MessageLookup extends MessageLookupByLibrary {
     "notificationTemplate": MessageLookupByLibrary.simpleMessage(
       "Varslingsmal",
     ),
-    "notifications": m16,
+    "notifications": m18,
     "oauth2Client": MessageLookupByLibrary.simpleMessage("OAuth2-klient"),
     "openAppSettings": MessageLookupByLibrary.simpleMessage(
       "Åpne appinnstillinger",
     ),
-    "openAppSettingsToGrantPermissionMessage": m17,
+    "openAppSettingsToGrantPermissionMessage": m19,
     "openSettingsAndGrantAccessToCameraToContinue":
         MessageLookupByLibrary.simpleMessage(
           "Åpne innstillinger og gi tilgang til kameraet for å fortsette",
@@ -626,7 +634,7 @@ class MessageLookup extends MessageLookupByLibrary {
       "Passordet ble endret",
     ),
     "permissions": MessageLookupByLibrary.simpleMessage("Tillatelser"),
-    "permissionsNotEnoughMessage": m18,
+    "permissionsNotEnoughMessage": m20,
     "phone": MessageLookupByLibrary.simpleMessage("Telefon"),
     "phoneIsInvalid": MessageLookupByLibrary.simpleMessage(
       "Telefonnummer er ugyldig",
@@ -653,7 +661,7 @@ class MessageLookup extends MessageLookupByLibrary {
       "Skann QR-koden på enheten din",
     ),
     "plusAlarmType": MessageLookupByLibrary.simpleMessage("+ Alarmtype"),
-    "popTitle": m19,
+    "popTitle": m21,
     "postalCode": MessageLookupByLibrary.simpleMessage("Postnummer"),
     "privacyPolicy": MessageLookupByLibrary.simpleMessage(
       "Personvernerklæring",
@@ -684,7 +692,7 @@ class MessageLookup extends MessageLookupByLibrary {
     ),
     "resend": MessageLookupByLibrary.simpleMessage("Send på nytt"),
     "resendCode": MessageLookupByLibrary.simpleMessage("Send koden på nytt"),
-    "resendCodeWait": m20,
+    "resendCodeWait": m22,
     "reset": MessageLookupByLibrary.simpleMessage("Tilbakestill"),
     "retry": MessageLookupByLibrary.simpleMessage("Prøv igjen"),
     "returnToDashboard": MessageLookupByLibrary.simpleMessage(
@@ -694,7 +702,7 @@ class MessageLookup extends MessageLookupByLibrary {
       "Gå tilbake til appen og trykk Klar-knappen",
     ),
     "role": MessageLookupByLibrary.simpleMessage("Rolle"),
-    "routeNotDefined": m21,
+    "routeNotDefined": m23,
     "rpc": MessageLookupByLibrary.simpleMessage("RPC"),
     "ruleChain": MessageLookupByLibrary.simpleMessage("Regelkjede"),
     "ruleNode": MessageLookupByLibrary.simpleMessage("Regelnode"),
@@ -705,7 +713,7 @@ class MessageLookup extends MessageLookupByLibrary {
     ),
     "search": MessageLookupByLibrary.simpleMessage("Søk"),
     "searchResults": MessageLookupByLibrary.simpleMessage("Søkeresultater"),
-    "searchUsers": m22,
+    "searchUsers": m24,
     "seconds": MessageLookupByLibrary.simpleMessage("sekunder"),
     "security": MessageLookupByLibrary.simpleMessage("Sikkerhet"),
     "selectAll": MessageLookupByLibrary.simpleMessage("Velg alle"),
@@ -732,7 +740,7 @@ class MessageLookup extends MessageLookupByLibrary {
     "severity": MessageLookupByLibrary.simpleMessage("Alvorlighetsgrad"),
     "signIn": MessageLookupByLibrary.simpleMessage("Logg inn"),
     "signUp": MessageLookupByLibrary.simpleMessage("Registrer deg"),
-    "smsAuthDescription": m23,
+    "smsAuthDescription": m25,
     "smsAuthPlaceholder": MessageLookupByLibrary.simpleMessage("SMS-kode"),
     "smsSetupSuccessDescription": MessageLookupByLibrary.simpleMessage(
       "Neste gang du logger inn, vil du bli bedt om å taste inn sikkerhetskoden som sendes til telefonnummeret",
@@ -790,7 +798,7 @@ class MessageLookup extends MessageLookupByLibrary {
     "unableConnectToDevice": MessageLookupByLibrary.simpleMessage(
       "Kan ikke koble til enhet",
     ),
-    "unableConnectToWifiBecauseNetworksWasntFoundByDevice": m24,
+    "unableConnectToWifiBecauseNetworksWasntFoundByDevice": m26,
     "unableToUseCamera": MessageLookupByLibrary.simpleMessage(
       "Kan ikke bruke kameraet",
     ),
@@ -806,7 +814,7 @@ class MessageLookup extends MessageLookupByLibrary {
     "updateRequired": MessageLookupByLibrary.simpleMessage(
       "Oppdatering kreves",
     ),
-    "updateTo": m25,
+    "updateTo": m27,
     "url": MessageLookupByLibrary.simpleMessage("URL"),
     "user": MessageLookupByLibrary.simpleMessage("Bruker"),
     "username": MessageLookupByLibrary.simpleMessage("brukernavn"),
@@ -831,9 +839,9 @@ class MessageLookup extends MessageLookupByLibrary {
     "warning": MessageLookupByLibrary.simpleMessage("Advarsel"),
     "widgetType": MessageLookupByLibrary.simpleMessage("Widgettype"),
     "widgetsBundle": MessageLookupByLibrary.simpleMessage("Widgetpakke"),
-    "wifiHelpMessage": m26,
+    "wifiHelpMessage": m28,
     "wifiPassword": MessageLookupByLibrary.simpleMessage("Wi-Fi-passord"),
-    "wifiPasswordMessage": m27,
+    "wifiPasswordMessage": m29,
     "yes": MessageLookupByLibrary.simpleMessage("Ja"),
     "yesDeactivate": MessageLookupByLibrary.simpleMessage("Ja, deaktiver"),
     "yesDiscard": MessageLookupByLibrary.simpleMessage("Ja, forkast"),

--- a/lib/generated/intl/messages_no_NO.dart
+++ b/lib/generated/intl/messages_no_NO.dart
@@ -58,40 +58,43 @@ class MessageLookup extends MessageLookupByLibrary {
 
   static String m13(error) => "Feil ved sending av kode: ${error}";
 
-  static String m14(count) => "${count} valgt";
+  static String m14(count) =>
+      "${Intl.plural(count, one: '1 handling mislyktes', other: '${count} handlinger mislyktes')}";
 
-  static String m15(count) =>
+  static String m15(count) => "${count} valgt";
+
+  static String m16(count) =>
       "${Intl.plural(count, one: 'Varsel', other: 'Varsler')}";
 
-  static String m16(permissions) =>
+  static String m17(permissions) =>
       "Du har ikke tilstrekkelige tillatelser for \"${permissions}\" til å fortsette. Åpne appinnstillingene, gi nødvendige tillatelser og trykk \"Prøv igjen\".";
 
-  static String m17(permissions) =>
+  static String m18(permissions) =>
       "Du har ikke tilstrekkelige tillatelser for \"${permissions}\" til å fortsette. Gi nødvendige tillatelser og trykk \"Prøv igjen\".";
 
-  static String m18(deviceName) =>
+  static String m19(deviceName) =>
       "Skriv inn PIN for ${deviceName} for å bekrefte eierskapsbevis";
 
-  static String m19(time) =>
+  static String m20(time) =>
       "Send koden på nytt om ${Intl.plural(time, one: '1 sekund', other: '${time} sekunder')}";
 
-  static String m20(name) => "Rute ikke definert: ${name}";
+  static String m21(name) => "Rute ikke definert: ${name}";
 
-  static String m21(count) =>
+  static String m22(count) =>
       "${Intl.plural(count, one: 'Søk bruker', other: 'Søk brukere')}";
 
-  static String m22(contact) =>
+  static String m23(contact) =>
       "En sikkerhetskode har blitt sendt til telefonen din på ${contact}.";
 
-  static String m23(name) =>
+  static String m24(name) =>
       "Kan ikke koble til Wi-Fi fordi enheten ${name} ikke fant nettverk";
 
-  static String m24(version) => "Oppdater til ${version}";
+  static String m25(version) => "Oppdater til ${version}";
 
-  static String m25(deviceName) =>
+  static String m26(deviceName) =>
       "For å fortsette oppsettet av enheten din ${deviceName}, vennligst oppgi nettverksinformasjonen din.";
 
-  static String m26(network) => "Skriv inn passordet for ${network}";
+  static String m27(network) => "Skriv inn passordet for ${network}";
 
   final messages = _notInlinedMessages(_notInlinedMessages);
   static Map<String, Function> _notInlinedMessages(_) => <String, Function>{
@@ -446,6 +449,7 @@ class MessageLookup extends MessageLookupByLibrary {
     "failedToLoadTheList": MessageLookupByLibrary.simpleMessage(
       "Kunne ikke laste listen",
     ),
+    "failedToPerformOperation": m14,
     "failedToSaveImage": MessageLookupByLibrary.simpleMessage(
       "Kunne ikke lagre bildet",
     ),
@@ -537,7 +541,7 @@ class MessageLookup extends MessageLookupByLibrary {
           "Mobilt dashbord må konfigureres i enhetsprofilen!",
         ),
     "more": MessageLookupByLibrary.simpleMessage("Mer"),
-    "nSelected": m14,
+    "nSelected": m15,
     "newPassword": MessageLookupByLibrary.simpleMessage("Nytt passord"),
     "newPassword2": MessageLookupByLibrary.simpleMessage(
       "Bekreft nytt passord",
@@ -582,12 +586,12 @@ class MessageLookup extends MessageLookupByLibrary {
     "notificationTemplate": MessageLookupByLibrary.simpleMessage(
       "Varslingsmal",
     ),
-    "notifications": m15,
+    "notifications": m16,
     "oauth2Client": MessageLookupByLibrary.simpleMessage("OAuth2-klient"),
     "openAppSettings": MessageLookupByLibrary.simpleMessage(
       "Åpne appinnstillinger",
     ),
-    "openAppSettingsToGrantPermissionMessage": m16,
+    "openAppSettingsToGrantPermissionMessage": m17,
     "openSettingsAndGrantAccessToCameraToContinue":
         MessageLookupByLibrary.simpleMessage(
           "Åpne innstillinger og gi tilgang til kameraet for å fortsette",
@@ -622,7 +626,7 @@ class MessageLookup extends MessageLookupByLibrary {
       "Passordet ble endret",
     ),
     "permissions": MessageLookupByLibrary.simpleMessage("Tillatelser"),
-    "permissionsNotEnoughMessage": m17,
+    "permissionsNotEnoughMessage": m18,
     "phone": MessageLookupByLibrary.simpleMessage("Telefon"),
     "phoneIsInvalid": MessageLookupByLibrary.simpleMessage(
       "Telefonnummer er ugyldig",
@@ -649,7 +653,7 @@ class MessageLookup extends MessageLookupByLibrary {
       "Skann QR-koden på enheten din",
     ),
     "plusAlarmType": MessageLookupByLibrary.simpleMessage("+ Alarmtype"),
-    "popTitle": m18,
+    "popTitle": m19,
     "postalCode": MessageLookupByLibrary.simpleMessage("Postnummer"),
     "privacyPolicy": MessageLookupByLibrary.simpleMessage(
       "Personvernerklæring",
@@ -680,7 +684,7 @@ class MessageLookup extends MessageLookupByLibrary {
     ),
     "resend": MessageLookupByLibrary.simpleMessage("Send på nytt"),
     "resendCode": MessageLookupByLibrary.simpleMessage("Send koden på nytt"),
-    "resendCodeWait": m19,
+    "resendCodeWait": m20,
     "reset": MessageLookupByLibrary.simpleMessage("Tilbakestill"),
     "retry": MessageLookupByLibrary.simpleMessage("Prøv igjen"),
     "returnToDashboard": MessageLookupByLibrary.simpleMessage(
@@ -690,7 +694,7 @@ class MessageLookup extends MessageLookupByLibrary {
       "Gå tilbake til appen og trykk Klar-knappen",
     ),
     "role": MessageLookupByLibrary.simpleMessage("Rolle"),
-    "routeNotDefined": m20,
+    "routeNotDefined": m21,
     "rpc": MessageLookupByLibrary.simpleMessage("RPC"),
     "ruleChain": MessageLookupByLibrary.simpleMessage("Regelkjede"),
     "ruleNode": MessageLookupByLibrary.simpleMessage("Regelnode"),
@@ -701,7 +705,7 @@ class MessageLookup extends MessageLookupByLibrary {
     ),
     "search": MessageLookupByLibrary.simpleMessage("Søk"),
     "searchResults": MessageLookupByLibrary.simpleMessage("Søkeresultater"),
-    "searchUsers": m21,
+    "searchUsers": m22,
     "seconds": MessageLookupByLibrary.simpleMessage("sekunder"),
     "security": MessageLookupByLibrary.simpleMessage("Sikkerhet"),
     "selectAll": MessageLookupByLibrary.simpleMessage("Velg alle"),
@@ -728,7 +732,7 @@ class MessageLookup extends MessageLookupByLibrary {
     "severity": MessageLookupByLibrary.simpleMessage("Alvorlighetsgrad"),
     "signIn": MessageLookupByLibrary.simpleMessage("Logg inn"),
     "signUp": MessageLookupByLibrary.simpleMessage("Registrer deg"),
-    "smsAuthDescription": m22,
+    "smsAuthDescription": m23,
     "smsAuthPlaceholder": MessageLookupByLibrary.simpleMessage("SMS-kode"),
     "smsSetupSuccessDescription": MessageLookupByLibrary.simpleMessage(
       "Neste gang du logger inn, vil du bli bedt om å taste inn sikkerhetskoden som sendes til telefonnummeret",
@@ -786,7 +790,7 @@ class MessageLookup extends MessageLookupByLibrary {
     "unableConnectToDevice": MessageLookupByLibrary.simpleMessage(
       "Kan ikke koble til enhet",
     ),
-    "unableConnectToWifiBecauseNetworksWasntFoundByDevice": m23,
+    "unableConnectToWifiBecauseNetworksWasntFoundByDevice": m24,
     "unableToUseCamera": MessageLookupByLibrary.simpleMessage(
       "Kan ikke bruke kameraet",
     ),
@@ -802,7 +806,7 @@ class MessageLookup extends MessageLookupByLibrary {
     "updateRequired": MessageLookupByLibrary.simpleMessage(
       "Oppdatering kreves",
     ),
-    "updateTo": m24,
+    "updateTo": m25,
     "url": MessageLookupByLibrary.simpleMessage("URL"),
     "user": MessageLookupByLibrary.simpleMessage("Bruker"),
     "username": MessageLookupByLibrary.simpleMessage("brukernavn"),
@@ -827,9 +831,9 @@ class MessageLookup extends MessageLookupByLibrary {
     "warning": MessageLookupByLibrary.simpleMessage("Advarsel"),
     "widgetType": MessageLookupByLibrary.simpleMessage("Widgettype"),
     "widgetsBundle": MessageLookupByLibrary.simpleMessage("Widgetpakke"),
-    "wifiHelpMessage": m25,
+    "wifiHelpMessage": m26,
     "wifiPassword": MessageLookupByLibrary.simpleMessage("Wi-Fi-passord"),
-    "wifiPasswordMessage": m26,
+    "wifiPasswordMessage": m27,
     "yes": MessageLookupByLibrary.simpleMessage("Ja"),
     "yesDeactivate": MessageLookupByLibrary.simpleMessage("Ja, deaktiver"),
     "yesDiscard": MessageLookupByLibrary.simpleMessage("Ja, forkast"),

--- a/lib/generated/intl/messages_no_NO.dart
+++ b/lib/generated/intl/messages_no_NO.dart
@@ -58,38 +58,40 @@ class MessageLookup extends MessageLookupByLibrary {
 
   static String m13(error) => "Feil ved sending av kode: ${error}";
 
-  static String m14(count) =>
+  static String m14(count) => "${count} valgt";
+
+  static String m15(count) =>
       "${Intl.plural(count, one: 'Varsel', other: 'Varsler')}";
 
-  static String m15(permissions) =>
+  static String m16(permissions) =>
       "Du har ikke tilstrekkelige tillatelser for \"${permissions}\" til å fortsette. Åpne appinnstillingene, gi nødvendige tillatelser og trykk \"Prøv igjen\".";
 
-  static String m16(permissions) =>
+  static String m17(permissions) =>
       "Du har ikke tilstrekkelige tillatelser for \"${permissions}\" til å fortsette. Gi nødvendige tillatelser og trykk \"Prøv igjen\".";
 
-  static String m17(deviceName) =>
+  static String m18(deviceName) =>
       "Skriv inn PIN for ${deviceName} for å bekrefte eierskapsbevis";
 
-  static String m18(time) =>
+  static String m19(time) =>
       "Send koden på nytt om ${Intl.plural(time, one: '1 sekund', other: '${time} sekunder')}";
 
-  static String m19(name) => "Rute ikke definert: ${name}";
+  static String m20(name) => "Rute ikke definert: ${name}";
 
-  static String m20(count) =>
+  static String m21(count) =>
       "${Intl.plural(count, one: 'Søk bruker', other: 'Søk brukere')}";
 
-  static String m21(contact) =>
+  static String m22(contact) =>
       "En sikkerhetskode har blitt sendt til telefonen din på ${contact}.";
 
-  static String m22(name) =>
+  static String m23(name) =>
       "Kan ikke koble til Wi-Fi fordi enheten ${name} ikke fant nettverk";
 
-  static String m23(version) => "Oppdater til ${version}";
+  static String m24(version) => "Oppdater til ${version}";
 
-  static String m24(deviceName) =>
+  static String m25(deviceName) =>
       "For å fortsette oppsettet av enheten din ${deviceName}, vennligst oppgi nettverksinformasjonen din.";
 
-  static String m25(network) => "Skriv inn passordet for ${network}";
+  static String m26(network) => "Skriv inn passordet for ${network}";
 
   final messages = _notInlinedMessages(_notInlinedMessages);
   static Map<String, Function> _notInlinedMessages(_) => <String, Function>{
@@ -535,6 +537,7 @@ class MessageLookup extends MessageLookupByLibrary {
           "Mobilt dashbord må konfigureres i enhetsprofilen!",
         ),
     "more": MessageLookupByLibrary.simpleMessage("Mer"),
+    "nSelected": m14,
     "newPassword": MessageLookupByLibrary.simpleMessage("Nytt passord"),
     "newPassword2": MessageLookupByLibrary.simpleMessage(
       "Bekreft nytt passord",
@@ -579,12 +582,12 @@ class MessageLookup extends MessageLookupByLibrary {
     "notificationTemplate": MessageLookupByLibrary.simpleMessage(
       "Varslingsmal",
     ),
-    "notifications": m14,
+    "notifications": m15,
     "oauth2Client": MessageLookupByLibrary.simpleMessage("OAuth2-klient"),
     "openAppSettings": MessageLookupByLibrary.simpleMessage(
       "Åpne appinnstillinger",
     ),
-    "openAppSettingsToGrantPermissionMessage": m15,
+    "openAppSettingsToGrantPermissionMessage": m16,
     "openSettingsAndGrantAccessToCameraToContinue":
         MessageLookupByLibrary.simpleMessage(
           "Åpne innstillinger og gi tilgang til kameraet for å fortsette",
@@ -619,7 +622,7 @@ class MessageLookup extends MessageLookupByLibrary {
       "Passordet ble endret",
     ),
     "permissions": MessageLookupByLibrary.simpleMessage("Tillatelser"),
-    "permissionsNotEnoughMessage": m16,
+    "permissionsNotEnoughMessage": m17,
     "phone": MessageLookupByLibrary.simpleMessage("Telefon"),
     "phoneIsInvalid": MessageLookupByLibrary.simpleMessage(
       "Telefonnummer er ugyldig",
@@ -646,7 +649,7 @@ class MessageLookup extends MessageLookupByLibrary {
       "Skann QR-koden på enheten din",
     ),
     "plusAlarmType": MessageLookupByLibrary.simpleMessage("+ Alarmtype"),
-    "popTitle": m17,
+    "popTitle": m18,
     "postalCode": MessageLookupByLibrary.simpleMessage("Postnummer"),
     "privacyPolicy": MessageLookupByLibrary.simpleMessage(
       "Personvernerklæring",
@@ -677,7 +680,7 @@ class MessageLookup extends MessageLookupByLibrary {
     ),
     "resend": MessageLookupByLibrary.simpleMessage("Send på nytt"),
     "resendCode": MessageLookupByLibrary.simpleMessage("Send koden på nytt"),
-    "resendCodeWait": m18,
+    "resendCodeWait": m19,
     "reset": MessageLookupByLibrary.simpleMessage("Tilbakestill"),
     "retry": MessageLookupByLibrary.simpleMessage("Prøv igjen"),
     "returnToDashboard": MessageLookupByLibrary.simpleMessage(
@@ -687,7 +690,7 @@ class MessageLookup extends MessageLookupByLibrary {
       "Gå tilbake til appen og trykk Klar-knappen",
     ),
     "role": MessageLookupByLibrary.simpleMessage("Rolle"),
-    "routeNotDefined": m19,
+    "routeNotDefined": m20,
     "rpc": MessageLookupByLibrary.simpleMessage("RPC"),
     "ruleChain": MessageLookupByLibrary.simpleMessage("Regelkjede"),
     "ruleNode": MessageLookupByLibrary.simpleMessage("Regelnode"),
@@ -698,9 +701,10 @@ class MessageLookup extends MessageLookupByLibrary {
     ),
     "search": MessageLookupByLibrary.simpleMessage("Søk"),
     "searchResults": MessageLookupByLibrary.simpleMessage("Søkeresultater"),
-    "searchUsers": m20,
+    "searchUsers": m21,
     "seconds": MessageLookupByLibrary.simpleMessage("sekunder"),
     "security": MessageLookupByLibrary.simpleMessage("Sikkerhet"),
+    "selectAll": MessageLookupByLibrary.simpleMessage("Velg alle"),
     "selectCountry": MessageLookupByLibrary.simpleMessage("Velg land"),
     "selectRegion": MessageLookupByLibrary.simpleMessage("Velg region"),
     "selectUser": MessageLookupByLibrary.simpleMessage("Velg brukere"),
@@ -724,7 +728,7 @@ class MessageLookup extends MessageLookupByLibrary {
     "severity": MessageLookupByLibrary.simpleMessage("Alvorlighetsgrad"),
     "signIn": MessageLookupByLibrary.simpleMessage("Logg inn"),
     "signUp": MessageLookupByLibrary.simpleMessage("Registrer deg"),
-    "smsAuthDescription": m21,
+    "smsAuthDescription": m22,
     "smsAuthPlaceholder": MessageLookupByLibrary.simpleMessage("SMS-kode"),
     "smsSetupSuccessDescription": MessageLookupByLibrary.simpleMessage(
       "Neste gang du logger inn, vil du bli bedt om å taste inn sikkerhetskoden som sendes til telefonnummeret",
@@ -782,7 +786,7 @@ class MessageLookup extends MessageLookupByLibrary {
     "unableConnectToDevice": MessageLookupByLibrary.simpleMessage(
       "Kan ikke koble til enhet",
     ),
-    "unableConnectToWifiBecauseNetworksWasntFoundByDevice": m22,
+    "unableConnectToWifiBecauseNetworksWasntFoundByDevice": m23,
     "unableToUseCamera": MessageLookupByLibrary.simpleMessage(
       "Kan ikke bruke kameraet",
     ),
@@ -798,7 +802,7 @@ class MessageLookup extends MessageLookupByLibrary {
     "updateRequired": MessageLookupByLibrary.simpleMessage(
       "Oppdatering kreves",
     ),
-    "updateTo": m23,
+    "updateTo": m24,
     "url": MessageLookupByLibrary.simpleMessage("URL"),
     "user": MessageLookupByLibrary.simpleMessage("Bruker"),
     "username": MessageLookupByLibrary.simpleMessage("brukernavn"),
@@ -823,9 +827,9 @@ class MessageLookup extends MessageLookupByLibrary {
     "warning": MessageLookupByLibrary.simpleMessage("Advarsel"),
     "widgetType": MessageLookupByLibrary.simpleMessage("Widgettype"),
     "widgetsBundle": MessageLookupByLibrary.simpleMessage("Widgetpakke"),
-    "wifiHelpMessage": m24,
+    "wifiHelpMessage": m25,
     "wifiPassword": MessageLookupByLibrary.simpleMessage("Wi-Fi-passord"),
-    "wifiPasswordMessage": m25,
+    "wifiPasswordMessage": m26,
     "yes": MessageLookupByLibrary.simpleMessage("Ja"),
     "yesDeactivate": MessageLookupByLibrary.simpleMessage("Ja, deaktiver"),
     "yesDiscard": MessageLookupByLibrary.simpleMessage("Ja, forkast"),

--- a/lib/generated/intl/messages_vi_VN.dart
+++ b/lib/generated/intl/messages_vi_VN.dart
@@ -46,54 +46,60 @@ class MessageLookup extends MessageLookupByLibrary {
       "${Intl.plural(count, one: 'Bảng điều khiển', other: 'Bảng điều khiển')}";
 
   static String m9(count) =>
+      "${Intl.plural(count, one: 'Xóa 1 thông báo?', other: 'Xóa ${count} thông báo?')}";
+
+  static String m10(count) =>
       "${Intl.plural(count, one: 'Thiết bị', other: 'Thiết bị')}";
 
-  static String m10(count) => "Mã ${count} chữ số";
+  static String m11(count) => "Mã ${count} chữ số";
 
-  static String m11(contact) =>
+  static String m12(contact) =>
       "Mã bảo mật đã được gửi đến địa chỉ email của bạn tại ${contact}.";
 
-  static String m12(e) => "Đã xảy ra lỗi: ${e}";
+  static String m13(e) => "Đã xảy ra lỗi: ${e}";
 
-  static String m13(error) => "Lỗi khi gửi mã: ${error}";
+  static String m14(error) => "Lỗi khi gửi mã: ${error}";
 
-  static String m14(count) =>
+  static String m15(count) =>
       "${Intl.plural(count, one: '1 thao tác thất bại', other: '${count} thao tác thất bại')}";
 
-  static String m15(count) => "${count} đã chọn";
-
   static String m16(count) =>
+      "${Intl.plural(count, one: 'Đánh dấu 1 thông báo đã đọc?', other: 'Đánh dấu ${count} thông báo đã đọc?')}";
+
+  static String m17(count) => "${count} đã chọn";
+
+  static String m18(count) =>
       "${Intl.plural(count, one: 'Thông báo', other: 'Thông báo')}";
 
-  static String m17(permissions) =>
+  static String m19(permissions) =>
       "Bạn không có đủ quyền cho \"${permissions}\" để tiếp tục. Vui lòng mở cài đặt ứng dụng, cấp quyền và nhấn \"Thử lại\".";
 
-  static String m18(permissions) =>
+  static String m20(permissions) =>
       "Bạn không có đủ quyền cho \"${permissions}\" để tiếp tục. Vui lòng cấp các quyền cần thiết và nhấn \"Thử lại\".";
 
-  static String m19(deviceName) =>
+  static String m21(deviceName) =>
       "Nhập mã PIN của ${deviceName} để xác nhận bằng chứng sở hữu";
 
-  static String m20(time) =>
+  static String m22(time) =>
       "Gửi lại mã sau ${Intl.plural(time, other: '${time} giây')}";
 
-  static String m21(name) => "Lộ trình chưa được xác định: ${name}";
+  static String m23(name) => "Lộ trình chưa được xác định: ${name}";
 
-  static String m22(count) =>
+  static String m24(count) =>
       "${Intl.plural(count, one: 'Tìm kiếm người dùng', other: 'Tìm kiếm người dùng')}";
 
-  static String m23(contact) =>
+  static String m25(contact) =>
       "Mã bảo mật đã được gửi đến điện thoại của bạn tại ${contact}.";
 
-  static String m24(name) =>
+  static String m26(name) =>
       "Không thể kết nối với Wi-Fi vì thiết bị ${name} không tìm thấy mạng";
 
-  static String m25(version) => "Cập nhật lên ${version}";
+  static String m27(version) => "Cập nhật lên ${version}";
 
-  static String m26(deviceName) =>
+  static String m28(deviceName) =>
       "Để tiếp tục thiết lập thiết bị ${deviceName} của bạn, vui lòng cung cấp thông tin đăng nhập Mạng của bạn.";
 
-  static String m27(network) => "Nhập mật khẩu cho ${network}";
+  static String m29(network) => "Nhập mật khẩu cho ${network}";
 
   final messages = _notInlinedMessages(_notInlinedMessages);
   static Map<String, Function> _notInlinedMessages(_) => <String, Function>{
@@ -379,6 +385,7 @@ class MessageLookup extends MessageLookupByLibrary {
     "delete": MessageLookupByLibrary.simpleMessage("Xóa"),
     "deleteAccount": MessageLookupByLibrary.simpleMessage("Xóa tài khoản"),
     "deleteComment": MessageLookupByLibrary.simpleMessage("Xóa bình luận"),
+    "deleteSelectedNotifications": m9,
     "details": MessageLookupByLibrary.simpleMessage("Chi tiết"),
     "deviceList": MessageLookupByLibrary.simpleMessage("Danh sách thiết bị"),
     "deviceNotAbleToFindWifiNearby": MessageLookupByLibrary.simpleMessage(
@@ -391,8 +398,8 @@ class MessageLookup extends MessageLookupByLibrary {
     "deviceProvisioning": MessageLookupByLibrary.simpleMessage(
       "Cung cấp thiết bị",
     ),
-    "devices": m9,
-    "digitsCode": m10,
+    "devices": m10,
+    "digitsCode": m11,
     "discardChanges": MessageLookupByLibrary.simpleMessage("Hủy thay đổi"),
     "domain": MessageLookupByLibrary.simpleMessage("Tên miền"),
     "done": MessageLookupByLibrary.simpleMessage("Hoàn tất"),
@@ -401,7 +408,7 @@ class MessageLookup extends MessageLookupByLibrary {
     "edit": MessageLookupByLibrary.simpleMessage("Chỉnh sửa"),
     "edited": MessageLookupByLibrary.simpleMessage("Đã chỉnh sửa"),
     "email": MessageLookupByLibrary.simpleMessage("Email"),
-    "emailAuthDescription": m11,
+    "emailAuthDescription": m12,
     "emailAuthPlaceholder": MessageLookupByLibrary.simpleMessage("Mã email"),
     "emailInvalidText": MessageLookupByLibrary.simpleMessage(
       "Định dạng email không hợp lệ.",
@@ -440,8 +447,8 @@ class MessageLookup extends MessageLookupByLibrary {
     "entityGroup": MessageLookupByLibrary.simpleMessage("Nhóm thực thể"),
     "entityType": MessageLookupByLibrary.simpleMessage("Loại thực thể"),
     "entityView": MessageLookupByLibrary.simpleMessage("Chế độ xem thực thể"),
-    "errorOccured": m12,
-    "errorSendingCode": m13,
+    "errorOccured": m13,
+    "errorSendingCode": m14,
     "europe": MessageLookupByLibrary.simpleMessage("Châu Âu"),
     "europeRegionShort": MessageLookupByLibrary.simpleMessage("Frankfurt"),
     "exitDeviceProvisioning": MessageLookupByLibrary.simpleMessage(
@@ -456,7 +463,7 @@ class MessageLookup extends MessageLookupByLibrary {
     "failedToLoadTheList": MessageLookupByLibrary.simpleMessage(
       "Không thể tải danh sách",
     ),
-    "failedToPerformOperation": m14,
+    "failedToPerformOperation": m15,
     "failedToSaveImage": MessageLookupByLibrary.simpleMessage(
       "Không thể lưu ảnh",
     ),
@@ -540,6 +547,7 @@ class MessageLookup extends MessageLookupByLibrary {
       "Đánh dấu tất cả là đã đọc",
     ),
     "markAsRead": MessageLookupByLibrary.simpleMessage("Đánh dấu là đã đọc"),
+    "markSelectedNotificationsAsRead": m16,
     "metricUnitSystem": MessageLookupByLibrary.simpleMessage("Hệ mét"),
     "mfaProviderBackupCode": MessageLookupByLibrary.simpleMessage(
       "Mã dự phòng",
@@ -560,7 +568,7 @@ class MessageLookup extends MessageLookupByLibrary {
           "Bảng điều khiển di động phải được cấu hình trong hồ sơ thiết bị!",
         ),
     "more": MessageLookupByLibrary.simpleMessage("Thêm"),
-    "nSelected": m15,
+    "nSelected": m17,
     "newPassword": MessageLookupByLibrary.simpleMessage("Mật khẩu mới"),
     "newPassword2": MessageLookupByLibrary.simpleMessage(
       "Xác nhận mật khẩu mới",
@@ -609,12 +617,12 @@ class MessageLookup extends MessageLookupByLibrary {
     "notificationTemplate": MessageLookupByLibrary.simpleMessage(
       "Mẫu thông báo",
     ),
-    "notifications": m16,
+    "notifications": m18,
     "oauth2Client": MessageLookupByLibrary.simpleMessage("Máy khách Oauth2"),
     "openAppSettings": MessageLookupByLibrary.simpleMessage(
       "Mở cài đặt ứng dụng",
     ),
-    "openAppSettingsToGrantPermissionMessage": m17,
+    "openAppSettingsToGrantPermissionMessage": m19,
     "openSettingsAndGrantAccessToCameraToContinue":
         MessageLookupByLibrary.simpleMessage(
           "Mở cài đặt và cấp quyền truy cập camera để tiếp tục",
@@ -647,7 +655,7 @@ class MessageLookup extends MessageLookupByLibrary {
       "Đổi mật khẩu thành công",
     ),
     "permissions": MessageLookupByLibrary.simpleMessage("Quyền"),
-    "permissionsNotEnoughMessage": m18,
+    "permissionsNotEnoughMessage": m20,
     "phone": MessageLookupByLibrary.simpleMessage("Điện thoại"),
     "phoneIsInvalid": MessageLookupByLibrary.simpleMessage(
       "Số điện thoại không hợp lệ",
@@ -674,7 +682,7 @@ class MessageLookup extends MessageLookupByLibrary {
       "Vui lòng quét mã QR trên thiết bị của bạn",
     ),
     "plusAlarmType": MessageLookupByLibrary.simpleMessage("+ Loại cảnh báo"),
-    "popTitle": m19,
+    "popTitle": m21,
     "postalCode": MessageLookupByLibrary.simpleMessage("Mã Zip / Mã bưu điện"),
     "privacyPolicy": MessageLookupByLibrary.simpleMessage(
       "Chính sách quyền riêng tư",
@@ -707,7 +715,7 @@ class MessageLookup extends MessageLookupByLibrary {
     ),
     "resend": MessageLookupByLibrary.simpleMessage("Gửi lại"),
     "resendCode": MessageLookupByLibrary.simpleMessage("Gửi lại mã"),
-    "resendCodeWait": m20,
+    "resendCodeWait": m22,
     "reset": MessageLookupByLibrary.simpleMessage("Đặt lại"),
     "retry": MessageLookupByLibrary.simpleMessage("Thử lại"),
     "returnToDashboard": MessageLookupByLibrary.simpleMessage(
@@ -717,7 +725,7 @@ class MessageLookup extends MessageLookupByLibrary {
       "Quay lại ứng dụng và nhấn nút Sẵn sàng",
     ),
     "role": MessageLookupByLibrary.simpleMessage("Vai trò"),
-    "routeNotDefined": m21,
+    "routeNotDefined": m23,
     "rpc": MessageLookupByLibrary.simpleMessage("RPC"),
     "ruleChain": MessageLookupByLibrary.simpleMessage("Chuỗi quy tắc"),
     "ruleNode": MessageLookupByLibrary.simpleMessage("Nút quy tắc"),
@@ -726,7 +734,7 @@ class MessageLookup extends MessageLookupByLibrary {
     "schedulerEvent": MessageLookupByLibrary.simpleMessage("Sự kiện lập lịch"),
     "search": MessageLookupByLibrary.simpleMessage("Tìm kiếm"),
     "searchResults": MessageLookupByLibrary.simpleMessage("Kết quả tìm kiếm"),
-    "searchUsers": m22,
+    "searchUsers": m24,
     "seconds": MessageLookupByLibrary.simpleMessage("giây"),
     "security": MessageLookupByLibrary.simpleMessage("Bảo mật"),
     "selectAll": MessageLookupByLibrary.simpleMessage("Chọn tất cả"),
@@ -753,7 +761,7 @@ class MessageLookup extends MessageLookupByLibrary {
     "severity": MessageLookupByLibrary.simpleMessage("Mức độ nghiêm trọng"),
     "signIn": MessageLookupByLibrary.simpleMessage("Đăng nhập"),
     "signUp": MessageLookupByLibrary.simpleMessage("Đăng ký"),
-    "smsAuthDescription": m23,
+    "smsAuthDescription": m25,
     "smsAuthPlaceholder": MessageLookupByLibrary.simpleMessage("Mã SMS"),
     "smsSetupSuccessDescription": MessageLookupByLibrary.simpleMessage(
       "Lần tiếp theo bạn đăng nhập, bạn sẽ được yêu cầu nhập mã bảo mật được gửi đến số điện thoại",
@@ -813,7 +821,7 @@ class MessageLookup extends MessageLookupByLibrary {
     "unableConnectToDevice": MessageLookupByLibrary.simpleMessage(
       "Không thể kết nối với thiết bị",
     ),
-    "unableConnectToWifiBecauseNetworksWasntFoundByDevice": m24,
+    "unableConnectToWifiBecauseNetworksWasntFoundByDevice": m26,
     "unableToUseCamera": MessageLookupByLibrary.simpleMessage(
       "Không thể sử dụng camera",
     ),
@@ -827,7 +835,7 @@ class MessageLookup extends MessageLookupByLibrary {
     ),
     "update": MessageLookupByLibrary.simpleMessage("Cập nhật"),
     "updateRequired": MessageLookupByLibrary.simpleMessage("Yêu cầu cập nhật"),
-    "updateTo": m25,
+    "updateTo": m27,
     "url": MessageLookupByLibrary.simpleMessage("Url"),
     "user": MessageLookupByLibrary.simpleMessage("Người dùng"),
     "username": MessageLookupByLibrary.simpleMessage("tên người dùng"),
@@ -854,9 +862,9 @@ class MessageLookup extends MessageLookupByLibrary {
     "warning": MessageLookupByLibrary.simpleMessage("Cảnh báo"),
     "widgetType": MessageLookupByLibrary.simpleMessage("Loại widget"),
     "widgetsBundle": MessageLookupByLibrary.simpleMessage("Gói widget"),
-    "wifiHelpMessage": m26,
+    "wifiHelpMessage": m28,
     "wifiPassword": MessageLookupByLibrary.simpleMessage("Mật khẩu Wi-Fi"),
-    "wifiPasswordMessage": m27,
+    "wifiPasswordMessage": m29,
     "yes": MessageLookupByLibrary.simpleMessage("Có"),
     "yesDeactivate": MessageLookupByLibrary.simpleMessage("Có, hủy kích hoạt"),
     "yesDiscard": MessageLookupByLibrary.simpleMessage("Có, hủy"),

--- a/lib/generated/intl/messages_vi_VN.dart
+++ b/lib/generated/intl/messages_vi_VN.dart
@@ -737,7 +737,7 @@ class MessageLookup extends MessageLookupByLibrary {
     "searchUsers": m24,
     "seconds": MessageLookupByLibrary.simpleMessage("giây"),
     "security": MessageLookupByLibrary.simpleMessage("Bảo mật"),
-    "selectAll": MessageLookupByLibrary.simpleMessage("Chọn tất cả"),
+    "selectAll": MessageLookupByLibrary.simpleMessage("Chọn tất cả đã tải"),
     "selectCountry": MessageLookupByLibrary.simpleMessage("Chọn quốc gia"),
     "selectRegion": MessageLookupByLibrary.simpleMessage("Chọn khu vực"),
     "selectUser": MessageLookupByLibrary.simpleMessage("Chọn người dùng"),

--- a/lib/generated/intl/messages_vi_VN.dart
+++ b/lib/generated/intl/messages_vi_VN.dart
@@ -57,40 +57,43 @@ class MessageLookup extends MessageLookupByLibrary {
 
   static String m13(error) => "Lỗi khi gửi mã: ${error}";
 
-  static String m14(count) => "${count} đã chọn";
+  static String m14(count) =>
+      "${Intl.plural(count, one: '1 thao tác thất bại', other: '${count} thao tác thất bại')}";
 
-  static String m15(count) =>
+  static String m15(count) => "${count} đã chọn";
+
+  static String m16(count) =>
       "${Intl.plural(count, one: 'Thông báo', other: 'Thông báo')}";
 
-  static String m16(permissions) =>
+  static String m17(permissions) =>
       "Bạn không có đủ quyền cho \"${permissions}\" để tiếp tục. Vui lòng mở cài đặt ứng dụng, cấp quyền và nhấn \"Thử lại\".";
 
-  static String m17(permissions) =>
+  static String m18(permissions) =>
       "Bạn không có đủ quyền cho \"${permissions}\" để tiếp tục. Vui lòng cấp các quyền cần thiết và nhấn \"Thử lại\".";
 
-  static String m18(deviceName) =>
+  static String m19(deviceName) =>
       "Nhập mã PIN của ${deviceName} để xác nhận bằng chứng sở hữu";
 
-  static String m19(time) =>
+  static String m20(time) =>
       "Gửi lại mã sau ${Intl.plural(time, other: '${time} giây')}";
 
-  static String m20(name) => "Lộ trình chưa được xác định: ${name}";
+  static String m21(name) => "Lộ trình chưa được xác định: ${name}";
 
-  static String m21(count) =>
+  static String m22(count) =>
       "${Intl.plural(count, one: 'Tìm kiếm người dùng', other: 'Tìm kiếm người dùng')}";
 
-  static String m22(contact) =>
+  static String m23(contact) =>
       "Mã bảo mật đã được gửi đến điện thoại của bạn tại ${contact}.";
 
-  static String m23(name) =>
+  static String m24(name) =>
       "Không thể kết nối với Wi-Fi vì thiết bị ${name} không tìm thấy mạng";
 
-  static String m24(version) => "Cập nhật lên ${version}";
+  static String m25(version) => "Cập nhật lên ${version}";
 
-  static String m25(deviceName) =>
+  static String m26(deviceName) =>
       "Để tiếp tục thiết lập thiết bị ${deviceName} của bạn, vui lòng cung cấp thông tin đăng nhập Mạng của bạn.";
 
-  static String m26(network) => "Nhập mật khẩu cho ${network}";
+  static String m27(network) => "Nhập mật khẩu cho ${network}";
 
   final messages = _notInlinedMessages(_notInlinedMessages);
   static Map<String, Function> _notInlinedMessages(_) => <String, Function>{
@@ -453,6 +456,7 @@ class MessageLookup extends MessageLookupByLibrary {
     "failedToLoadTheList": MessageLookupByLibrary.simpleMessage(
       "Không thể tải danh sách",
     ),
+    "failedToPerformOperation": m14,
     "failedToSaveImage": MessageLookupByLibrary.simpleMessage(
       "Không thể lưu ảnh",
     ),
@@ -556,7 +560,7 @@ class MessageLookup extends MessageLookupByLibrary {
           "Bảng điều khiển di động phải được cấu hình trong hồ sơ thiết bị!",
         ),
     "more": MessageLookupByLibrary.simpleMessage("Thêm"),
-    "nSelected": m14,
+    "nSelected": m15,
     "newPassword": MessageLookupByLibrary.simpleMessage("Mật khẩu mới"),
     "newPassword2": MessageLookupByLibrary.simpleMessage(
       "Xác nhận mật khẩu mới",
@@ -605,12 +609,12 @@ class MessageLookup extends MessageLookupByLibrary {
     "notificationTemplate": MessageLookupByLibrary.simpleMessage(
       "Mẫu thông báo",
     ),
-    "notifications": m15,
+    "notifications": m16,
     "oauth2Client": MessageLookupByLibrary.simpleMessage("Máy khách Oauth2"),
     "openAppSettings": MessageLookupByLibrary.simpleMessage(
       "Mở cài đặt ứng dụng",
     ),
-    "openAppSettingsToGrantPermissionMessage": m16,
+    "openAppSettingsToGrantPermissionMessage": m17,
     "openSettingsAndGrantAccessToCameraToContinue":
         MessageLookupByLibrary.simpleMessage(
           "Mở cài đặt và cấp quyền truy cập camera để tiếp tục",
@@ -643,7 +647,7 @@ class MessageLookup extends MessageLookupByLibrary {
       "Đổi mật khẩu thành công",
     ),
     "permissions": MessageLookupByLibrary.simpleMessage("Quyền"),
-    "permissionsNotEnoughMessage": m17,
+    "permissionsNotEnoughMessage": m18,
     "phone": MessageLookupByLibrary.simpleMessage("Điện thoại"),
     "phoneIsInvalid": MessageLookupByLibrary.simpleMessage(
       "Số điện thoại không hợp lệ",
@@ -670,7 +674,7 @@ class MessageLookup extends MessageLookupByLibrary {
       "Vui lòng quét mã QR trên thiết bị của bạn",
     ),
     "plusAlarmType": MessageLookupByLibrary.simpleMessage("+ Loại cảnh báo"),
-    "popTitle": m18,
+    "popTitle": m19,
     "postalCode": MessageLookupByLibrary.simpleMessage("Mã Zip / Mã bưu điện"),
     "privacyPolicy": MessageLookupByLibrary.simpleMessage(
       "Chính sách quyền riêng tư",
@@ -703,7 +707,7 @@ class MessageLookup extends MessageLookupByLibrary {
     ),
     "resend": MessageLookupByLibrary.simpleMessage("Gửi lại"),
     "resendCode": MessageLookupByLibrary.simpleMessage("Gửi lại mã"),
-    "resendCodeWait": m19,
+    "resendCodeWait": m20,
     "reset": MessageLookupByLibrary.simpleMessage("Đặt lại"),
     "retry": MessageLookupByLibrary.simpleMessage("Thử lại"),
     "returnToDashboard": MessageLookupByLibrary.simpleMessage(
@@ -713,7 +717,7 @@ class MessageLookup extends MessageLookupByLibrary {
       "Quay lại ứng dụng và nhấn nút Sẵn sàng",
     ),
     "role": MessageLookupByLibrary.simpleMessage("Vai trò"),
-    "routeNotDefined": m20,
+    "routeNotDefined": m21,
     "rpc": MessageLookupByLibrary.simpleMessage("RPC"),
     "ruleChain": MessageLookupByLibrary.simpleMessage("Chuỗi quy tắc"),
     "ruleNode": MessageLookupByLibrary.simpleMessage("Nút quy tắc"),
@@ -722,7 +726,7 @@ class MessageLookup extends MessageLookupByLibrary {
     "schedulerEvent": MessageLookupByLibrary.simpleMessage("Sự kiện lập lịch"),
     "search": MessageLookupByLibrary.simpleMessage("Tìm kiếm"),
     "searchResults": MessageLookupByLibrary.simpleMessage("Kết quả tìm kiếm"),
-    "searchUsers": m21,
+    "searchUsers": m22,
     "seconds": MessageLookupByLibrary.simpleMessage("giây"),
     "security": MessageLookupByLibrary.simpleMessage("Bảo mật"),
     "selectAll": MessageLookupByLibrary.simpleMessage("Chọn tất cả"),
@@ -749,7 +753,7 @@ class MessageLookup extends MessageLookupByLibrary {
     "severity": MessageLookupByLibrary.simpleMessage("Mức độ nghiêm trọng"),
     "signIn": MessageLookupByLibrary.simpleMessage("Đăng nhập"),
     "signUp": MessageLookupByLibrary.simpleMessage("Đăng ký"),
-    "smsAuthDescription": m22,
+    "smsAuthDescription": m23,
     "smsAuthPlaceholder": MessageLookupByLibrary.simpleMessage("Mã SMS"),
     "smsSetupSuccessDescription": MessageLookupByLibrary.simpleMessage(
       "Lần tiếp theo bạn đăng nhập, bạn sẽ được yêu cầu nhập mã bảo mật được gửi đến số điện thoại",
@@ -809,7 +813,7 @@ class MessageLookup extends MessageLookupByLibrary {
     "unableConnectToDevice": MessageLookupByLibrary.simpleMessage(
       "Không thể kết nối với thiết bị",
     ),
-    "unableConnectToWifiBecauseNetworksWasntFoundByDevice": m23,
+    "unableConnectToWifiBecauseNetworksWasntFoundByDevice": m24,
     "unableToUseCamera": MessageLookupByLibrary.simpleMessage(
       "Không thể sử dụng camera",
     ),
@@ -823,7 +827,7 @@ class MessageLookup extends MessageLookupByLibrary {
     ),
     "update": MessageLookupByLibrary.simpleMessage("Cập nhật"),
     "updateRequired": MessageLookupByLibrary.simpleMessage("Yêu cầu cập nhật"),
-    "updateTo": m24,
+    "updateTo": m25,
     "url": MessageLookupByLibrary.simpleMessage("Url"),
     "user": MessageLookupByLibrary.simpleMessage("Người dùng"),
     "username": MessageLookupByLibrary.simpleMessage("tên người dùng"),
@@ -850,9 +854,9 @@ class MessageLookup extends MessageLookupByLibrary {
     "warning": MessageLookupByLibrary.simpleMessage("Cảnh báo"),
     "widgetType": MessageLookupByLibrary.simpleMessage("Loại widget"),
     "widgetsBundle": MessageLookupByLibrary.simpleMessage("Gói widget"),
-    "wifiHelpMessage": m25,
+    "wifiHelpMessage": m26,
     "wifiPassword": MessageLookupByLibrary.simpleMessage("Mật khẩu Wi-Fi"),
-    "wifiPasswordMessage": m26,
+    "wifiPasswordMessage": m27,
     "yes": MessageLookupByLibrary.simpleMessage("Có"),
     "yesDeactivate": MessageLookupByLibrary.simpleMessage("Có, hủy kích hoạt"),
     "yesDiscard": MessageLookupByLibrary.simpleMessage("Có, hủy"),

--- a/lib/generated/intl/messages_vi_VN.dart
+++ b/lib/generated/intl/messages_vi_VN.dart
@@ -57,38 +57,40 @@ class MessageLookup extends MessageLookupByLibrary {
 
   static String m13(error) => "Lỗi khi gửi mã: ${error}";
 
-  static String m14(count) =>
+  static String m14(count) => "${count} đã chọn";
+
+  static String m15(count) =>
       "${Intl.plural(count, one: 'Thông báo', other: 'Thông báo')}";
 
-  static String m15(permissions) =>
+  static String m16(permissions) =>
       "Bạn không có đủ quyền cho \"${permissions}\" để tiếp tục. Vui lòng mở cài đặt ứng dụng, cấp quyền và nhấn \"Thử lại\".";
 
-  static String m16(permissions) =>
+  static String m17(permissions) =>
       "Bạn không có đủ quyền cho \"${permissions}\" để tiếp tục. Vui lòng cấp các quyền cần thiết và nhấn \"Thử lại\".";
 
-  static String m17(deviceName) =>
+  static String m18(deviceName) =>
       "Nhập mã PIN của ${deviceName} để xác nhận bằng chứng sở hữu";
 
-  static String m18(time) =>
+  static String m19(time) =>
       "Gửi lại mã sau ${Intl.plural(time, other: '${time} giây')}";
 
-  static String m19(name) => "Lộ trình chưa được xác định: ${name}";
+  static String m20(name) => "Lộ trình chưa được xác định: ${name}";
 
-  static String m20(count) =>
+  static String m21(count) =>
       "${Intl.plural(count, one: 'Tìm kiếm người dùng', other: 'Tìm kiếm người dùng')}";
 
-  static String m21(contact) =>
+  static String m22(contact) =>
       "Mã bảo mật đã được gửi đến điện thoại của bạn tại ${contact}.";
 
-  static String m22(name) =>
+  static String m23(name) =>
       "Không thể kết nối với Wi-Fi vì thiết bị ${name} không tìm thấy mạng";
 
-  static String m23(version) => "Cập nhật lên ${version}";
+  static String m24(version) => "Cập nhật lên ${version}";
 
-  static String m24(deviceName) =>
+  static String m25(deviceName) =>
       "Để tiếp tục thiết lập thiết bị ${deviceName} của bạn, vui lòng cung cấp thông tin đăng nhập Mạng của bạn.";
 
-  static String m25(network) => "Nhập mật khẩu cho ${network}";
+  static String m26(network) => "Nhập mật khẩu cho ${network}";
 
   final messages = _notInlinedMessages(_notInlinedMessages);
   static Map<String, Function> _notInlinedMessages(_) => <String, Function>{
@@ -554,6 +556,7 @@ class MessageLookup extends MessageLookupByLibrary {
           "Bảng điều khiển di động phải được cấu hình trong hồ sơ thiết bị!",
         ),
     "more": MessageLookupByLibrary.simpleMessage("Thêm"),
+    "nSelected": m14,
     "newPassword": MessageLookupByLibrary.simpleMessage("Mật khẩu mới"),
     "newPassword2": MessageLookupByLibrary.simpleMessage(
       "Xác nhận mật khẩu mới",
@@ -602,12 +605,12 @@ class MessageLookup extends MessageLookupByLibrary {
     "notificationTemplate": MessageLookupByLibrary.simpleMessage(
       "Mẫu thông báo",
     ),
-    "notifications": m14,
+    "notifications": m15,
     "oauth2Client": MessageLookupByLibrary.simpleMessage("Máy khách Oauth2"),
     "openAppSettings": MessageLookupByLibrary.simpleMessage(
       "Mở cài đặt ứng dụng",
     ),
-    "openAppSettingsToGrantPermissionMessage": m15,
+    "openAppSettingsToGrantPermissionMessage": m16,
     "openSettingsAndGrantAccessToCameraToContinue":
         MessageLookupByLibrary.simpleMessage(
           "Mở cài đặt và cấp quyền truy cập camera để tiếp tục",
@@ -640,7 +643,7 @@ class MessageLookup extends MessageLookupByLibrary {
       "Đổi mật khẩu thành công",
     ),
     "permissions": MessageLookupByLibrary.simpleMessage("Quyền"),
-    "permissionsNotEnoughMessage": m16,
+    "permissionsNotEnoughMessage": m17,
     "phone": MessageLookupByLibrary.simpleMessage("Điện thoại"),
     "phoneIsInvalid": MessageLookupByLibrary.simpleMessage(
       "Số điện thoại không hợp lệ",
@@ -667,7 +670,7 @@ class MessageLookup extends MessageLookupByLibrary {
       "Vui lòng quét mã QR trên thiết bị của bạn",
     ),
     "plusAlarmType": MessageLookupByLibrary.simpleMessage("+ Loại cảnh báo"),
-    "popTitle": m17,
+    "popTitle": m18,
     "postalCode": MessageLookupByLibrary.simpleMessage("Mã Zip / Mã bưu điện"),
     "privacyPolicy": MessageLookupByLibrary.simpleMessage(
       "Chính sách quyền riêng tư",
@@ -700,7 +703,7 @@ class MessageLookup extends MessageLookupByLibrary {
     ),
     "resend": MessageLookupByLibrary.simpleMessage("Gửi lại"),
     "resendCode": MessageLookupByLibrary.simpleMessage("Gửi lại mã"),
-    "resendCodeWait": m18,
+    "resendCodeWait": m19,
     "reset": MessageLookupByLibrary.simpleMessage("Đặt lại"),
     "retry": MessageLookupByLibrary.simpleMessage("Thử lại"),
     "returnToDashboard": MessageLookupByLibrary.simpleMessage(
@@ -710,7 +713,7 @@ class MessageLookup extends MessageLookupByLibrary {
       "Quay lại ứng dụng và nhấn nút Sẵn sàng",
     ),
     "role": MessageLookupByLibrary.simpleMessage("Vai trò"),
-    "routeNotDefined": m19,
+    "routeNotDefined": m20,
     "rpc": MessageLookupByLibrary.simpleMessage("RPC"),
     "ruleChain": MessageLookupByLibrary.simpleMessage("Chuỗi quy tắc"),
     "ruleNode": MessageLookupByLibrary.simpleMessage("Nút quy tắc"),
@@ -719,9 +722,10 @@ class MessageLookup extends MessageLookupByLibrary {
     "schedulerEvent": MessageLookupByLibrary.simpleMessage("Sự kiện lập lịch"),
     "search": MessageLookupByLibrary.simpleMessage("Tìm kiếm"),
     "searchResults": MessageLookupByLibrary.simpleMessage("Kết quả tìm kiếm"),
-    "searchUsers": m20,
+    "searchUsers": m21,
     "seconds": MessageLookupByLibrary.simpleMessage("giây"),
     "security": MessageLookupByLibrary.simpleMessage("Bảo mật"),
+    "selectAll": MessageLookupByLibrary.simpleMessage("Chọn tất cả"),
     "selectCountry": MessageLookupByLibrary.simpleMessage("Chọn quốc gia"),
     "selectRegion": MessageLookupByLibrary.simpleMessage("Chọn khu vực"),
     "selectUser": MessageLookupByLibrary.simpleMessage("Chọn người dùng"),
@@ -745,7 +749,7 @@ class MessageLookup extends MessageLookupByLibrary {
     "severity": MessageLookupByLibrary.simpleMessage("Mức độ nghiêm trọng"),
     "signIn": MessageLookupByLibrary.simpleMessage("Đăng nhập"),
     "signUp": MessageLookupByLibrary.simpleMessage("Đăng ký"),
-    "smsAuthDescription": m21,
+    "smsAuthDescription": m22,
     "smsAuthPlaceholder": MessageLookupByLibrary.simpleMessage("Mã SMS"),
     "smsSetupSuccessDescription": MessageLookupByLibrary.simpleMessage(
       "Lần tiếp theo bạn đăng nhập, bạn sẽ được yêu cầu nhập mã bảo mật được gửi đến số điện thoại",
@@ -805,7 +809,7 @@ class MessageLookup extends MessageLookupByLibrary {
     "unableConnectToDevice": MessageLookupByLibrary.simpleMessage(
       "Không thể kết nối với thiết bị",
     ),
-    "unableConnectToWifiBecauseNetworksWasntFoundByDevice": m22,
+    "unableConnectToWifiBecauseNetworksWasntFoundByDevice": m23,
     "unableToUseCamera": MessageLookupByLibrary.simpleMessage(
       "Không thể sử dụng camera",
     ),
@@ -819,7 +823,7 @@ class MessageLookup extends MessageLookupByLibrary {
     ),
     "update": MessageLookupByLibrary.simpleMessage("Cập nhật"),
     "updateRequired": MessageLookupByLibrary.simpleMessage("Yêu cầu cập nhật"),
-    "updateTo": m23,
+    "updateTo": m24,
     "url": MessageLookupByLibrary.simpleMessage("Url"),
     "user": MessageLookupByLibrary.simpleMessage("Người dùng"),
     "username": MessageLookupByLibrary.simpleMessage("tên người dùng"),
@@ -846,9 +850,9 @@ class MessageLookup extends MessageLookupByLibrary {
     "warning": MessageLookupByLibrary.simpleMessage("Cảnh báo"),
     "widgetType": MessageLookupByLibrary.simpleMessage("Loại widget"),
     "widgetsBundle": MessageLookupByLibrary.simpleMessage("Gói widget"),
-    "wifiHelpMessage": m24,
+    "wifiHelpMessage": m25,
     "wifiPassword": MessageLookupByLibrary.simpleMessage("Mật khẩu Wi-Fi"),
-    "wifiPasswordMessage": m25,
+    "wifiPasswordMessage": m26,
     "yes": MessageLookupByLibrary.simpleMessage("Có"),
     "yesDeactivate": MessageLookupByLibrary.simpleMessage("Có, hủy kích hoạt"),
     "yesDiscard": MessageLookupByLibrary.simpleMessage("Có, hủy"),

--- a/lib/generated/intl/messages_zh.dart
+++ b/lib/generated/intl/messages_zh.dart
@@ -44,48 +44,54 @@ class MessageLookup extends MessageLookupByLibrary {
       "${Intl.plural(count, one: 'Dashboard', other: 'Dashboards')}";
 
   static String m9(count) =>
-      "${Intl.plural(count, one: 'Device', other: 'Devices')}";
+      "${Intl.plural(count, one: '删除 1 条通知？', other: '删除 ${count} 条通知？')}";
 
   static String m10(count) =>
+      "${Intl.plural(count, one: 'Device', other: 'Devices')}";
+
+  static String m11(count) =>
       "${count}-${Intl.plural(count, one: 'digit', other: 'digits')} code";
 
-  static String m11(contact) => "安全码已发送到您的邮箱 ${contact}。";
+  static String m12(contact) => "安全码已发送到您的邮箱 ${contact}。";
 
-  static String m12(e) => "Error occured: ${e}";
+  static String m13(e) => "Error occured: ${e}";
 
-  static String m14(count) =>
+  static String m15(count) =>
       "${Intl.plural(count, one: '1 项操作失败', other: '${count} 项操作失败')}";
 
-  static String m15(count) => "已选择 ${count} 项";
+  static String m16(count) =>
+      "${Intl.plural(count, one: '将 1 条通知标记为已读？', other: '将 ${count} 条通知标记为已读？')}";
 
-  static String m16(count) => "${Intl.plural(count, one: '通知', other: '通知')}";
+  static String m17(count) => "已选择 ${count} 项";
 
-  static String m17(permissions) =>
+  static String m18(count) => "${Intl.plural(count, one: '通知', other: '通知')}";
+
+  static String m19(permissions) =>
       "您没有足够的\"${permissions}\"权限以继续。请打开应用设置，授予权限并点击\"再试一次\"。";
 
-  static String m18(permissions) =>
+  static String m20(permissions) =>
       "您没有足够的\"${permissions}\"权限以继续。请授予所需权限并点击\"再试一次\"。";
 
-  static String m19(deviceName) => "输入 ${deviceName} 的PIN码以确认拥有权证明";
+  static String m21(deviceName) => "输入 ${deviceName} 的PIN码以确认拥有权证明";
 
-  static String m20(time) =>
+  static String m22(time) =>
       "在 ${Intl.plural(time, one: '1 秒', other: '${time} 秒')}内重新发送验证码";
 
-  static String m21(name) => "路由未定义: ${name}";
+  static String m23(name) => "路由未定义: ${name}";
 
-  static String m22(count) =>
+  static String m24(count) =>
       "${Intl.plural(count, one: '搜索用户', other: '搜索用户')}";
 
-  static String m23(contact) => "安全码已发送到您的手机 ${contact}。";
+  static String m25(contact) => "安全码已发送到您的手机 ${contact}。";
 
-  static String m24(name) =>
+  static String m26(name) =>
       "Unable connect to Wi-Fi because networks wasn\'t found by device ${name}";
 
-  static String m25(version) => "更新到 ${version}";
+  static String m27(version) => "更新到 ${version}";
 
-  static String m26(deviceName) => "要继续设置您的设备 ${deviceName}，请提供您网络的凭据。";
+  static String m28(deviceName) => "要继续设置您的设备 ${deviceName}，请提供您网络的凭据。";
 
-  static String m27(network) => "输入 ${network} 的密码";
+  static String m29(network) => "输入 ${network} 的密码";
 
   final messages = _notInlinedMessages(_notInlinedMessages);
   static Map<String, Function> _notInlinedMessages(_) => <String, Function>{
@@ -327,6 +333,7 @@ class MessageLookup extends MessageLookupByLibrary {
     "delete": MessageLookupByLibrary.simpleMessage("删除"),
     "deleteAccount": MessageLookupByLibrary.simpleMessage("Delete account"),
     "deleteComment": MessageLookupByLibrary.simpleMessage("删除评论"),
+    "deleteSelectedNotifications": m9,
     "details": MessageLookupByLibrary.simpleMessage("详情"),
     "deviceList": MessageLookupByLibrary.simpleMessage("设备列表"),
     "deviceNotAbleToFindWifiNearby": MessageLookupByLibrary.simpleMessage(
@@ -339,8 +346,8 @@ class MessageLookup extends MessageLookupByLibrary {
     "deviceProvisioning": MessageLookupByLibrary.simpleMessage(
       "Device provisioning",
     ),
-    "devices": m9,
-    "digitsCode": m10,
+    "devices": m10,
+    "digitsCode": m11,
     "discardChanges": MessageLookupByLibrary.simpleMessage("Discard changes"),
     "domain": MessageLookupByLibrary.simpleMessage("Domain"),
     "done": MessageLookupByLibrary.simpleMessage("Done"),
@@ -349,7 +356,7 @@ class MessageLookup extends MessageLookupByLibrary {
     "edit": MessageLookupByLibrary.simpleMessage("编辑"),
     "edited": MessageLookupByLibrary.simpleMessage("已编辑"),
     "email": MessageLookupByLibrary.simpleMessage("邮箱"),
-    "emailAuthDescription": m11,
+    "emailAuthDescription": m12,
     "emailAuthPlaceholder": MessageLookupByLibrary.simpleMessage("邮箱验证码"),
     "emailInvalidText": MessageLookupByLibrary.simpleMessage("邮箱格式无效"),
     "emailRequireText": MessageLookupByLibrary.simpleMessage("邮箱是必填项"),
@@ -376,7 +383,7 @@ class MessageLookup extends MessageLookupByLibrary {
     "entityGroup": MessageLookupByLibrary.simpleMessage("实体组"),
     "entityType": MessageLookupByLibrary.simpleMessage("实体类型"),
     "entityView": MessageLookupByLibrary.simpleMessage("实体视图"),
-    "errorOccured": m12,
+    "errorOccured": m13,
     "europe": MessageLookupByLibrary.simpleMessage("欧洲"),
     "europeRegionShort": MessageLookupByLibrary.simpleMessage("法兰克福"),
     "exitDeviceProvisioning": MessageLookupByLibrary.simpleMessage(
@@ -389,7 +396,7 @@ class MessageLookup extends MessageLookupByLibrary {
       "加载告警详情失败",
     ),
     "failedToLoadTheList": MessageLookupByLibrary.simpleMessage("加载列表失败"),
-    "failedToPerformOperation": m14,
+    "failedToPerformOperation": m15,
     "failedToSaveImage": MessageLookupByLibrary.simpleMessage("保存图片失败"),
     "failureDetails": MessageLookupByLibrary.simpleMessage("失败详情"),
     "fatalApplicationErrorOccurred": MessageLookupByLibrary.simpleMessage(
@@ -449,6 +456,7 @@ class MessageLookup extends MessageLookupByLibrary {
     "major": MessageLookupByLibrary.simpleMessage("重要"),
     "markAllAsRead": MessageLookupByLibrary.simpleMessage("Mark all as read"),
     "markAsRead": MessageLookupByLibrary.simpleMessage("Mark as read"),
+    "markSelectedNotificationsAsRead": m16,
     "metricUnitSystem": MessageLookupByLibrary.simpleMessage("Metric"),
     "mfaProviderBackupCode": MessageLookupByLibrary.simpleMessage("备份码"),
     "mfaProviderEmail": MessageLookupByLibrary.simpleMessage("邮箱"),
@@ -465,7 +473,7 @@ class MessageLookup extends MessageLookupByLibrary {
           "Mobile dashboard should be configured in device profile!",
         ),
     "more": MessageLookupByLibrary.simpleMessage("更多"),
-    "nSelected": m15,
+    "nSelected": m17,
     "newPassword": MessageLookupByLibrary.simpleMessage("新密码"),
     "newPassword2": MessageLookupByLibrary.simpleMessage("确认新密码"),
     "newPassword2RequireText": MessageLookupByLibrary.simpleMessage("请再次输入新密码"),
@@ -492,12 +500,12 @@ class MessageLookup extends MessageLookupByLibrary {
     "notificationRule": MessageLookupByLibrary.simpleMessage("通知规则"),
     "notificationTarget": MessageLookupByLibrary.simpleMessage("通知目标"),
     "notificationTemplate": MessageLookupByLibrary.simpleMessage("通知模板"),
-    "notifications": m16,
+    "notifications": m18,
     "oauth2Client": MessageLookupByLibrary.simpleMessage("Oauth2 client"),
     "openAppSettings": MessageLookupByLibrary.simpleMessage(
       "Open app settings",
     ),
-    "openAppSettingsToGrantPermissionMessage": m17,
+    "openAppSettingsToGrantPermissionMessage": m19,
     "openSettingsAndGrantAccessToCameraToContinue":
         MessageLookupByLibrary.simpleMessage("打开设置并授予摄像头访问权限以继续"),
     "openWifiSettings": MessageLookupByLibrary.simpleMessage(
@@ -522,7 +530,7 @@ class MessageLookup extends MessageLookupByLibrary {
       "密码修改成功",
     ),
     "permissions": MessageLookupByLibrary.simpleMessage("Permissions"),
-    "permissionsNotEnoughMessage": m18,
+    "permissionsNotEnoughMessage": m20,
     "phone": MessageLookupByLibrary.simpleMessage("电话"),
     "phoneIsInvalid": MessageLookupByLibrary.simpleMessage("Phone is invalid"),
     "phoneIsRequired": MessageLookupByLibrary.simpleMessage(
@@ -547,7 +555,7 @@ class MessageLookup extends MessageLookupByLibrary {
       "Please scan QR code on your device",
     ),
     "plusAlarmType": MessageLookupByLibrary.simpleMessage("+ Alarm type"),
-    "popTitle": m19,
+    "popTitle": m21,
     "postalCode": MessageLookupByLibrary.simpleMessage("邮编"),
     "privacyPolicy": MessageLookupByLibrary.simpleMessage("隐私政策"),
     "profile": MessageLookupByLibrary.simpleMessage("Profile"),
@@ -570,7 +578,7 @@ class MessageLookup extends MessageLookupByLibrary {
     ),
     "resend": MessageLookupByLibrary.simpleMessage("重新发送"),
     "resendCode": MessageLookupByLibrary.simpleMessage("重新发送验证码"),
-    "resendCodeWait": m20,
+    "resendCodeWait": m22,
     "reset": MessageLookupByLibrary.simpleMessage("Reset"),
     "retry": MessageLookupByLibrary.simpleMessage("Retry"),
     "returnToDashboard": MessageLookupByLibrary.simpleMessage("返回仪表板"),
@@ -578,7 +586,7 @@ class MessageLookup extends MessageLookupByLibrary {
       "Return to the app and tap Ready button",
     ),
     "role": MessageLookupByLibrary.simpleMessage("角色"),
-    "routeNotDefined": m21,
+    "routeNotDefined": m23,
     "rpc": MessageLookupByLibrary.simpleMessage("RPC"),
     "ruleChain": MessageLookupByLibrary.simpleMessage("规则链"),
     "ruleNode": MessageLookupByLibrary.simpleMessage("规则节点"),
@@ -587,7 +595,7 @@ class MessageLookup extends MessageLookupByLibrary {
     "schedulerEvent": MessageLookupByLibrary.simpleMessage("调度事件"),
     "search": MessageLookupByLibrary.simpleMessage("Search"),
     "searchResults": MessageLookupByLibrary.simpleMessage("搜索结果"),
-    "searchUsers": m22,
+    "searchUsers": m24,
     "seconds": MessageLookupByLibrary.simpleMessage("秒"),
     "security": MessageLookupByLibrary.simpleMessage("Security"),
     "selectAll": MessageLookupByLibrary.simpleMessage("全选"),
@@ -612,7 +620,7 @@ class MessageLookup extends MessageLookupByLibrary {
     "severity": MessageLookupByLibrary.simpleMessage("严重程度"),
     "signIn": MessageLookupByLibrary.simpleMessage("登录"),
     "signUp": MessageLookupByLibrary.simpleMessage("注册"),
-    "smsAuthDescription": m23,
+    "smsAuthDescription": m25,
     "smsAuthPlaceholder": MessageLookupByLibrary.simpleMessage("短信验证码"),
     "smsSetupSuccessDescription": MessageLookupByLibrary.simpleMessage(
       "The next time you log in, you will be prompted to enter the security code that will be sent to the phone number",
@@ -664,7 +672,7 @@ class MessageLookup extends MessageLookupByLibrary {
     "unableConnectToDevice": MessageLookupByLibrary.simpleMessage(
       "Unable connect to device",
     ),
-    "unableConnectToWifiBecauseNetworksWasntFoundByDevice": m24,
+    "unableConnectToWifiBecauseNetworksWasntFoundByDevice": m26,
     "unableToUseCamera": MessageLookupByLibrary.simpleMessage("无法使用摄像头"),
     "unacknowledged": MessageLookupByLibrary.simpleMessage("未确认"),
     "unassigned": MessageLookupByLibrary.simpleMessage("未分配"),
@@ -674,7 +682,7 @@ class MessageLookup extends MessageLookupByLibrary {
     "unsavedChanges": MessageLookupByLibrary.simpleMessage("Unsaved changes"),
     "update": MessageLookupByLibrary.simpleMessage("Update"),
     "updateRequired": MessageLookupByLibrary.simpleMessage("需要更新"),
-    "updateTo": m25,
+    "updateTo": m27,
     "url": MessageLookupByLibrary.simpleMessage("Url"),
     "user": MessageLookupByLibrary.simpleMessage("User"),
     "username": MessageLookupByLibrary.simpleMessage("用户名"),
@@ -693,9 +701,9 @@ class MessageLookup extends MessageLookupByLibrary {
     "warning": MessageLookupByLibrary.simpleMessage("警告"),
     "widgetType": MessageLookupByLibrary.simpleMessage("组件类型"),
     "widgetsBundle": MessageLookupByLibrary.simpleMessage("组件包"),
-    "wifiHelpMessage": m26,
+    "wifiHelpMessage": m28,
     "wifiPassword": MessageLookupByLibrary.simpleMessage("Wi-Fi 密码"),
-    "wifiPasswordMessage": m27,
+    "wifiPasswordMessage": m29,
     "yes": MessageLookupByLibrary.simpleMessage("是"),
     "yesDeactivate": MessageLookupByLibrary.simpleMessage("Yes, deactivate"),
     "yesDiscard": MessageLookupByLibrary.simpleMessage("Yes, discard"),

--- a/lib/generated/intl/messages_zh.dart
+++ b/lib/generated/intl/messages_zh.dart
@@ -598,7 +598,7 @@ class MessageLookup extends MessageLookupByLibrary {
     "searchUsers": m24,
     "seconds": MessageLookupByLibrary.simpleMessage("秒"),
     "security": MessageLookupByLibrary.simpleMessage("Security"),
-    "selectAll": MessageLookupByLibrary.simpleMessage("全选"),
+    "selectAll": MessageLookupByLibrary.simpleMessage("全选已加载"),
     "selectCountry": MessageLookupByLibrary.simpleMessage("Select country"),
     "selectRegion": MessageLookupByLibrary.simpleMessage("选择地区"),
     "selectUser": MessageLookupByLibrary.simpleMessage("选择用户"),

--- a/lib/generated/intl/messages_zh.dart
+++ b/lib/generated/intl/messages_zh.dart
@@ -53,36 +53,39 @@ class MessageLookup extends MessageLookupByLibrary {
 
   static String m12(e) => "Error occured: ${e}";
 
-  static String m14(count) => "已选择 ${count} 项";
+  static String m14(count) =>
+      "${Intl.plural(count, one: '1 项操作失败', other: '${count} 项操作失败')}";
 
-  static String m15(count) => "${Intl.plural(count, one: '通知', other: '通知')}";
+  static String m15(count) => "已选择 ${count} 项";
 
-  static String m16(permissions) =>
-      "您没有足够的\"${permissions}\"权限以继续。请打开应用设置，授予权限并点击\"再试一次\"。";
+  static String m16(count) => "${Intl.plural(count, one: '通知', other: '通知')}";
 
   static String m17(permissions) =>
+      "您没有足够的\"${permissions}\"权限以继续。请打开应用设置，授予权限并点击\"再试一次\"。";
+
+  static String m18(permissions) =>
       "您没有足够的\"${permissions}\"权限以继续。请授予所需权限并点击\"再试一次\"。";
 
-  static String m18(deviceName) => "输入 ${deviceName} 的PIN码以确认拥有权证明";
+  static String m19(deviceName) => "输入 ${deviceName} 的PIN码以确认拥有权证明";
 
-  static String m19(time) =>
+  static String m20(time) =>
       "在 ${Intl.plural(time, one: '1 秒', other: '${time} 秒')}内重新发送验证码";
 
-  static String m20(name) => "路由未定义: ${name}";
+  static String m21(name) => "路由未定义: ${name}";
 
-  static String m21(count) =>
+  static String m22(count) =>
       "${Intl.plural(count, one: '搜索用户', other: '搜索用户')}";
 
-  static String m22(contact) => "安全码已发送到您的手机 ${contact}。";
+  static String m23(contact) => "安全码已发送到您的手机 ${contact}。";
 
-  static String m23(name) =>
+  static String m24(name) =>
       "Unable connect to Wi-Fi because networks wasn\'t found by device ${name}";
 
-  static String m24(version) => "更新到 ${version}";
+  static String m25(version) => "更新到 ${version}";
 
-  static String m25(deviceName) => "要继续设置您的设备 ${deviceName}，请提供您网络的凭据。";
+  static String m26(deviceName) => "要继续设置您的设备 ${deviceName}，请提供您网络的凭据。";
 
-  static String m26(network) => "输入 ${network} 的密码";
+  static String m27(network) => "输入 ${network} 的密码";
 
   final messages = _notInlinedMessages(_notInlinedMessages);
   static Map<String, Function> _notInlinedMessages(_) => <String, Function>{
@@ -386,6 +389,7 @@ class MessageLookup extends MessageLookupByLibrary {
       "加载告警详情失败",
     ),
     "failedToLoadTheList": MessageLookupByLibrary.simpleMessage("加载列表失败"),
+    "failedToPerformOperation": m14,
     "failedToSaveImage": MessageLookupByLibrary.simpleMessage("保存图片失败"),
     "failureDetails": MessageLookupByLibrary.simpleMessage("失败详情"),
     "fatalApplicationErrorOccurred": MessageLookupByLibrary.simpleMessage(
@@ -461,7 +465,7 @@ class MessageLookup extends MessageLookupByLibrary {
           "Mobile dashboard should be configured in device profile!",
         ),
     "more": MessageLookupByLibrary.simpleMessage("更多"),
-    "nSelected": m14,
+    "nSelected": m15,
     "newPassword": MessageLookupByLibrary.simpleMessage("新密码"),
     "newPassword2": MessageLookupByLibrary.simpleMessage("确认新密码"),
     "newPassword2RequireText": MessageLookupByLibrary.simpleMessage("请再次输入新密码"),
@@ -488,12 +492,12 @@ class MessageLookup extends MessageLookupByLibrary {
     "notificationRule": MessageLookupByLibrary.simpleMessage("通知规则"),
     "notificationTarget": MessageLookupByLibrary.simpleMessage("通知目标"),
     "notificationTemplate": MessageLookupByLibrary.simpleMessage("通知模板"),
-    "notifications": m15,
+    "notifications": m16,
     "oauth2Client": MessageLookupByLibrary.simpleMessage("Oauth2 client"),
     "openAppSettings": MessageLookupByLibrary.simpleMessage(
       "Open app settings",
     ),
-    "openAppSettingsToGrantPermissionMessage": m16,
+    "openAppSettingsToGrantPermissionMessage": m17,
     "openSettingsAndGrantAccessToCameraToContinue":
         MessageLookupByLibrary.simpleMessage("打开设置并授予摄像头访问权限以继续"),
     "openWifiSettings": MessageLookupByLibrary.simpleMessage(
@@ -518,7 +522,7 @@ class MessageLookup extends MessageLookupByLibrary {
       "密码修改成功",
     ),
     "permissions": MessageLookupByLibrary.simpleMessage("Permissions"),
-    "permissionsNotEnoughMessage": m17,
+    "permissionsNotEnoughMessage": m18,
     "phone": MessageLookupByLibrary.simpleMessage("电话"),
     "phoneIsInvalid": MessageLookupByLibrary.simpleMessage("Phone is invalid"),
     "phoneIsRequired": MessageLookupByLibrary.simpleMessage(
@@ -543,7 +547,7 @@ class MessageLookup extends MessageLookupByLibrary {
       "Please scan QR code on your device",
     ),
     "plusAlarmType": MessageLookupByLibrary.simpleMessage("+ Alarm type"),
-    "popTitle": m18,
+    "popTitle": m19,
     "postalCode": MessageLookupByLibrary.simpleMessage("邮编"),
     "privacyPolicy": MessageLookupByLibrary.simpleMessage("隐私政策"),
     "profile": MessageLookupByLibrary.simpleMessage("Profile"),
@@ -566,7 +570,7 @@ class MessageLookup extends MessageLookupByLibrary {
     ),
     "resend": MessageLookupByLibrary.simpleMessage("重新发送"),
     "resendCode": MessageLookupByLibrary.simpleMessage("重新发送验证码"),
-    "resendCodeWait": m19,
+    "resendCodeWait": m20,
     "reset": MessageLookupByLibrary.simpleMessage("Reset"),
     "retry": MessageLookupByLibrary.simpleMessage("Retry"),
     "returnToDashboard": MessageLookupByLibrary.simpleMessage("返回仪表板"),
@@ -574,7 +578,7 @@ class MessageLookup extends MessageLookupByLibrary {
       "Return to the app and tap Ready button",
     ),
     "role": MessageLookupByLibrary.simpleMessage("角色"),
-    "routeNotDefined": m20,
+    "routeNotDefined": m21,
     "rpc": MessageLookupByLibrary.simpleMessage("RPC"),
     "ruleChain": MessageLookupByLibrary.simpleMessage("规则链"),
     "ruleNode": MessageLookupByLibrary.simpleMessage("规则节点"),
@@ -583,7 +587,7 @@ class MessageLookup extends MessageLookupByLibrary {
     "schedulerEvent": MessageLookupByLibrary.simpleMessage("调度事件"),
     "search": MessageLookupByLibrary.simpleMessage("Search"),
     "searchResults": MessageLookupByLibrary.simpleMessage("搜索结果"),
-    "searchUsers": m21,
+    "searchUsers": m22,
     "seconds": MessageLookupByLibrary.simpleMessage("秒"),
     "security": MessageLookupByLibrary.simpleMessage("Security"),
     "selectAll": MessageLookupByLibrary.simpleMessage("全选"),
@@ -608,7 +612,7 @@ class MessageLookup extends MessageLookupByLibrary {
     "severity": MessageLookupByLibrary.simpleMessage("严重程度"),
     "signIn": MessageLookupByLibrary.simpleMessage("登录"),
     "signUp": MessageLookupByLibrary.simpleMessage("注册"),
-    "smsAuthDescription": m22,
+    "smsAuthDescription": m23,
     "smsAuthPlaceholder": MessageLookupByLibrary.simpleMessage("短信验证码"),
     "smsSetupSuccessDescription": MessageLookupByLibrary.simpleMessage(
       "The next time you log in, you will be prompted to enter the security code that will be sent to the phone number",
@@ -660,7 +664,7 @@ class MessageLookup extends MessageLookupByLibrary {
     "unableConnectToDevice": MessageLookupByLibrary.simpleMessage(
       "Unable connect to device",
     ),
-    "unableConnectToWifiBecauseNetworksWasntFoundByDevice": m23,
+    "unableConnectToWifiBecauseNetworksWasntFoundByDevice": m24,
     "unableToUseCamera": MessageLookupByLibrary.simpleMessage("无法使用摄像头"),
     "unacknowledged": MessageLookupByLibrary.simpleMessage("未确认"),
     "unassigned": MessageLookupByLibrary.simpleMessage("未分配"),
@@ -670,7 +674,7 @@ class MessageLookup extends MessageLookupByLibrary {
     "unsavedChanges": MessageLookupByLibrary.simpleMessage("Unsaved changes"),
     "update": MessageLookupByLibrary.simpleMessage("Update"),
     "updateRequired": MessageLookupByLibrary.simpleMessage("需要更新"),
-    "updateTo": m24,
+    "updateTo": m25,
     "url": MessageLookupByLibrary.simpleMessage("Url"),
     "user": MessageLookupByLibrary.simpleMessage("User"),
     "username": MessageLookupByLibrary.simpleMessage("用户名"),
@@ -689,9 +693,9 @@ class MessageLookup extends MessageLookupByLibrary {
     "warning": MessageLookupByLibrary.simpleMessage("警告"),
     "widgetType": MessageLookupByLibrary.simpleMessage("组件类型"),
     "widgetsBundle": MessageLookupByLibrary.simpleMessage("组件包"),
-    "wifiHelpMessage": m25,
+    "wifiHelpMessage": m26,
     "wifiPassword": MessageLookupByLibrary.simpleMessage("Wi-Fi 密码"),
-    "wifiPasswordMessage": m26,
+    "wifiPasswordMessage": m27,
     "yes": MessageLookupByLibrary.simpleMessage("是"),
     "yesDeactivate": MessageLookupByLibrary.simpleMessage("Yes, deactivate"),
     "yesDiscard": MessageLookupByLibrary.simpleMessage("Yes, discard"),

--- a/lib/generated/intl/messages_zh.dart
+++ b/lib/generated/intl/messages_zh.dart
@@ -53,34 +53,36 @@ class MessageLookup extends MessageLookupByLibrary {
 
   static String m12(e) => "Error occured: ${e}";
 
-  static String m14(count) => "${Intl.plural(count, one: '通知', other: '通知')}";
+  static String m14(count) => "已选择 ${count} 项";
 
-  static String m15(permissions) =>
-      "您没有足够的\"${permissions}\"权限以继续。请打开应用设置，授予权限并点击\"再试一次\"。";
+  static String m15(count) => "${Intl.plural(count, one: '通知', other: '通知')}";
 
   static String m16(permissions) =>
+      "您没有足够的\"${permissions}\"权限以继续。请打开应用设置，授予权限并点击\"再试一次\"。";
+
+  static String m17(permissions) =>
       "您没有足够的\"${permissions}\"权限以继续。请授予所需权限并点击\"再试一次\"。";
 
-  static String m17(deviceName) => "输入 ${deviceName} 的PIN码以确认拥有权证明";
+  static String m18(deviceName) => "输入 ${deviceName} 的PIN码以确认拥有权证明";
 
-  static String m18(time) =>
+  static String m19(time) =>
       "在 ${Intl.plural(time, one: '1 秒', other: '${time} 秒')}内重新发送验证码";
 
-  static String m19(name) => "路由未定义: ${name}";
+  static String m20(name) => "路由未定义: ${name}";
 
-  static String m20(count) =>
+  static String m21(count) =>
       "${Intl.plural(count, one: '搜索用户', other: '搜索用户')}";
 
-  static String m21(contact) => "安全码已发送到您的手机 ${contact}。";
+  static String m22(contact) => "安全码已发送到您的手机 ${contact}。";
 
-  static String m22(name) =>
+  static String m23(name) =>
       "Unable connect to Wi-Fi because networks wasn\'t found by device ${name}";
 
-  static String m23(version) => "更新到 ${version}";
+  static String m24(version) => "更新到 ${version}";
 
-  static String m24(deviceName) => "要继续设置您的设备 ${deviceName}，请提供您网络的凭据。";
+  static String m25(deviceName) => "要继续设置您的设备 ${deviceName}，请提供您网络的凭据。";
 
-  static String m25(network) => "输入 ${network} 的密码";
+  static String m26(network) => "输入 ${network} 的密码";
 
   final messages = _notInlinedMessages(_notInlinedMessages);
   static Map<String, Function> _notInlinedMessages(_) => <String, Function>{
@@ -459,6 +461,7 @@ class MessageLookup extends MessageLookupByLibrary {
           "Mobile dashboard should be configured in device profile!",
         ),
     "more": MessageLookupByLibrary.simpleMessage("更多"),
+    "nSelected": m14,
     "newPassword": MessageLookupByLibrary.simpleMessage("新密码"),
     "newPassword2": MessageLookupByLibrary.simpleMessage("确认新密码"),
     "newPassword2RequireText": MessageLookupByLibrary.simpleMessage("请再次输入新密码"),
@@ -485,12 +488,12 @@ class MessageLookup extends MessageLookupByLibrary {
     "notificationRule": MessageLookupByLibrary.simpleMessage("通知规则"),
     "notificationTarget": MessageLookupByLibrary.simpleMessage("通知目标"),
     "notificationTemplate": MessageLookupByLibrary.simpleMessage("通知模板"),
-    "notifications": m14,
+    "notifications": m15,
     "oauth2Client": MessageLookupByLibrary.simpleMessage("Oauth2 client"),
     "openAppSettings": MessageLookupByLibrary.simpleMessage(
       "Open app settings",
     ),
-    "openAppSettingsToGrantPermissionMessage": m15,
+    "openAppSettingsToGrantPermissionMessage": m16,
     "openSettingsAndGrantAccessToCameraToContinue":
         MessageLookupByLibrary.simpleMessage("打开设置并授予摄像头访问权限以继续"),
     "openWifiSettings": MessageLookupByLibrary.simpleMessage(
@@ -515,7 +518,7 @@ class MessageLookup extends MessageLookupByLibrary {
       "密码修改成功",
     ),
     "permissions": MessageLookupByLibrary.simpleMessage("Permissions"),
-    "permissionsNotEnoughMessage": m16,
+    "permissionsNotEnoughMessage": m17,
     "phone": MessageLookupByLibrary.simpleMessage("电话"),
     "phoneIsInvalid": MessageLookupByLibrary.simpleMessage("Phone is invalid"),
     "phoneIsRequired": MessageLookupByLibrary.simpleMessage(
@@ -540,7 +543,7 @@ class MessageLookup extends MessageLookupByLibrary {
       "Please scan QR code on your device",
     ),
     "plusAlarmType": MessageLookupByLibrary.simpleMessage("+ Alarm type"),
-    "popTitle": m17,
+    "popTitle": m18,
     "postalCode": MessageLookupByLibrary.simpleMessage("邮编"),
     "privacyPolicy": MessageLookupByLibrary.simpleMessage("隐私政策"),
     "profile": MessageLookupByLibrary.simpleMessage("Profile"),
@@ -563,7 +566,7 @@ class MessageLookup extends MessageLookupByLibrary {
     ),
     "resend": MessageLookupByLibrary.simpleMessage("重新发送"),
     "resendCode": MessageLookupByLibrary.simpleMessage("重新发送验证码"),
-    "resendCodeWait": m18,
+    "resendCodeWait": m19,
     "reset": MessageLookupByLibrary.simpleMessage("Reset"),
     "retry": MessageLookupByLibrary.simpleMessage("Retry"),
     "returnToDashboard": MessageLookupByLibrary.simpleMessage("返回仪表板"),
@@ -571,7 +574,7 @@ class MessageLookup extends MessageLookupByLibrary {
       "Return to the app and tap Ready button",
     ),
     "role": MessageLookupByLibrary.simpleMessage("角色"),
-    "routeNotDefined": m19,
+    "routeNotDefined": m20,
     "rpc": MessageLookupByLibrary.simpleMessage("RPC"),
     "ruleChain": MessageLookupByLibrary.simpleMessage("规则链"),
     "ruleNode": MessageLookupByLibrary.simpleMessage("规则节点"),
@@ -580,9 +583,10 @@ class MessageLookup extends MessageLookupByLibrary {
     "schedulerEvent": MessageLookupByLibrary.simpleMessage("调度事件"),
     "search": MessageLookupByLibrary.simpleMessage("Search"),
     "searchResults": MessageLookupByLibrary.simpleMessage("搜索结果"),
-    "searchUsers": m20,
+    "searchUsers": m21,
     "seconds": MessageLookupByLibrary.simpleMessage("秒"),
     "security": MessageLookupByLibrary.simpleMessage("Security"),
+    "selectAll": MessageLookupByLibrary.simpleMessage("全选"),
     "selectCountry": MessageLookupByLibrary.simpleMessage("Select country"),
     "selectRegion": MessageLookupByLibrary.simpleMessage("选择地区"),
     "selectUser": MessageLookupByLibrary.simpleMessage("选择用户"),
@@ -604,7 +608,7 @@ class MessageLookup extends MessageLookupByLibrary {
     "severity": MessageLookupByLibrary.simpleMessage("严重程度"),
     "signIn": MessageLookupByLibrary.simpleMessage("登录"),
     "signUp": MessageLookupByLibrary.simpleMessage("注册"),
-    "smsAuthDescription": m21,
+    "smsAuthDescription": m22,
     "smsAuthPlaceholder": MessageLookupByLibrary.simpleMessage("短信验证码"),
     "smsSetupSuccessDescription": MessageLookupByLibrary.simpleMessage(
       "The next time you log in, you will be prompted to enter the security code that will be sent to the phone number",
@@ -656,7 +660,7 @@ class MessageLookup extends MessageLookupByLibrary {
     "unableConnectToDevice": MessageLookupByLibrary.simpleMessage(
       "Unable connect to device",
     ),
-    "unableConnectToWifiBecauseNetworksWasntFoundByDevice": m22,
+    "unableConnectToWifiBecauseNetworksWasntFoundByDevice": m23,
     "unableToUseCamera": MessageLookupByLibrary.simpleMessage("无法使用摄像头"),
     "unacknowledged": MessageLookupByLibrary.simpleMessage("未确认"),
     "unassigned": MessageLookupByLibrary.simpleMessage("未分配"),
@@ -666,7 +670,7 @@ class MessageLookup extends MessageLookupByLibrary {
     "unsavedChanges": MessageLookupByLibrary.simpleMessage("Unsaved changes"),
     "update": MessageLookupByLibrary.simpleMessage("Update"),
     "updateRequired": MessageLookupByLibrary.simpleMessage("需要更新"),
-    "updateTo": m23,
+    "updateTo": m24,
     "url": MessageLookupByLibrary.simpleMessage("Url"),
     "user": MessageLookupByLibrary.simpleMessage("User"),
     "username": MessageLookupByLibrary.simpleMessage("用户名"),
@@ -685,9 +689,9 @@ class MessageLookup extends MessageLookupByLibrary {
     "warning": MessageLookupByLibrary.simpleMessage("警告"),
     "widgetType": MessageLookupByLibrary.simpleMessage("组件类型"),
     "widgetsBundle": MessageLookupByLibrary.simpleMessage("组件包"),
-    "wifiHelpMessage": m24,
+    "wifiHelpMessage": m25,
     "wifiPassword": MessageLookupByLibrary.simpleMessage("Wi-Fi 密码"),
-    "wifiPasswordMessage": m25,
+    "wifiPasswordMessage": m26,
     "yes": MessageLookupByLibrary.simpleMessage("是"),
     "yesDeactivate": MessageLookupByLibrary.simpleMessage("Yes, deactivate"),
     "yesDiscard": MessageLookupByLibrary.simpleMessage("Yes, discard"),

--- a/lib/generated/intl/messages_zh_CN.dart
+++ b/lib/generated/intl/messages_zh_CN.dart
@@ -50,33 +50,35 @@ class MessageLookup extends MessageLookupByLibrary {
 
   static String m13(error) => "发送验证码错误：${error}";
 
-  static String m14(count) => "${Intl.plural(count, one: '通知', other: '通知')}";
+  static String m14(count) => "已选择 ${count} 项";
 
-  static String m15(permissions) =>
-      "您没有足够的\"${permissions}\"权限以继续。请打开应用设置，授予权限并点击\"再试一次\"。";
+  static String m15(count) => "${Intl.plural(count, one: '通知', other: '通知')}";
 
   static String m16(permissions) =>
+      "您没有足够的\"${permissions}\"权限以继续。请打开应用设置，授予权限并点击\"再试一次\"。";
+
+  static String m17(permissions) =>
       "您没有足够的\"${permissions}\"权限以继续。请授予所需权限并点击\"再试一次\"。";
 
-  static String m17(deviceName) => "输入 ${deviceName} 的PIN码以确认拥有权证明";
+  static String m18(deviceName) => "输入 ${deviceName} 的PIN码以确认拥有权证明";
 
-  static String m18(time) =>
+  static String m19(time) =>
       "在 ${Intl.plural(time, one: '1 秒', other: '${time} 秒')}内重新发送验证码";
 
-  static String m19(name) => "路由未定义: ${name}";
+  static String m20(name) => "路由未定义: ${name}";
 
-  static String m20(count) =>
+  static String m21(count) =>
       "${Intl.plural(count, one: '搜索用户', other: '搜索用户')}";
 
-  static String m21(contact) => "安全码已发送到您的手机 ${contact}。";
+  static String m22(contact) => "安全码已发送到您的手机 ${contact}。";
 
-  static String m22(name) => "无法连接 Wi-Fi，因为设备 ${name} 未找到网络";
+  static String m23(name) => "无法连接 Wi-Fi，因为设备 ${name} 未找到网络";
 
-  static String m23(version) => "更新到 ${version}";
+  static String m24(version) => "更新到 ${version}";
 
-  static String m24(deviceName) => "要继续设置您的设备 ${deviceName}，请提供您网络的凭据。";
+  static String m25(deviceName) => "要继续设置您的设备 ${deviceName}，请提供您网络的凭据。";
 
-  static String m25(network) => "输入 ${network} 的密码";
+  static String m26(network) => "输入 ${network} 的密码";
 
   final messages = _notInlinedMessages(_notInlinedMessages);
   static Map<String, Function> _notInlinedMessages(_) => <String, Function>{
@@ -406,6 +408,7 @@ class MessageLookup extends MessageLookupByLibrary {
     "mobileDashboardShouldBeConfiguredInDeviceProfile":
         MessageLookupByLibrary.simpleMessage("需要在设备配置文件中配置移动仪表板！"),
     "more": MessageLookupByLibrary.simpleMessage("更多"),
+    "nSelected": m14,
     "newPassword": MessageLookupByLibrary.simpleMessage("新密码"),
     "newPassword2": MessageLookupByLibrary.simpleMessage("确认新密码"),
     "newPassword2RequireText": MessageLookupByLibrary.simpleMessage("请再次输入新密码"),
@@ -426,10 +429,10 @@ class MessageLookup extends MessageLookupByLibrary {
     "notificationRule": MessageLookupByLibrary.simpleMessage("通知规则"),
     "notificationTarget": MessageLookupByLibrary.simpleMessage("通知目标"),
     "notificationTemplate": MessageLookupByLibrary.simpleMessage("通知模板"),
-    "notifications": m14,
+    "notifications": m15,
     "oauth2Client": MessageLookupByLibrary.simpleMessage("OAuth2 客户端"),
     "openAppSettings": MessageLookupByLibrary.simpleMessage("打开应用设置"),
-    "openAppSettingsToGrantPermissionMessage": m15,
+    "openAppSettingsToGrantPermissionMessage": m16,
     "openSettingsAndGrantAccessToCameraToContinue":
         MessageLookupByLibrary.simpleMessage("打开设置并授予摄像头访问权限以继续"),
     "openWifiSettings": MessageLookupByLibrary.simpleMessage("打开 Wi-Fi 设置"),
@@ -452,7 +455,7 @@ class MessageLookup extends MessageLookupByLibrary {
       "密码修改成功",
     ),
     "permissions": MessageLookupByLibrary.simpleMessage("权限"),
-    "permissionsNotEnoughMessage": m16,
+    "permissionsNotEnoughMessage": m17,
     "phone": MessageLookupByLibrary.simpleMessage("电话"),
     "phoneIsInvalid": MessageLookupByLibrary.simpleMessage("手机号码无效"),
     "phoneIsRequired": MessageLookupByLibrary.simpleMessage("手机号码是必填项"),
@@ -469,7 +472,7 @@ class MessageLookup extends MessageLookupByLibrary {
       "请扫描您设备上的二维码",
     ),
     "plusAlarmType": MessageLookupByLibrary.simpleMessage("+ 告警类型"),
-    "popTitle": m17,
+    "popTitle": m18,
     "postalCode": MessageLookupByLibrary.simpleMessage("邮编"),
     "privacyPolicy": MessageLookupByLibrary.simpleMessage("隐私政策"),
     "profile": MessageLookupByLibrary.simpleMessage("个人资料"),
@@ -490,7 +493,7 @@ class MessageLookup extends MessageLookupByLibrary {
     ),
     "resend": MessageLookupByLibrary.simpleMessage("重新发送"),
     "resendCode": MessageLookupByLibrary.simpleMessage("重新发送验证码"),
-    "resendCodeWait": m18,
+    "resendCodeWait": m19,
     "reset": MessageLookupByLibrary.simpleMessage("重置"),
     "retry": MessageLookupByLibrary.simpleMessage("重试"),
     "returnToDashboard": MessageLookupByLibrary.simpleMessage("返回仪表板"),
@@ -498,7 +501,7 @@ class MessageLookup extends MessageLookupByLibrary {
       "返回应用并点击准备好按钮",
     ),
     "role": MessageLookupByLibrary.simpleMessage("角色"),
-    "routeNotDefined": m19,
+    "routeNotDefined": m20,
     "rpc": MessageLookupByLibrary.simpleMessage("RPC"),
     "ruleChain": MessageLookupByLibrary.simpleMessage("规则链"),
     "ruleNode": MessageLookupByLibrary.simpleMessage("规则节点"),
@@ -507,9 +510,10 @@ class MessageLookup extends MessageLookupByLibrary {
     "schedulerEvent": MessageLookupByLibrary.simpleMessage("调度事件"),
     "search": MessageLookupByLibrary.simpleMessage("搜索"),
     "searchResults": MessageLookupByLibrary.simpleMessage("搜索结果"),
-    "searchUsers": m20,
+    "searchUsers": m21,
     "seconds": MessageLookupByLibrary.simpleMessage("秒"),
     "security": MessageLookupByLibrary.simpleMessage("安全"),
+    "selectAll": MessageLookupByLibrary.simpleMessage("全选"),
     "selectCountry": MessageLookupByLibrary.simpleMessage("选择国家"),
     "selectRegion": MessageLookupByLibrary.simpleMessage("选择地区"),
     "selectUser": MessageLookupByLibrary.simpleMessage("选择用户"),
@@ -525,7 +529,7 @@ class MessageLookup extends MessageLookupByLibrary {
     "severity": MessageLookupByLibrary.simpleMessage("严重程度"),
     "signIn": MessageLookupByLibrary.simpleMessage("登录"),
     "signUp": MessageLookupByLibrary.simpleMessage("注册"),
-    "smsAuthDescription": m21,
+    "smsAuthDescription": m22,
     "smsAuthPlaceholder": MessageLookupByLibrary.simpleMessage("短信验证码"),
     "smsSetupSuccessDescription": MessageLookupByLibrary.simpleMessage(
       "下次登录时，您将需要输入发送到手机号码的安全码",
@@ -571,7 +575,7 @@ class MessageLookup extends MessageLookupByLibrary {
         ),
     "type": MessageLookupByLibrary.simpleMessage("类型"),
     "unableConnectToDevice": MessageLookupByLibrary.simpleMessage("无法连接到设备"),
-    "unableConnectToWifiBecauseNetworksWasntFoundByDevice": m22,
+    "unableConnectToWifiBecauseNetworksWasntFoundByDevice": m23,
     "unableToUseCamera": MessageLookupByLibrary.simpleMessage("无法使用摄像头"),
     "unacknowledged": MessageLookupByLibrary.simpleMessage("未确认"),
     "unassigned": MessageLookupByLibrary.simpleMessage("未分配"),
@@ -581,7 +585,7 @@ class MessageLookup extends MessageLookupByLibrary {
     "unsavedChanges": MessageLookupByLibrary.simpleMessage("未保存的更改"),
     "update": MessageLookupByLibrary.simpleMessage("更新"),
     "updateRequired": MessageLookupByLibrary.simpleMessage("需要更新"),
-    "updateTo": m23,
+    "updateTo": m24,
     "url": MessageLookupByLibrary.simpleMessage("链接"),
     "user": MessageLookupByLibrary.simpleMessage("用户"),
     "username": MessageLookupByLibrary.simpleMessage("用户名"),
@@ -598,9 +602,9 @@ class MessageLookup extends MessageLookupByLibrary {
     "warning": MessageLookupByLibrary.simpleMessage("警告"),
     "widgetType": MessageLookupByLibrary.simpleMessage("组件类型"),
     "widgetsBundle": MessageLookupByLibrary.simpleMessage("组件包"),
-    "wifiHelpMessage": m24,
+    "wifiHelpMessage": m25,
     "wifiPassword": MessageLookupByLibrary.simpleMessage("Wi-Fi 密码"),
-    "wifiPasswordMessage": m25,
+    "wifiPasswordMessage": m26,
     "yes": MessageLookupByLibrary.simpleMessage("是"),
     "yesDeactivate": MessageLookupByLibrary.simpleMessage("是的，停用"),
     "yesDiscard": MessageLookupByLibrary.simpleMessage("是的，放弃"),

--- a/lib/generated/intl/messages_zh_CN.dart
+++ b/lib/generated/intl/messages_zh_CN.dart
@@ -40,48 +40,54 @@ class MessageLookup extends MessageLookupByLibrary {
 
   static String m8(count) => "${Intl.plural(count, one: '仪表板', other: '仪表板')}";
 
-  static String m9(count) => "${Intl.plural(count, one: '设备', other: '设备')}";
+  static String m9(count) =>
+      "${Intl.plural(count, one: '删除 1 条通知？', other: '删除 ${count} 条通知？')}";
 
-  static String m10(count) => "${count}位数验证码";
+  static String m10(count) => "${Intl.plural(count, one: '设备', other: '设备')}";
 
-  static String m11(contact) => "安全码已发送到您的邮箱 ${contact}。";
+  static String m11(count) => "${count}位数验证码";
 
-  static String m12(e) => "发生错误：${e}";
+  static String m12(contact) => "安全码已发送到您的邮箱 ${contact}。";
 
-  static String m13(error) => "发送验证码错误：${error}";
+  static String m13(e) => "发生错误：${e}";
 
-  static String m14(count) =>
+  static String m14(error) => "发送验证码错误：${error}";
+
+  static String m15(count) =>
       "${Intl.plural(count, one: '1 项操作失败', other: '${count} 项操作失败')}";
 
-  static String m15(count) => "已选择 ${count} 项";
+  static String m16(count) =>
+      "${Intl.plural(count, one: '将 1 条通知标记为已读？', other: '将 ${count} 条通知标记为已读？')}";
 
-  static String m16(count) => "${Intl.plural(count, one: '通知', other: '通知')}";
+  static String m17(count) => "已选择 ${count} 项";
 
-  static String m17(permissions) =>
+  static String m18(count) => "${Intl.plural(count, one: '通知', other: '通知')}";
+
+  static String m19(permissions) =>
       "您没有足够的\"${permissions}\"权限以继续。请打开应用设置，授予权限并点击\"再试一次\"。";
 
-  static String m18(permissions) =>
+  static String m20(permissions) =>
       "您没有足够的\"${permissions}\"权限以继续。请授予所需权限并点击\"再试一次\"。";
 
-  static String m19(deviceName) => "输入 ${deviceName} 的PIN码以确认拥有权证明";
+  static String m21(deviceName) => "输入 ${deviceName} 的PIN码以确认拥有权证明";
 
-  static String m20(time) =>
+  static String m22(time) =>
       "在 ${Intl.plural(time, one: '1 秒', other: '${time} 秒')}内重新发送验证码";
 
-  static String m21(name) => "路由未定义: ${name}";
+  static String m23(name) => "路由未定义: ${name}";
 
-  static String m22(count) =>
+  static String m24(count) =>
       "${Intl.plural(count, one: '搜索用户', other: '搜索用户')}";
 
-  static String m23(contact) => "安全码已发送到您的手机 ${contact}。";
+  static String m25(contact) => "安全码已发送到您的手机 ${contact}。";
 
-  static String m24(name) => "无法连接 Wi-Fi，因为设备 ${name} 未找到网络";
+  static String m26(name) => "无法连接 Wi-Fi，因为设备 ${name} 未找到网络";
 
-  static String m25(version) => "更新到 ${version}";
+  static String m27(version) => "更新到 ${version}";
 
-  static String m26(deviceName) => "要继续设置您的设备 ${deviceName}，请提供您网络的凭据。";
+  static String m28(deviceName) => "要继续设置您的设备 ${deviceName}，请提供您网络的凭据。";
 
-  static String m27(network) => "输入 ${network} 的密码";
+  static String m29(network) => "输入 ${network} 的密码";
 
   final messages = _notInlinedMessages(_notInlinedMessages);
   static Map<String, Function> _notInlinedMessages(_) => <String, Function>{
@@ -283,6 +289,7 @@ class MessageLookup extends MessageLookupByLibrary {
     "delete": MessageLookupByLibrary.simpleMessage("删除"),
     "deleteAccount": MessageLookupByLibrary.simpleMessage("删除账户"),
     "deleteComment": MessageLookupByLibrary.simpleMessage("删除评论"),
+    "deleteSelectedNotifications": m9,
     "details": MessageLookupByLibrary.simpleMessage("详情"),
     "deviceList": MessageLookupByLibrary.simpleMessage("设备列表"),
     "deviceNotAbleToFindWifiNearby": MessageLookupByLibrary.simpleMessage(
@@ -293,8 +300,8 @@ class MessageLookup extends MessageLookupByLibrary {
     ),
     "deviceProfile": MessageLookupByLibrary.simpleMessage("设备配置文件"),
     "deviceProvisioning": MessageLookupByLibrary.simpleMessage("设备配置"),
-    "devices": m9,
-    "digitsCode": m10,
+    "devices": m10,
+    "digitsCode": m11,
     "discardChanges": MessageLookupByLibrary.simpleMessage("放弃更改"),
     "domain": MessageLookupByLibrary.simpleMessage("域名"),
     "done": MessageLookupByLibrary.simpleMessage("完成"),
@@ -303,7 +310,7 @@ class MessageLookup extends MessageLookupByLibrary {
     "edit": MessageLookupByLibrary.simpleMessage("编辑"),
     "edited": MessageLookupByLibrary.simpleMessage("已编辑"),
     "email": MessageLookupByLibrary.simpleMessage("邮箱"),
-    "emailAuthDescription": m11,
+    "emailAuthDescription": m12,
     "emailAuthPlaceholder": MessageLookupByLibrary.simpleMessage("邮箱验证码"),
     "emailInvalidText": MessageLookupByLibrary.simpleMessage("邮箱格式无效"),
     "emailRequireText": MessageLookupByLibrary.simpleMessage("邮箱是必填项"),
@@ -330,8 +337,8 @@ class MessageLookup extends MessageLookupByLibrary {
     "entityGroup": MessageLookupByLibrary.simpleMessage("实体组"),
     "entityType": MessageLookupByLibrary.simpleMessage("实体类型"),
     "entityView": MessageLookupByLibrary.simpleMessage("实体视图"),
-    "errorOccured": m12,
-    "errorSendingCode": m13,
+    "errorOccured": m13,
+    "errorSendingCode": m14,
     "europe": MessageLookupByLibrary.simpleMessage("欧洲"),
     "europeRegionShort": MessageLookupByLibrary.simpleMessage("法兰克福"),
     "exitDeviceProvisioning": MessageLookupByLibrary.simpleMessage("退出设备配置"),
@@ -340,7 +347,7 @@ class MessageLookup extends MessageLookupByLibrary {
       "加载告警详情失败",
     ),
     "failedToLoadTheList": MessageLookupByLibrary.simpleMessage("加载列表失败"),
-    "failedToPerformOperation": m14,
+    "failedToPerformOperation": m15,
     "failedToSaveImage": MessageLookupByLibrary.simpleMessage("保存图片失败"),
     "failureDetails": MessageLookupByLibrary.simpleMessage("失败详情"),
     "fatalApplicationErrorOccurred": MessageLookupByLibrary.simpleMessage(
@@ -400,6 +407,7 @@ class MessageLookup extends MessageLookupByLibrary {
     "major": MessageLookupByLibrary.simpleMessage("重要"),
     "markAllAsRead": MessageLookupByLibrary.simpleMessage("全部标记为已读"),
     "markAsRead": MessageLookupByLibrary.simpleMessage("标记为已读"),
+    "markSelectedNotificationsAsRead": m16,
     "metricUnitSystem": MessageLookupByLibrary.simpleMessage("公制"),
     "mfaProviderBackupCode": MessageLookupByLibrary.simpleMessage("备份码"),
     "mfaProviderEmail": MessageLookupByLibrary.simpleMessage("邮箱"),
@@ -412,7 +420,7 @@ class MessageLookup extends MessageLookupByLibrary {
     "mobileDashboardShouldBeConfiguredInDeviceProfile":
         MessageLookupByLibrary.simpleMessage("需要在设备配置文件中配置移动仪表板！"),
     "more": MessageLookupByLibrary.simpleMessage("更多"),
-    "nSelected": m15,
+    "nSelected": m17,
     "newPassword": MessageLookupByLibrary.simpleMessage("新密码"),
     "newPassword2": MessageLookupByLibrary.simpleMessage("确认新密码"),
     "newPassword2RequireText": MessageLookupByLibrary.simpleMessage("请再次输入新密码"),
@@ -433,10 +441,10 @@ class MessageLookup extends MessageLookupByLibrary {
     "notificationRule": MessageLookupByLibrary.simpleMessage("通知规则"),
     "notificationTarget": MessageLookupByLibrary.simpleMessage("通知目标"),
     "notificationTemplate": MessageLookupByLibrary.simpleMessage("通知模板"),
-    "notifications": m16,
+    "notifications": m18,
     "oauth2Client": MessageLookupByLibrary.simpleMessage("OAuth2 客户端"),
     "openAppSettings": MessageLookupByLibrary.simpleMessage("打开应用设置"),
-    "openAppSettingsToGrantPermissionMessage": m17,
+    "openAppSettingsToGrantPermissionMessage": m19,
     "openSettingsAndGrantAccessToCameraToContinue":
         MessageLookupByLibrary.simpleMessage("打开设置并授予摄像头访问权限以继续"),
     "openWifiSettings": MessageLookupByLibrary.simpleMessage("打开 Wi-Fi 设置"),
@@ -459,7 +467,7 @@ class MessageLookup extends MessageLookupByLibrary {
       "密码修改成功",
     ),
     "permissions": MessageLookupByLibrary.simpleMessage("权限"),
-    "permissionsNotEnoughMessage": m18,
+    "permissionsNotEnoughMessage": m20,
     "phone": MessageLookupByLibrary.simpleMessage("电话"),
     "phoneIsInvalid": MessageLookupByLibrary.simpleMessage("手机号码无效"),
     "phoneIsRequired": MessageLookupByLibrary.simpleMessage("手机号码是必填项"),
@@ -476,7 +484,7 @@ class MessageLookup extends MessageLookupByLibrary {
       "请扫描您设备上的二维码",
     ),
     "plusAlarmType": MessageLookupByLibrary.simpleMessage("+ 告警类型"),
-    "popTitle": m19,
+    "popTitle": m21,
     "postalCode": MessageLookupByLibrary.simpleMessage("邮编"),
     "privacyPolicy": MessageLookupByLibrary.simpleMessage("隐私政策"),
     "profile": MessageLookupByLibrary.simpleMessage("个人资料"),
@@ -497,7 +505,7 @@ class MessageLookup extends MessageLookupByLibrary {
     ),
     "resend": MessageLookupByLibrary.simpleMessage("重新发送"),
     "resendCode": MessageLookupByLibrary.simpleMessage("重新发送验证码"),
-    "resendCodeWait": m20,
+    "resendCodeWait": m22,
     "reset": MessageLookupByLibrary.simpleMessage("重置"),
     "retry": MessageLookupByLibrary.simpleMessage("重试"),
     "returnToDashboard": MessageLookupByLibrary.simpleMessage("返回仪表板"),
@@ -505,7 +513,7 @@ class MessageLookup extends MessageLookupByLibrary {
       "返回应用并点击准备好按钮",
     ),
     "role": MessageLookupByLibrary.simpleMessage("角色"),
-    "routeNotDefined": m21,
+    "routeNotDefined": m23,
     "rpc": MessageLookupByLibrary.simpleMessage("RPC"),
     "ruleChain": MessageLookupByLibrary.simpleMessage("规则链"),
     "ruleNode": MessageLookupByLibrary.simpleMessage("规则节点"),
@@ -514,7 +522,7 @@ class MessageLookup extends MessageLookupByLibrary {
     "schedulerEvent": MessageLookupByLibrary.simpleMessage("调度事件"),
     "search": MessageLookupByLibrary.simpleMessage("搜索"),
     "searchResults": MessageLookupByLibrary.simpleMessage("搜索结果"),
-    "searchUsers": m22,
+    "searchUsers": m24,
     "seconds": MessageLookupByLibrary.simpleMessage("秒"),
     "security": MessageLookupByLibrary.simpleMessage("安全"),
     "selectAll": MessageLookupByLibrary.simpleMessage("全选"),
@@ -533,7 +541,7 @@ class MessageLookup extends MessageLookupByLibrary {
     "severity": MessageLookupByLibrary.simpleMessage("严重程度"),
     "signIn": MessageLookupByLibrary.simpleMessage("登录"),
     "signUp": MessageLookupByLibrary.simpleMessage("注册"),
-    "smsAuthDescription": m23,
+    "smsAuthDescription": m25,
     "smsAuthPlaceholder": MessageLookupByLibrary.simpleMessage("短信验证码"),
     "smsSetupSuccessDescription": MessageLookupByLibrary.simpleMessage(
       "下次登录时，您将需要输入发送到手机号码的安全码",
@@ -579,7 +587,7 @@ class MessageLookup extends MessageLookupByLibrary {
         ),
     "type": MessageLookupByLibrary.simpleMessage("类型"),
     "unableConnectToDevice": MessageLookupByLibrary.simpleMessage("无法连接到设备"),
-    "unableConnectToWifiBecauseNetworksWasntFoundByDevice": m24,
+    "unableConnectToWifiBecauseNetworksWasntFoundByDevice": m26,
     "unableToUseCamera": MessageLookupByLibrary.simpleMessage("无法使用摄像头"),
     "unacknowledged": MessageLookupByLibrary.simpleMessage("未确认"),
     "unassigned": MessageLookupByLibrary.simpleMessage("未分配"),
@@ -589,7 +597,7 @@ class MessageLookup extends MessageLookupByLibrary {
     "unsavedChanges": MessageLookupByLibrary.simpleMessage("未保存的更改"),
     "update": MessageLookupByLibrary.simpleMessage("更新"),
     "updateRequired": MessageLookupByLibrary.simpleMessage("需要更新"),
-    "updateTo": m25,
+    "updateTo": m27,
     "url": MessageLookupByLibrary.simpleMessage("链接"),
     "user": MessageLookupByLibrary.simpleMessage("用户"),
     "username": MessageLookupByLibrary.simpleMessage("用户名"),
@@ -606,9 +614,9 @@ class MessageLookup extends MessageLookupByLibrary {
     "warning": MessageLookupByLibrary.simpleMessage("警告"),
     "widgetType": MessageLookupByLibrary.simpleMessage("组件类型"),
     "widgetsBundle": MessageLookupByLibrary.simpleMessage("组件包"),
-    "wifiHelpMessage": m26,
+    "wifiHelpMessage": m28,
     "wifiPassword": MessageLookupByLibrary.simpleMessage("Wi-Fi 密码"),
-    "wifiPasswordMessage": m27,
+    "wifiPasswordMessage": m29,
     "yes": MessageLookupByLibrary.simpleMessage("是"),
     "yesDeactivate": MessageLookupByLibrary.simpleMessage("是的，停用"),
     "yesDiscard": MessageLookupByLibrary.simpleMessage("是的，放弃"),

--- a/lib/generated/intl/messages_zh_CN.dart
+++ b/lib/generated/intl/messages_zh_CN.dart
@@ -525,7 +525,7 @@ class MessageLookup extends MessageLookupByLibrary {
     "searchUsers": m24,
     "seconds": MessageLookupByLibrary.simpleMessage("秒"),
     "security": MessageLookupByLibrary.simpleMessage("安全"),
-    "selectAll": MessageLookupByLibrary.simpleMessage("全选"),
+    "selectAll": MessageLookupByLibrary.simpleMessage("全选已加载"),
     "selectCountry": MessageLookupByLibrary.simpleMessage("选择国家"),
     "selectRegion": MessageLookupByLibrary.simpleMessage("选择地区"),
     "selectUser": MessageLookupByLibrary.simpleMessage("选择用户"),

--- a/lib/generated/intl/messages_zh_CN.dart
+++ b/lib/generated/intl/messages_zh_CN.dart
@@ -50,35 +50,38 @@ class MessageLookup extends MessageLookupByLibrary {
 
   static String m13(error) => "发送验证码错误：${error}";
 
-  static String m14(count) => "已选择 ${count} 项";
+  static String m14(count) =>
+      "${Intl.plural(count, one: '1 项操作失败', other: '${count} 项操作失败')}";
 
-  static String m15(count) => "${Intl.plural(count, one: '通知', other: '通知')}";
+  static String m15(count) => "已选择 ${count} 项";
 
-  static String m16(permissions) =>
-      "您没有足够的\"${permissions}\"权限以继续。请打开应用设置，授予权限并点击\"再试一次\"。";
+  static String m16(count) => "${Intl.plural(count, one: '通知', other: '通知')}";
 
   static String m17(permissions) =>
+      "您没有足够的\"${permissions}\"权限以继续。请打开应用设置，授予权限并点击\"再试一次\"。";
+
+  static String m18(permissions) =>
       "您没有足够的\"${permissions}\"权限以继续。请授予所需权限并点击\"再试一次\"。";
 
-  static String m18(deviceName) => "输入 ${deviceName} 的PIN码以确认拥有权证明";
+  static String m19(deviceName) => "输入 ${deviceName} 的PIN码以确认拥有权证明";
 
-  static String m19(time) =>
+  static String m20(time) =>
       "在 ${Intl.plural(time, one: '1 秒', other: '${time} 秒')}内重新发送验证码";
 
-  static String m20(name) => "路由未定义: ${name}";
+  static String m21(name) => "路由未定义: ${name}";
 
-  static String m21(count) =>
+  static String m22(count) =>
       "${Intl.plural(count, one: '搜索用户', other: '搜索用户')}";
 
-  static String m22(contact) => "安全码已发送到您的手机 ${contact}。";
+  static String m23(contact) => "安全码已发送到您的手机 ${contact}。";
 
-  static String m23(name) => "无法连接 Wi-Fi，因为设备 ${name} 未找到网络";
+  static String m24(name) => "无法连接 Wi-Fi，因为设备 ${name} 未找到网络";
 
-  static String m24(version) => "更新到 ${version}";
+  static String m25(version) => "更新到 ${version}";
 
-  static String m25(deviceName) => "要继续设置您的设备 ${deviceName}，请提供您网络的凭据。";
+  static String m26(deviceName) => "要继续设置您的设备 ${deviceName}，请提供您网络的凭据。";
 
-  static String m26(network) => "输入 ${network} 的密码";
+  static String m27(network) => "输入 ${network} 的密码";
 
   final messages = _notInlinedMessages(_notInlinedMessages);
   static Map<String, Function> _notInlinedMessages(_) => <String, Function>{
@@ -337,6 +340,7 @@ class MessageLookup extends MessageLookupByLibrary {
       "加载告警详情失败",
     ),
     "failedToLoadTheList": MessageLookupByLibrary.simpleMessage("加载列表失败"),
+    "failedToPerformOperation": m14,
     "failedToSaveImage": MessageLookupByLibrary.simpleMessage("保存图片失败"),
     "failureDetails": MessageLookupByLibrary.simpleMessage("失败详情"),
     "fatalApplicationErrorOccurred": MessageLookupByLibrary.simpleMessage(
@@ -408,7 +412,7 @@ class MessageLookup extends MessageLookupByLibrary {
     "mobileDashboardShouldBeConfiguredInDeviceProfile":
         MessageLookupByLibrary.simpleMessage("需要在设备配置文件中配置移动仪表板！"),
     "more": MessageLookupByLibrary.simpleMessage("更多"),
-    "nSelected": m14,
+    "nSelected": m15,
     "newPassword": MessageLookupByLibrary.simpleMessage("新密码"),
     "newPassword2": MessageLookupByLibrary.simpleMessage("确认新密码"),
     "newPassword2RequireText": MessageLookupByLibrary.simpleMessage("请再次输入新密码"),
@@ -429,10 +433,10 @@ class MessageLookup extends MessageLookupByLibrary {
     "notificationRule": MessageLookupByLibrary.simpleMessage("通知规则"),
     "notificationTarget": MessageLookupByLibrary.simpleMessage("通知目标"),
     "notificationTemplate": MessageLookupByLibrary.simpleMessage("通知模板"),
-    "notifications": m15,
+    "notifications": m16,
     "oauth2Client": MessageLookupByLibrary.simpleMessage("OAuth2 客户端"),
     "openAppSettings": MessageLookupByLibrary.simpleMessage("打开应用设置"),
-    "openAppSettingsToGrantPermissionMessage": m16,
+    "openAppSettingsToGrantPermissionMessage": m17,
     "openSettingsAndGrantAccessToCameraToContinue":
         MessageLookupByLibrary.simpleMessage("打开设置并授予摄像头访问权限以继续"),
     "openWifiSettings": MessageLookupByLibrary.simpleMessage("打开 Wi-Fi 设置"),
@@ -455,7 +459,7 @@ class MessageLookup extends MessageLookupByLibrary {
       "密码修改成功",
     ),
     "permissions": MessageLookupByLibrary.simpleMessage("权限"),
-    "permissionsNotEnoughMessage": m17,
+    "permissionsNotEnoughMessage": m18,
     "phone": MessageLookupByLibrary.simpleMessage("电话"),
     "phoneIsInvalid": MessageLookupByLibrary.simpleMessage("手机号码无效"),
     "phoneIsRequired": MessageLookupByLibrary.simpleMessage("手机号码是必填项"),
@@ -472,7 +476,7 @@ class MessageLookup extends MessageLookupByLibrary {
       "请扫描您设备上的二维码",
     ),
     "plusAlarmType": MessageLookupByLibrary.simpleMessage("+ 告警类型"),
-    "popTitle": m18,
+    "popTitle": m19,
     "postalCode": MessageLookupByLibrary.simpleMessage("邮编"),
     "privacyPolicy": MessageLookupByLibrary.simpleMessage("隐私政策"),
     "profile": MessageLookupByLibrary.simpleMessage("个人资料"),
@@ -493,7 +497,7 @@ class MessageLookup extends MessageLookupByLibrary {
     ),
     "resend": MessageLookupByLibrary.simpleMessage("重新发送"),
     "resendCode": MessageLookupByLibrary.simpleMessage("重新发送验证码"),
-    "resendCodeWait": m19,
+    "resendCodeWait": m20,
     "reset": MessageLookupByLibrary.simpleMessage("重置"),
     "retry": MessageLookupByLibrary.simpleMessage("重试"),
     "returnToDashboard": MessageLookupByLibrary.simpleMessage("返回仪表板"),
@@ -501,7 +505,7 @@ class MessageLookup extends MessageLookupByLibrary {
       "返回应用并点击准备好按钮",
     ),
     "role": MessageLookupByLibrary.simpleMessage("角色"),
-    "routeNotDefined": m20,
+    "routeNotDefined": m21,
     "rpc": MessageLookupByLibrary.simpleMessage("RPC"),
     "ruleChain": MessageLookupByLibrary.simpleMessage("规则链"),
     "ruleNode": MessageLookupByLibrary.simpleMessage("规则节点"),
@@ -510,7 +514,7 @@ class MessageLookup extends MessageLookupByLibrary {
     "schedulerEvent": MessageLookupByLibrary.simpleMessage("调度事件"),
     "search": MessageLookupByLibrary.simpleMessage("搜索"),
     "searchResults": MessageLookupByLibrary.simpleMessage("搜索结果"),
-    "searchUsers": m21,
+    "searchUsers": m22,
     "seconds": MessageLookupByLibrary.simpleMessage("秒"),
     "security": MessageLookupByLibrary.simpleMessage("安全"),
     "selectAll": MessageLookupByLibrary.simpleMessage("全选"),
@@ -529,7 +533,7 @@ class MessageLookup extends MessageLookupByLibrary {
     "severity": MessageLookupByLibrary.simpleMessage("严重程度"),
     "signIn": MessageLookupByLibrary.simpleMessage("登录"),
     "signUp": MessageLookupByLibrary.simpleMessage("注册"),
-    "smsAuthDescription": m22,
+    "smsAuthDescription": m23,
     "smsAuthPlaceholder": MessageLookupByLibrary.simpleMessage("短信验证码"),
     "smsSetupSuccessDescription": MessageLookupByLibrary.simpleMessage(
       "下次登录时，您将需要输入发送到手机号码的安全码",
@@ -575,7 +579,7 @@ class MessageLookup extends MessageLookupByLibrary {
         ),
     "type": MessageLookupByLibrary.simpleMessage("类型"),
     "unableConnectToDevice": MessageLookupByLibrary.simpleMessage("无法连接到设备"),
-    "unableConnectToWifiBecauseNetworksWasntFoundByDevice": m23,
+    "unableConnectToWifiBecauseNetworksWasntFoundByDevice": m24,
     "unableToUseCamera": MessageLookupByLibrary.simpleMessage("无法使用摄像头"),
     "unacknowledged": MessageLookupByLibrary.simpleMessage("未确认"),
     "unassigned": MessageLookupByLibrary.simpleMessage("未分配"),
@@ -585,7 +589,7 @@ class MessageLookup extends MessageLookupByLibrary {
     "unsavedChanges": MessageLookupByLibrary.simpleMessage("未保存的更改"),
     "update": MessageLookupByLibrary.simpleMessage("更新"),
     "updateRequired": MessageLookupByLibrary.simpleMessage("需要更新"),
-    "updateTo": m24,
+    "updateTo": m25,
     "url": MessageLookupByLibrary.simpleMessage("链接"),
     "user": MessageLookupByLibrary.simpleMessage("用户"),
     "username": MessageLookupByLibrary.simpleMessage("用户名"),
@@ -602,9 +606,9 @@ class MessageLookup extends MessageLookupByLibrary {
     "warning": MessageLookupByLibrary.simpleMessage("警告"),
     "widgetType": MessageLookupByLibrary.simpleMessage("组件类型"),
     "widgetsBundle": MessageLookupByLibrary.simpleMessage("组件包"),
-    "wifiHelpMessage": m25,
+    "wifiHelpMessage": m26,
     "wifiPassword": MessageLookupByLibrary.simpleMessage("Wi-Fi 密码"),
-    "wifiPasswordMessage": m26,
+    "wifiPasswordMessage": m27,
     "yes": MessageLookupByLibrary.simpleMessage("是"),
     "yesDeactivate": MessageLookupByLibrary.simpleMessage("是的，停用"),
     "yesDiscard": MessageLookupByLibrary.simpleMessage("是的，放弃"),

--- a/lib/generated/intl/messages_zh_TW.dart
+++ b/lib/generated/intl/messages_zh_TW.dart
@@ -50,33 +50,35 @@ class MessageLookup extends MessageLookupByLibrary {
 
   static String m13(error) => "傳送驗證碼錯誤：${error}";
 
-  static String m14(count) => "${Intl.plural(count, one: '通知', other: '通知')}";
+  static String m14(count) => "已選擇 ${count} 項";
 
-  static String m15(permissions) =>
-      "您沒有足夠的「${permissions}」權限以繼續。請開啟應用程式設定，授予權限並點選「再試一次」。";
+  static String m15(count) => "${Intl.plural(count, one: '通知', other: '通知')}";
 
   static String m16(permissions) =>
+      "您沒有足夠的「${permissions}」權限以繼續。請開啟應用程式設定，授予權限並點選「再試一次」。";
+
+  static String m17(permissions) =>
       "您沒有足夠的「${permissions}」權限以繼續。請授予所需權限並點選「再試一次」。";
 
-  static String m17(deviceName) => "輸入 ${deviceName} 的PIN碼以確認持有權證明";
+  static String m18(deviceName) => "輸入 ${deviceName} 的PIN碼以確認持有權證明";
 
-  static String m18(time) =>
+  static String m19(time) =>
       "在 ${Intl.plural(time, one: '1 秒', other: '${time} 秒')}內重新發送驗證碼";
 
-  static String m19(name) => "路由未定義：${name}";
+  static String m20(name) => "路由未定義：${name}";
 
-  static String m20(count) =>
+  static String m21(count) =>
       "${Intl.plural(count, one: '搜尋使用者', other: '搜尋使用者')}";
 
-  static String m21(contact) => "安全碼已發送到您的手機 ${contact}。";
+  static String m22(contact) => "安全碼已發送到您的手機 ${contact}。";
 
-  static String m22(name) => "無法連線 Wi-Fi，因為設備 ${name} 未找到網路";
+  static String m23(name) => "無法連線 Wi-Fi，因為設備 ${name} 未找到網路";
 
-  static String m23(version) => "更新至 ${version}";
+  static String m24(version) => "更新至 ${version}";
 
-  static String m24(deviceName) => "要繼續設定您的設備 ${deviceName}，請提供您網路的認證資料。";
+  static String m25(deviceName) => "要繼續設定您的設備 ${deviceName}，請提供您網路的認證資料。";
 
-  static String m25(network) => "輸入 ${network} 的密碼";
+  static String m26(network) => "輸入 ${network} 的密碼";
 
   final messages = _notInlinedMessages(_notInlinedMessages);
   static Map<String, Function> _notInlinedMessages(_) => <String, Function>{
@@ -408,6 +410,7 @@ class MessageLookup extends MessageLookupByLibrary {
     "mobileDashboardShouldBeConfiguredInDeviceProfile":
         MessageLookupByLibrary.simpleMessage("需要在設備設定檔中設定行動儀表板！"),
     "more": MessageLookupByLibrary.simpleMessage("更多"),
+    "nSelected": m14,
     "newPassword": MessageLookupByLibrary.simpleMessage("新密碼"),
     "newPassword2": MessageLookupByLibrary.simpleMessage("確認新密碼"),
     "newPassword2RequireText": MessageLookupByLibrary.simpleMessage("請再次輸入新密碼"),
@@ -428,10 +431,10 @@ class MessageLookup extends MessageLookupByLibrary {
     "notificationRule": MessageLookupByLibrary.simpleMessage("通知規則"),
     "notificationTarget": MessageLookupByLibrary.simpleMessage("通知目標"),
     "notificationTemplate": MessageLookupByLibrary.simpleMessage("通知範本"),
-    "notifications": m14,
+    "notifications": m15,
     "oauth2Client": MessageLookupByLibrary.simpleMessage("OAuth2 用戶端"),
     "openAppSettings": MessageLookupByLibrary.simpleMessage("開啟應用程式設定"),
-    "openAppSettingsToGrantPermissionMessage": m15,
+    "openAppSettingsToGrantPermissionMessage": m16,
     "openSettingsAndGrantAccessToCameraToContinue":
         MessageLookupByLibrary.simpleMessage("開啟設定並授予攝影機存取權限以繼續"),
     "openWifiSettings": MessageLookupByLibrary.simpleMessage("開啟 Wi-Fi 設定"),
@@ -454,7 +457,7 @@ class MessageLookup extends MessageLookupByLibrary {
       "密碼修改成功",
     ),
     "permissions": MessageLookupByLibrary.simpleMessage("權限"),
-    "permissionsNotEnoughMessage": m16,
+    "permissionsNotEnoughMessage": m17,
     "phone": MessageLookupByLibrary.simpleMessage("電話"),
     "phoneIsInvalid": MessageLookupByLibrary.simpleMessage("手機號碼無效"),
     "phoneIsRequired": MessageLookupByLibrary.simpleMessage("手機號碼為必填項目"),
@@ -471,7 +474,7 @@ class MessageLookup extends MessageLookupByLibrary {
       "請掃描您設備上的 QR 碼",
     ),
     "plusAlarmType": MessageLookupByLibrary.simpleMessage("+ 警報類型"),
-    "popTitle": m17,
+    "popTitle": m18,
     "postalCode": MessageLookupByLibrary.simpleMessage("郵遞區號"),
     "privacyPolicy": MessageLookupByLibrary.simpleMessage("隱私權政策"),
     "profile": MessageLookupByLibrary.simpleMessage("個人資料"),
@@ -492,7 +495,7 @@ class MessageLookup extends MessageLookupByLibrary {
     ),
     "resend": MessageLookupByLibrary.simpleMessage("重新發送"),
     "resendCode": MessageLookupByLibrary.simpleMessage("重新發送驗證碼"),
-    "resendCodeWait": m18,
+    "resendCodeWait": m19,
     "reset": MessageLookupByLibrary.simpleMessage("重設"),
     "retry": MessageLookupByLibrary.simpleMessage("重試"),
     "returnToDashboard": MessageLookupByLibrary.simpleMessage("返回儀表板"),
@@ -500,7 +503,7 @@ class MessageLookup extends MessageLookupByLibrary {
       "返回應用程式並點選準備好按鈕",
     ),
     "role": MessageLookupByLibrary.simpleMessage("角色"),
-    "routeNotDefined": m19,
+    "routeNotDefined": m20,
     "rpc": MessageLookupByLibrary.simpleMessage("RPC"),
     "ruleChain": MessageLookupByLibrary.simpleMessage("規則鏈"),
     "ruleNode": MessageLookupByLibrary.simpleMessage("規則節點"),
@@ -509,9 +512,10 @@ class MessageLookup extends MessageLookupByLibrary {
     "schedulerEvent": MessageLookupByLibrary.simpleMessage("排程事件"),
     "search": MessageLookupByLibrary.simpleMessage("搜尋"),
     "searchResults": MessageLookupByLibrary.simpleMessage("搜尋結果"),
-    "searchUsers": m20,
+    "searchUsers": m21,
     "seconds": MessageLookupByLibrary.simpleMessage("秒"),
     "security": MessageLookupByLibrary.simpleMessage("安全性"),
+    "selectAll": MessageLookupByLibrary.simpleMessage("全選"),
     "selectCountry": MessageLookupByLibrary.simpleMessage("選擇國家"),
     "selectRegion": MessageLookupByLibrary.simpleMessage("選擇地區"),
     "selectUser": MessageLookupByLibrary.simpleMessage("選擇使用者"),
@@ -527,7 +531,7 @@ class MessageLookup extends MessageLookupByLibrary {
     "severity": MessageLookupByLibrary.simpleMessage("嚴重程度"),
     "signIn": MessageLookupByLibrary.simpleMessage("登入"),
     "signUp": MessageLookupByLibrary.simpleMessage("註冊"),
-    "smsAuthDescription": m21,
+    "smsAuthDescription": m22,
     "smsAuthPlaceholder": MessageLookupByLibrary.simpleMessage("簡訊驗證碼"),
     "smsSetupSuccessDescription": MessageLookupByLibrary.simpleMessage(
       "下次登入時，您將需要輸入傳送到手機號碼的安全碼",
@@ -573,7 +577,7 @@ class MessageLookup extends MessageLookupByLibrary {
         ),
     "type": MessageLookupByLibrary.simpleMessage("類型"),
     "unableConnectToDevice": MessageLookupByLibrary.simpleMessage("無法連線到設備"),
-    "unableConnectToWifiBecauseNetworksWasntFoundByDevice": m22,
+    "unableConnectToWifiBecauseNetworksWasntFoundByDevice": m23,
     "unableToUseCamera": MessageLookupByLibrary.simpleMessage("無法使用攝影機"),
     "unacknowledged": MessageLookupByLibrary.simpleMessage("未確認"),
     "unassigned": MessageLookupByLibrary.simpleMessage("未指派"),
@@ -583,7 +587,7 @@ class MessageLookup extends MessageLookupByLibrary {
     "unsavedChanges": MessageLookupByLibrary.simpleMessage("未儲存的變更"),
     "update": MessageLookupByLibrary.simpleMessage("更新"),
     "updateRequired": MessageLookupByLibrary.simpleMessage("需要更新"),
-    "updateTo": m23,
+    "updateTo": m24,
     "url": MessageLookupByLibrary.simpleMessage("連結"),
     "user": MessageLookupByLibrary.simpleMessage("使用者"),
     "username": MessageLookupByLibrary.simpleMessage("使用者名稱"),
@@ -600,9 +604,9 @@ class MessageLookup extends MessageLookupByLibrary {
     "warning": MessageLookupByLibrary.simpleMessage("警告"),
     "widgetType": MessageLookupByLibrary.simpleMessage("元件類型"),
     "widgetsBundle": MessageLookupByLibrary.simpleMessage("元件包"),
-    "wifiHelpMessage": m24,
+    "wifiHelpMessage": m25,
     "wifiPassword": MessageLookupByLibrary.simpleMessage("Wi-Fi 密碼"),
-    "wifiPasswordMessage": m25,
+    "wifiPasswordMessage": m26,
     "yes": MessageLookupByLibrary.simpleMessage("是"),
     "yesDeactivate": MessageLookupByLibrary.simpleMessage("是的，停用"),
     "yesDiscard": MessageLookupByLibrary.simpleMessage("是的，捨棄"),

--- a/lib/generated/intl/messages_zh_TW.dart
+++ b/lib/generated/intl/messages_zh_TW.dart
@@ -40,48 +40,54 @@ class MessageLookup extends MessageLookupByLibrary {
 
   static String m8(count) => "${Intl.plural(count, one: '儀表板', other: '儀表板')}";
 
-  static String m9(count) => "${Intl.plural(count, one: '設備', other: '設備')}";
+  static String m9(count) =>
+      "${Intl.plural(count, one: '刪除 1 則通知？', other: '刪除 ${count} 則通知？')}";
 
-  static String m10(count) => "${count}位數驗證碼";
+  static String m10(count) => "${Intl.plural(count, one: '設備', other: '設備')}";
 
-  static String m11(contact) => "安全碼已發送到您的電子郵件 ${contact}。";
+  static String m11(count) => "${count}位數驗證碼";
 
-  static String m12(e) => "發生錯誤：${e}";
+  static String m12(contact) => "安全碼已發送到您的電子郵件 ${contact}。";
 
-  static String m13(error) => "傳送驗證碼錯誤：${error}";
+  static String m13(e) => "發生錯誤：${e}";
 
-  static String m14(count) =>
+  static String m14(error) => "傳送驗證碼錯誤：${error}";
+
+  static String m15(count) =>
       "${Intl.plural(count, one: '1 項操作失敗', other: '${count} 項操作失敗')}";
 
-  static String m15(count) => "已選擇 ${count} 項";
+  static String m16(count) =>
+      "${Intl.plural(count, one: '將 1 則通知標記為已讀？', other: '將 ${count} 則通知標記為已讀？')}";
 
-  static String m16(count) => "${Intl.plural(count, one: '通知', other: '通知')}";
+  static String m17(count) => "已選擇 ${count} 項";
 
-  static String m17(permissions) =>
+  static String m18(count) => "${Intl.plural(count, one: '通知', other: '通知')}";
+
+  static String m19(permissions) =>
       "您沒有足夠的「${permissions}」權限以繼續。請開啟應用程式設定，授予權限並點選「再試一次」。";
 
-  static String m18(permissions) =>
+  static String m20(permissions) =>
       "您沒有足夠的「${permissions}」權限以繼續。請授予所需權限並點選「再試一次」。";
 
-  static String m19(deviceName) => "輸入 ${deviceName} 的PIN碼以確認持有權證明";
+  static String m21(deviceName) => "輸入 ${deviceName} 的PIN碼以確認持有權證明";
 
-  static String m20(time) =>
+  static String m22(time) =>
       "在 ${Intl.plural(time, one: '1 秒', other: '${time} 秒')}內重新發送驗證碼";
 
-  static String m21(name) => "路由未定義：${name}";
+  static String m23(name) => "路由未定義：${name}";
 
-  static String m22(count) =>
+  static String m24(count) =>
       "${Intl.plural(count, one: '搜尋使用者', other: '搜尋使用者')}";
 
-  static String m23(contact) => "安全碼已發送到您的手機 ${contact}。";
+  static String m25(contact) => "安全碼已發送到您的手機 ${contact}。";
 
-  static String m24(name) => "無法連線 Wi-Fi，因為設備 ${name} 未找到網路";
+  static String m26(name) => "無法連線 Wi-Fi，因為設備 ${name} 未找到網路";
 
-  static String m25(version) => "更新至 ${version}";
+  static String m27(version) => "更新至 ${version}";
 
-  static String m26(deviceName) => "要繼續設定您的設備 ${deviceName}，請提供您網路的認證資料。";
+  static String m28(deviceName) => "要繼續設定您的設備 ${deviceName}，請提供您網路的認證資料。";
 
-  static String m27(network) => "輸入 ${network} 的密碼";
+  static String m29(network) => "輸入 ${network} 的密碼";
 
   final messages = _notInlinedMessages(_notInlinedMessages);
   static Map<String, Function> _notInlinedMessages(_) => <String, Function>{
@@ -285,6 +291,7 @@ class MessageLookup extends MessageLookupByLibrary {
     "delete": MessageLookupByLibrary.simpleMessage("刪除"),
     "deleteAccount": MessageLookupByLibrary.simpleMessage("刪除帳戶"),
     "deleteComment": MessageLookupByLibrary.simpleMessage("刪除評論"),
+    "deleteSelectedNotifications": m9,
     "details": MessageLookupByLibrary.simpleMessage("詳情"),
     "deviceList": MessageLookupByLibrary.simpleMessage("設備清單"),
     "deviceNotAbleToFindWifiNearby": MessageLookupByLibrary.simpleMessage(
@@ -295,8 +302,8 @@ class MessageLookup extends MessageLookupByLibrary {
     ),
     "deviceProfile": MessageLookupByLibrary.simpleMessage("設備設定檔"),
     "deviceProvisioning": MessageLookupByLibrary.simpleMessage("設備設定"),
-    "devices": m9,
-    "digitsCode": m10,
+    "devices": m10,
+    "digitsCode": m11,
     "discardChanges": MessageLookupByLibrary.simpleMessage("捨棄變更"),
     "domain": MessageLookupByLibrary.simpleMessage("網域"),
     "done": MessageLookupByLibrary.simpleMessage("完成"),
@@ -305,7 +312,7 @@ class MessageLookup extends MessageLookupByLibrary {
     "edit": MessageLookupByLibrary.simpleMessage("編輯"),
     "edited": MessageLookupByLibrary.simpleMessage("已編輯"),
     "email": MessageLookupByLibrary.simpleMessage("電子郵件"),
-    "emailAuthDescription": m11,
+    "emailAuthDescription": m12,
     "emailAuthPlaceholder": MessageLookupByLibrary.simpleMessage("電子郵件驗證碼"),
     "emailInvalidText": MessageLookupByLibrary.simpleMessage("電子郵件格式無效"),
     "emailRequireText": MessageLookupByLibrary.simpleMessage("電子郵件為必填項目"),
@@ -332,8 +339,8 @@ class MessageLookup extends MessageLookupByLibrary {
     "entityGroup": MessageLookupByLibrary.simpleMessage("實體群組"),
     "entityType": MessageLookupByLibrary.simpleMessage("實體類型"),
     "entityView": MessageLookupByLibrary.simpleMessage("實體視圖"),
-    "errorOccured": m12,
-    "errorSendingCode": m13,
+    "errorOccured": m13,
+    "errorSendingCode": m14,
     "europe": MessageLookupByLibrary.simpleMessage("歐洲"),
     "europeRegionShort": MessageLookupByLibrary.simpleMessage("法蘭克福"),
     "exitDeviceProvisioning": MessageLookupByLibrary.simpleMessage("退出設備設定"),
@@ -342,7 +349,7 @@ class MessageLookup extends MessageLookupByLibrary {
       "載入警報詳情失敗",
     ),
     "failedToLoadTheList": MessageLookupByLibrary.simpleMessage("載入清單失敗"),
-    "failedToPerformOperation": m14,
+    "failedToPerformOperation": m15,
     "failedToSaveImage": MessageLookupByLibrary.simpleMessage("儲存圖片失敗"),
     "failureDetails": MessageLookupByLibrary.simpleMessage("失敗詳情"),
     "fatalApplicationErrorOccurred": MessageLookupByLibrary.simpleMessage(
@@ -402,6 +409,7 @@ class MessageLookup extends MessageLookupByLibrary {
     "major": MessageLookupByLibrary.simpleMessage("重要"),
     "markAllAsRead": MessageLookupByLibrary.simpleMessage("全部標記為已讀"),
     "markAsRead": MessageLookupByLibrary.simpleMessage("標記為已讀"),
+    "markSelectedNotificationsAsRead": m16,
     "metricUnitSystem": MessageLookupByLibrary.simpleMessage("公制"),
     "mfaProviderBackupCode": MessageLookupByLibrary.simpleMessage("備份碼"),
     "mfaProviderEmail": MessageLookupByLibrary.simpleMessage("電子郵件"),
@@ -414,7 +422,7 @@ class MessageLookup extends MessageLookupByLibrary {
     "mobileDashboardShouldBeConfiguredInDeviceProfile":
         MessageLookupByLibrary.simpleMessage("需要在設備設定檔中設定行動儀表板！"),
     "more": MessageLookupByLibrary.simpleMessage("更多"),
-    "nSelected": m15,
+    "nSelected": m17,
     "newPassword": MessageLookupByLibrary.simpleMessage("新密碼"),
     "newPassword2": MessageLookupByLibrary.simpleMessage("確認新密碼"),
     "newPassword2RequireText": MessageLookupByLibrary.simpleMessage("請再次輸入新密碼"),
@@ -435,10 +443,10 @@ class MessageLookup extends MessageLookupByLibrary {
     "notificationRule": MessageLookupByLibrary.simpleMessage("通知規則"),
     "notificationTarget": MessageLookupByLibrary.simpleMessage("通知目標"),
     "notificationTemplate": MessageLookupByLibrary.simpleMessage("通知範本"),
-    "notifications": m16,
+    "notifications": m18,
     "oauth2Client": MessageLookupByLibrary.simpleMessage("OAuth2 用戶端"),
     "openAppSettings": MessageLookupByLibrary.simpleMessage("開啟應用程式設定"),
-    "openAppSettingsToGrantPermissionMessage": m17,
+    "openAppSettingsToGrantPermissionMessage": m19,
     "openSettingsAndGrantAccessToCameraToContinue":
         MessageLookupByLibrary.simpleMessage("開啟設定並授予攝影機存取權限以繼續"),
     "openWifiSettings": MessageLookupByLibrary.simpleMessage("開啟 Wi-Fi 設定"),
@@ -461,7 +469,7 @@ class MessageLookup extends MessageLookupByLibrary {
       "密碼修改成功",
     ),
     "permissions": MessageLookupByLibrary.simpleMessage("權限"),
-    "permissionsNotEnoughMessage": m18,
+    "permissionsNotEnoughMessage": m20,
     "phone": MessageLookupByLibrary.simpleMessage("電話"),
     "phoneIsInvalid": MessageLookupByLibrary.simpleMessage("手機號碼無效"),
     "phoneIsRequired": MessageLookupByLibrary.simpleMessage("手機號碼為必填項目"),
@@ -478,7 +486,7 @@ class MessageLookup extends MessageLookupByLibrary {
       "請掃描您設備上的 QR 碼",
     ),
     "plusAlarmType": MessageLookupByLibrary.simpleMessage("+ 警報類型"),
-    "popTitle": m19,
+    "popTitle": m21,
     "postalCode": MessageLookupByLibrary.simpleMessage("郵遞區號"),
     "privacyPolicy": MessageLookupByLibrary.simpleMessage("隱私權政策"),
     "profile": MessageLookupByLibrary.simpleMessage("個人資料"),
@@ -499,7 +507,7 @@ class MessageLookup extends MessageLookupByLibrary {
     ),
     "resend": MessageLookupByLibrary.simpleMessage("重新發送"),
     "resendCode": MessageLookupByLibrary.simpleMessage("重新發送驗證碼"),
-    "resendCodeWait": m20,
+    "resendCodeWait": m22,
     "reset": MessageLookupByLibrary.simpleMessage("重設"),
     "retry": MessageLookupByLibrary.simpleMessage("重試"),
     "returnToDashboard": MessageLookupByLibrary.simpleMessage("返回儀表板"),
@@ -507,7 +515,7 @@ class MessageLookup extends MessageLookupByLibrary {
       "返回應用程式並點選準備好按鈕",
     ),
     "role": MessageLookupByLibrary.simpleMessage("角色"),
-    "routeNotDefined": m21,
+    "routeNotDefined": m23,
     "rpc": MessageLookupByLibrary.simpleMessage("RPC"),
     "ruleChain": MessageLookupByLibrary.simpleMessage("規則鏈"),
     "ruleNode": MessageLookupByLibrary.simpleMessage("規則節點"),
@@ -516,7 +524,7 @@ class MessageLookup extends MessageLookupByLibrary {
     "schedulerEvent": MessageLookupByLibrary.simpleMessage("排程事件"),
     "search": MessageLookupByLibrary.simpleMessage("搜尋"),
     "searchResults": MessageLookupByLibrary.simpleMessage("搜尋結果"),
-    "searchUsers": m22,
+    "searchUsers": m24,
     "seconds": MessageLookupByLibrary.simpleMessage("秒"),
     "security": MessageLookupByLibrary.simpleMessage("安全性"),
     "selectAll": MessageLookupByLibrary.simpleMessage("全選"),
@@ -535,7 +543,7 @@ class MessageLookup extends MessageLookupByLibrary {
     "severity": MessageLookupByLibrary.simpleMessage("嚴重程度"),
     "signIn": MessageLookupByLibrary.simpleMessage("登入"),
     "signUp": MessageLookupByLibrary.simpleMessage("註冊"),
-    "smsAuthDescription": m23,
+    "smsAuthDescription": m25,
     "smsAuthPlaceholder": MessageLookupByLibrary.simpleMessage("簡訊驗證碼"),
     "smsSetupSuccessDescription": MessageLookupByLibrary.simpleMessage(
       "下次登入時，您將需要輸入傳送到手機號碼的安全碼",
@@ -581,7 +589,7 @@ class MessageLookup extends MessageLookupByLibrary {
         ),
     "type": MessageLookupByLibrary.simpleMessage("類型"),
     "unableConnectToDevice": MessageLookupByLibrary.simpleMessage("無法連線到設備"),
-    "unableConnectToWifiBecauseNetworksWasntFoundByDevice": m24,
+    "unableConnectToWifiBecauseNetworksWasntFoundByDevice": m26,
     "unableToUseCamera": MessageLookupByLibrary.simpleMessage("無法使用攝影機"),
     "unacknowledged": MessageLookupByLibrary.simpleMessage("未確認"),
     "unassigned": MessageLookupByLibrary.simpleMessage("未指派"),
@@ -591,7 +599,7 @@ class MessageLookup extends MessageLookupByLibrary {
     "unsavedChanges": MessageLookupByLibrary.simpleMessage("未儲存的變更"),
     "update": MessageLookupByLibrary.simpleMessage("更新"),
     "updateRequired": MessageLookupByLibrary.simpleMessage("需要更新"),
-    "updateTo": m25,
+    "updateTo": m27,
     "url": MessageLookupByLibrary.simpleMessage("連結"),
     "user": MessageLookupByLibrary.simpleMessage("使用者"),
     "username": MessageLookupByLibrary.simpleMessage("使用者名稱"),
@@ -608,9 +616,9 @@ class MessageLookup extends MessageLookupByLibrary {
     "warning": MessageLookupByLibrary.simpleMessage("警告"),
     "widgetType": MessageLookupByLibrary.simpleMessage("元件類型"),
     "widgetsBundle": MessageLookupByLibrary.simpleMessage("元件包"),
-    "wifiHelpMessage": m26,
+    "wifiHelpMessage": m28,
     "wifiPassword": MessageLookupByLibrary.simpleMessage("Wi-Fi 密碼"),
-    "wifiPasswordMessage": m27,
+    "wifiPasswordMessage": m29,
     "yes": MessageLookupByLibrary.simpleMessage("是"),
     "yesDeactivate": MessageLookupByLibrary.simpleMessage("是的，停用"),
     "yesDiscard": MessageLookupByLibrary.simpleMessage("是的，捨棄"),

--- a/lib/generated/intl/messages_zh_TW.dart
+++ b/lib/generated/intl/messages_zh_TW.dart
@@ -527,7 +527,7 @@ class MessageLookup extends MessageLookupByLibrary {
     "searchUsers": m24,
     "seconds": MessageLookupByLibrary.simpleMessage("秒"),
     "security": MessageLookupByLibrary.simpleMessage("安全性"),
-    "selectAll": MessageLookupByLibrary.simpleMessage("全選"),
+    "selectAll": MessageLookupByLibrary.simpleMessage("全選已載入"),
     "selectCountry": MessageLookupByLibrary.simpleMessage("選擇國家"),
     "selectRegion": MessageLookupByLibrary.simpleMessage("選擇地區"),
     "selectUser": MessageLookupByLibrary.simpleMessage("選擇使用者"),

--- a/lib/generated/intl/messages_zh_TW.dart
+++ b/lib/generated/intl/messages_zh_TW.dart
@@ -50,35 +50,38 @@ class MessageLookup extends MessageLookupByLibrary {
 
   static String m13(error) => "傳送驗證碼錯誤：${error}";
 
-  static String m14(count) => "已選擇 ${count} 項";
+  static String m14(count) =>
+      "${Intl.plural(count, one: '1 項操作失敗', other: '${count} 項操作失敗')}";
 
-  static String m15(count) => "${Intl.plural(count, one: '通知', other: '通知')}";
+  static String m15(count) => "已選擇 ${count} 項";
 
-  static String m16(permissions) =>
-      "您沒有足夠的「${permissions}」權限以繼續。請開啟應用程式設定，授予權限並點選「再試一次」。";
+  static String m16(count) => "${Intl.plural(count, one: '通知', other: '通知')}";
 
   static String m17(permissions) =>
+      "您沒有足夠的「${permissions}」權限以繼續。請開啟應用程式設定，授予權限並點選「再試一次」。";
+
+  static String m18(permissions) =>
       "您沒有足夠的「${permissions}」權限以繼續。請授予所需權限並點選「再試一次」。";
 
-  static String m18(deviceName) => "輸入 ${deviceName} 的PIN碼以確認持有權證明";
+  static String m19(deviceName) => "輸入 ${deviceName} 的PIN碼以確認持有權證明";
 
-  static String m19(time) =>
+  static String m20(time) =>
       "在 ${Intl.plural(time, one: '1 秒', other: '${time} 秒')}內重新發送驗證碼";
 
-  static String m20(name) => "路由未定義：${name}";
+  static String m21(name) => "路由未定義：${name}";
 
-  static String m21(count) =>
+  static String m22(count) =>
       "${Intl.plural(count, one: '搜尋使用者', other: '搜尋使用者')}";
 
-  static String m22(contact) => "安全碼已發送到您的手機 ${contact}。";
+  static String m23(contact) => "安全碼已發送到您的手機 ${contact}。";
 
-  static String m23(name) => "無法連線 Wi-Fi，因為設備 ${name} 未找到網路";
+  static String m24(name) => "無法連線 Wi-Fi，因為設備 ${name} 未找到網路";
 
-  static String m24(version) => "更新至 ${version}";
+  static String m25(version) => "更新至 ${version}";
 
-  static String m25(deviceName) => "要繼續設定您的設備 ${deviceName}，請提供您網路的認證資料。";
+  static String m26(deviceName) => "要繼續設定您的設備 ${deviceName}，請提供您網路的認證資料。";
 
-  static String m26(network) => "輸入 ${network} 的密碼";
+  static String m27(network) => "輸入 ${network} 的密碼";
 
   final messages = _notInlinedMessages(_notInlinedMessages);
   static Map<String, Function> _notInlinedMessages(_) => <String, Function>{
@@ -339,6 +342,7 @@ class MessageLookup extends MessageLookupByLibrary {
       "載入警報詳情失敗",
     ),
     "failedToLoadTheList": MessageLookupByLibrary.simpleMessage("載入清單失敗"),
+    "failedToPerformOperation": m14,
     "failedToSaveImage": MessageLookupByLibrary.simpleMessage("儲存圖片失敗"),
     "failureDetails": MessageLookupByLibrary.simpleMessage("失敗詳情"),
     "fatalApplicationErrorOccurred": MessageLookupByLibrary.simpleMessage(
@@ -410,7 +414,7 @@ class MessageLookup extends MessageLookupByLibrary {
     "mobileDashboardShouldBeConfiguredInDeviceProfile":
         MessageLookupByLibrary.simpleMessage("需要在設備設定檔中設定行動儀表板！"),
     "more": MessageLookupByLibrary.simpleMessage("更多"),
-    "nSelected": m14,
+    "nSelected": m15,
     "newPassword": MessageLookupByLibrary.simpleMessage("新密碼"),
     "newPassword2": MessageLookupByLibrary.simpleMessage("確認新密碼"),
     "newPassword2RequireText": MessageLookupByLibrary.simpleMessage("請再次輸入新密碼"),
@@ -431,10 +435,10 @@ class MessageLookup extends MessageLookupByLibrary {
     "notificationRule": MessageLookupByLibrary.simpleMessage("通知規則"),
     "notificationTarget": MessageLookupByLibrary.simpleMessage("通知目標"),
     "notificationTemplate": MessageLookupByLibrary.simpleMessage("通知範本"),
-    "notifications": m15,
+    "notifications": m16,
     "oauth2Client": MessageLookupByLibrary.simpleMessage("OAuth2 用戶端"),
     "openAppSettings": MessageLookupByLibrary.simpleMessage("開啟應用程式設定"),
-    "openAppSettingsToGrantPermissionMessage": m16,
+    "openAppSettingsToGrantPermissionMessage": m17,
     "openSettingsAndGrantAccessToCameraToContinue":
         MessageLookupByLibrary.simpleMessage("開啟設定並授予攝影機存取權限以繼續"),
     "openWifiSettings": MessageLookupByLibrary.simpleMessage("開啟 Wi-Fi 設定"),
@@ -457,7 +461,7 @@ class MessageLookup extends MessageLookupByLibrary {
       "密碼修改成功",
     ),
     "permissions": MessageLookupByLibrary.simpleMessage("權限"),
-    "permissionsNotEnoughMessage": m17,
+    "permissionsNotEnoughMessage": m18,
     "phone": MessageLookupByLibrary.simpleMessage("電話"),
     "phoneIsInvalid": MessageLookupByLibrary.simpleMessage("手機號碼無效"),
     "phoneIsRequired": MessageLookupByLibrary.simpleMessage("手機號碼為必填項目"),
@@ -474,7 +478,7 @@ class MessageLookup extends MessageLookupByLibrary {
       "請掃描您設備上的 QR 碼",
     ),
     "plusAlarmType": MessageLookupByLibrary.simpleMessage("+ 警報類型"),
-    "popTitle": m18,
+    "popTitle": m19,
     "postalCode": MessageLookupByLibrary.simpleMessage("郵遞區號"),
     "privacyPolicy": MessageLookupByLibrary.simpleMessage("隱私權政策"),
     "profile": MessageLookupByLibrary.simpleMessage("個人資料"),
@@ -495,7 +499,7 @@ class MessageLookup extends MessageLookupByLibrary {
     ),
     "resend": MessageLookupByLibrary.simpleMessage("重新發送"),
     "resendCode": MessageLookupByLibrary.simpleMessage("重新發送驗證碼"),
-    "resendCodeWait": m19,
+    "resendCodeWait": m20,
     "reset": MessageLookupByLibrary.simpleMessage("重設"),
     "retry": MessageLookupByLibrary.simpleMessage("重試"),
     "returnToDashboard": MessageLookupByLibrary.simpleMessage("返回儀表板"),
@@ -503,7 +507,7 @@ class MessageLookup extends MessageLookupByLibrary {
       "返回應用程式並點選準備好按鈕",
     ),
     "role": MessageLookupByLibrary.simpleMessage("角色"),
-    "routeNotDefined": m20,
+    "routeNotDefined": m21,
     "rpc": MessageLookupByLibrary.simpleMessage("RPC"),
     "ruleChain": MessageLookupByLibrary.simpleMessage("規則鏈"),
     "ruleNode": MessageLookupByLibrary.simpleMessage("規則節點"),
@@ -512,7 +516,7 @@ class MessageLookup extends MessageLookupByLibrary {
     "schedulerEvent": MessageLookupByLibrary.simpleMessage("排程事件"),
     "search": MessageLookupByLibrary.simpleMessage("搜尋"),
     "searchResults": MessageLookupByLibrary.simpleMessage("搜尋結果"),
-    "searchUsers": m21,
+    "searchUsers": m22,
     "seconds": MessageLookupByLibrary.simpleMessage("秒"),
     "security": MessageLookupByLibrary.simpleMessage("安全性"),
     "selectAll": MessageLookupByLibrary.simpleMessage("全選"),
@@ -531,7 +535,7 @@ class MessageLookup extends MessageLookupByLibrary {
     "severity": MessageLookupByLibrary.simpleMessage("嚴重程度"),
     "signIn": MessageLookupByLibrary.simpleMessage("登入"),
     "signUp": MessageLookupByLibrary.simpleMessage("註冊"),
-    "smsAuthDescription": m22,
+    "smsAuthDescription": m23,
     "smsAuthPlaceholder": MessageLookupByLibrary.simpleMessage("簡訊驗證碼"),
     "smsSetupSuccessDescription": MessageLookupByLibrary.simpleMessage(
       "下次登入時，您將需要輸入傳送到手機號碼的安全碼",
@@ -577,7 +581,7 @@ class MessageLookup extends MessageLookupByLibrary {
         ),
     "type": MessageLookupByLibrary.simpleMessage("類型"),
     "unableConnectToDevice": MessageLookupByLibrary.simpleMessage("無法連線到設備"),
-    "unableConnectToWifiBecauseNetworksWasntFoundByDevice": m23,
+    "unableConnectToWifiBecauseNetworksWasntFoundByDevice": m24,
     "unableToUseCamera": MessageLookupByLibrary.simpleMessage("無法使用攝影機"),
     "unacknowledged": MessageLookupByLibrary.simpleMessage("未確認"),
     "unassigned": MessageLookupByLibrary.simpleMessage("未指派"),
@@ -587,7 +591,7 @@ class MessageLookup extends MessageLookupByLibrary {
     "unsavedChanges": MessageLookupByLibrary.simpleMessage("未儲存的變更"),
     "update": MessageLookupByLibrary.simpleMessage("更新"),
     "updateRequired": MessageLookupByLibrary.simpleMessage("需要更新"),
-    "updateTo": m24,
+    "updateTo": m25,
     "url": MessageLookupByLibrary.simpleMessage("連結"),
     "user": MessageLookupByLibrary.simpleMessage("使用者"),
     "username": MessageLookupByLibrary.simpleMessage("使用者名稱"),
@@ -604,9 +608,9 @@ class MessageLookup extends MessageLookupByLibrary {
     "warning": MessageLookupByLibrary.simpleMessage("警告"),
     "widgetType": MessageLookupByLibrary.simpleMessage("元件類型"),
     "widgetsBundle": MessageLookupByLibrary.simpleMessage("元件包"),
-    "wifiHelpMessage": m25,
+    "wifiHelpMessage": m26,
     "wifiPassword": MessageLookupByLibrary.simpleMessage("Wi-Fi 密碼"),
-    "wifiPasswordMessage": m26,
+    "wifiPasswordMessage": m27,
     "yes": MessageLookupByLibrary.simpleMessage("是"),
     "yesDeactivate": MessageLookupByLibrary.simpleMessage("是的，停用"),
     "yesDiscard": MessageLookupByLibrary.simpleMessage("是的，捨棄"),

--- a/lib/generated/l10n.dart
+++ b/lib/generated/l10n.dart
@@ -3373,9 +3373,14 @@ class S {
     );
   }
 
-  /// `Select all`
+  /// `Select all loaded`
   String get selectAll {
-    return Intl.message('Select all', name: 'selectAll', desc: '', args: []);
+    return Intl.message(
+      'Select all loaded',
+      name: 'selectAll',
+      desc: '',
+      args: [],
+    );
   }
 
   /// `{count, plural, =1{1 operation failed} other{{count} operations failed}}`

--- a/lib/generated/l10n.dart
+++ b/lib/generated/l10n.dart
@@ -3377,6 +3377,18 @@ class S {
   String get selectAll {
     return Intl.message('Select all', name: 'selectAll', desc: '', args: []);
   }
+
+  /// `{count, plural, =1{1 operation failed} other{{count} operations failed}}`
+  String failedToPerformOperation(int count) {
+    return Intl.plural(
+      count,
+      one: '1 operation failed',
+      other: '$count operations failed',
+      name: 'failedToPerformOperation',
+      desc: '',
+      args: [count],
+    );
+  }
 }
 
 class AppLocalizationDelegate extends LocalizationsDelegate<S> {

--- a/lib/generated/l10n.dart
+++ b/lib/generated/l10n.dart
@@ -3389,6 +3389,30 @@ class S {
       args: [count],
     );
   }
+
+  /// `{count, plural, =1{Delete 1 notification?} other{Delete {count} notifications?}}`
+  String deleteSelectedNotifications(int count) {
+    return Intl.plural(
+      count,
+      one: 'Delete 1 notification?',
+      other: 'Delete $count notifications?',
+      name: 'deleteSelectedNotifications',
+      desc: '',
+      args: [count],
+    );
+  }
+
+  /// `{count, plural, =1{Mark 1 notification as read?} other{Mark {count} notifications as read?}}`
+  String markSelectedNotificationsAsRead(int count) {
+    return Intl.plural(
+      count,
+      one: 'Mark 1 notification as read?',
+      other: 'Mark $count notifications as read?',
+      name: 'markSelectedNotificationsAsRead',
+      desc: '',
+      args: [count],
+    );
+  }
 }
 
 class AppLocalizationDelegate extends LocalizationsDelegate<S> {

--- a/lib/generated/l10n.dart
+++ b/lib/generated/l10n.dart
@@ -3362,6 +3362,21 @@ class S {
       args: [],
     );
   }
+
+  /// `{count} selected`
+  String nSelected(int count) {
+    return Intl.message(
+      '$count selected',
+      name: 'nSelected',
+      desc: '',
+      args: [count],
+    );
+  }
+
+  /// `Select all`
+  String get selectAll {
+    return Intl.message('Select all', name: 'selectAll', desc: '', args: []);
+  }
 }
 
 class AppLocalizationDelegate extends LocalizationsDelegate<S> {

--- a/lib/l10n/intl_ar.arb
+++ b/lib/l10n/intl_ar.arb
@@ -466,5 +466,21 @@
         "type": "int"
       }
     }
+  },
+  "deleteSelectedNotifications": "{count, plural, =1{حذف إشعار واحد؟} other{حذف {count} إشعارات؟}}",
+  "markSelectedNotificationsAsRead": "{count, plural, =1{وضع علامة مقروء لإشعار واحد؟} other{وضع علامة مقروء لـ {count} إشعارات؟}}",
+  "@deleteSelectedNotifications": {
+    "placeholders": {
+      "count": {
+        "type": "int"
+      }
+    }
+  },
+  "@markSelectedNotificationsAsRead": {
+    "placeholders": {
+      "count": {
+        "type": "int"
+      }
+    }
   }
 }

--- a/lib/l10n/intl_ar.arb
+++ b/lib/l10n/intl_ar.arb
@@ -458,5 +458,13 @@
       }
     }
   },
-  "selectAll": "تحديد الكل"
+  "selectAll": "تحديد الكل",
+  "failedToPerformOperation": "{count, plural, =1{فشلت عملية واحدة} other{فشلت {count} عمليات}}",
+  "@failedToPerformOperation": {
+    "placeholders": {
+      "count": {
+        "type": "int"
+      }
+    }
+  }
 }

--- a/lib/l10n/intl_ar.arb
+++ b/lib/l10n/intl_ar.arb
@@ -449,5 +449,14 @@
   "schedulerEvent": "حدث المجدول",
   "youDontHavePermissionsToPerformThisOperation": "ليس لديك صلاحيات لتنفيذ هذه العملية!",
   "imageSavedToGallery": "تم الحفظ في 'معرض الصور'",
-  "failedToSaveImage": "فشل في حفظ الصورة"
+  "failedToSaveImage": "فشل في حفظ الصورة",
+  "nSelected": "{count} محدد",
+  "@nSelected": {
+    "placeholders": {
+      "count": {
+        "type": "int"
+      }
+    }
+  },
+  "selectAll": "تحديد الكل"
 }

--- a/lib/l10n/intl_ar.arb
+++ b/lib/l10n/intl_ar.arb
@@ -458,7 +458,7 @@
       }
     }
   },
-  "selectAll": "تحديد الكل",
+  "selectAll": "تحديد الكل المحمّل",
   "failedToPerformOperation": "{count, plural, =1{فشلت عملية واحدة} other{فشلت {count} عمليات}}",
   "@failedToPerformOperation": {
     "placeholders": {

--- a/lib/l10n/intl_da_DK.arb
+++ b/lib/l10n/intl_da_DK.arb
@@ -459,5 +459,13 @@
       }
     }
   },
-  "selectAll": "Vælg alle"
+  "selectAll": "Vælg alle",
+  "failedToPerformOperation": "{count, plural, =1{1 handling mislykkedes} other{{count} handlinger mislykkedes}}",
+  "@failedToPerformOperation": {
+    "placeholders": {
+      "count": {
+        "type": "int"
+      }
+    }
+  }
 }

--- a/lib/l10n/intl_da_DK.arb
+++ b/lib/l10n/intl_da_DK.arb
@@ -459,7 +459,7 @@
       }
     }
   },
-  "selectAll": "Vælg alle",
+  "selectAll": "Vælg alle indlæste",
   "failedToPerformOperation": "{count, plural, =1{1 handling mislykkedes} other{{count} handlinger mislykkedes}}",
   "@failedToPerformOperation": {
     "placeholders": {

--- a/lib/l10n/intl_da_DK.arb
+++ b/lib/l10n/intl_da_DK.arb
@@ -450,5 +450,14 @@
   "schedulerEvent": "Planlægningshændelse",
   "youDontHavePermissionsToPerformThisOperation": "Du har ikke tilladelser til at udføre denne handling!",
   "imageSavedToGallery": "Gemt i 'Billedgalleri'",
-  "failedToSaveImage": "Kunne ikke gemme billede"
+  "failedToSaveImage": "Kunne ikke gemme billede",
+  "nSelected": "{count} valgt",
+  "@nSelected": {
+    "placeholders": {
+      "count": {
+        "type": "int"
+      }
+    }
+  },
+  "selectAll": "Vælg alle"
 }

--- a/lib/l10n/intl_da_DK.arb
+++ b/lib/l10n/intl_da_DK.arb
@@ -467,5 +467,21 @@
         "type": "int"
       }
     }
+  },
+  "deleteSelectedNotifications": "{count, plural, =1{Slet 1 notifikation?} other{Slet {count} notifikationer?}}",
+  "markSelectedNotificationsAsRead": "{count, plural, =1{Markér 1 notifikation som læst?} other{Markér {count} notifikationer som læst?}}",
+  "@deleteSelectedNotifications": {
+    "placeholders": {
+      "count": {
+        "type": "int"
+      }
+    }
+  },
+  "@markSelectedNotificationsAsRead": {
+    "placeholders": {
+      "count": {
+        "type": "int"
+      }
+    }
   }
 }

--- a/lib/l10n/intl_de_DE.arb
+++ b/lib/l10n/intl_de_DE.arb
@@ -459,7 +459,7 @@
       }
     }
   },
-  "selectAll": "Alle auswählen",
+  "selectAll": "Alle geladenen auswählen",
   "failedToPerformOperation": "{count, plural, =1{1 Vorgang fehlgeschlagen} other{{count} Vorgänge fehlgeschlagen}}",
   "@failedToPerformOperation": {
     "placeholders": {

--- a/lib/l10n/intl_de_DE.arb
+++ b/lib/l10n/intl_de_DE.arb
@@ -459,5 +459,13 @@
       }
     }
   },
-  "selectAll": "Alle auswählen"
+  "selectAll": "Alle auswählen",
+  "failedToPerformOperation": "{count, plural, =1{1 Vorgang fehlgeschlagen} other{{count} Vorgänge fehlgeschlagen}}",
+  "@failedToPerformOperation": {
+    "placeholders": {
+      "count": {
+        "type": "int"
+      }
+    }
+  }
 }

--- a/lib/l10n/intl_de_DE.arb
+++ b/lib/l10n/intl_de_DE.arb
@@ -467,5 +467,21 @@
         "type": "int"
       }
     }
+  },
+  "deleteSelectedNotifications": "{count, plural, =1{1 Benachrichtigung löschen?} other{{count} Benachrichtigungen löschen?}}",
+  "markSelectedNotificationsAsRead": "{count, plural, =1{1 Benachrichtigung als gelesen markieren?} other{{count} Benachrichtigungen als gelesen markieren?}}",
+  "@deleteSelectedNotifications": {
+    "placeholders": {
+      "count": {
+        "type": "int"
+      }
+    }
+  },
+  "@markSelectedNotificationsAsRead": {
+    "placeholders": {
+      "count": {
+        "type": "int"
+      }
+    }
   }
 }

--- a/lib/l10n/intl_de_DE.arb
+++ b/lib/l10n/intl_de_DE.arb
@@ -450,5 +450,14 @@
   "schedulerEvent": "Planer-Ereignis",
   "youDontHavePermissionsToPerformThisOperation": "Sie haben keine Berechtigungen, um diesen Vorgang auszuführen!",
   "imageSavedToGallery": "In 'Bildergalerie' gespeichert",
-  "failedToSaveImage": "Bild konnte nicht gespeichert werden"
+  "failedToSaveImage": "Bild konnte nicht gespeichert werden",
+  "nSelected": "{count} ausgewählt",
+  "@nSelected": {
+    "placeholders": {
+      "count": {
+        "type": "int"
+      }
+    }
+  },
+  "selectAll": "Alle auswählen"
 }

--- a/lib/l10n/intl_el_GR.arb
+++ b/lib/l10n/intl_el_GR.arb
@@ -459,7 +459,7 @@
       }
     }
   },
-  "selectAll": "Επιλογή όλων",
+  "selectAll": "Επιλογή όλων των φορτωμένων",
   "failedToPerformOperation": "{count, plural, =1{1 ενέργεια απέτυχε} other{{count} ενέργειες απέτυχαν}}",
   "@failedToPerformOperation": {
     "placeholders": {

--- a/lib/l10n/intl_el_GR.arb
+++ b/lib/l10n/intl_el_GR.arb
@@ -450,5 +450,14 @@
   "schedulerEvent": "Προγραμματισμένο συμβάν",
   "youDontHavePermissionsToPerformThisOperation": "Δεν έχετε δικαιώματα για να εκτελέσετε αυτήν τη λειτουργία!",
   "imageSavedToGallery": "Αποθηκεύτηκε στη 'Συλλογή εικόνων'",
-  "failedToSaveImage": "Αποτυχία αποθήκευσης εικόνας"
+  "failedToSaveImage": "Αποτυχία αποθήκευσης εικόνας",
+  "nSelected": "{count} επιλεγμένα",
+  "@nSelected": {
+    "placeholders": {
+      "count": {
+        "type": "int"
+      }
+    }
+  },
+  "selectAll": "Επιλογή όλων"
 }

--- a/lib/l10n/intl_el_GR.arb
+++ b/lib/l10n/intl_el_GR.arb
@@ -467,5 +467,21 @@
         "type": "int"
       }
     }
+  },
+  "deleteSelectedNotifications": "{count, plural, =1{Διαγραφή 1 ειδοποίησης;} other{Διαγραφή {count} ειδοποιήσεων;}}",
+  "markSelectedNotificationsAsRead": "{count, plural, =1{Σήμανση 1 ειδοποίησης ως αναγνωσμένης;} other{Σήμανση {count} ειδοποιήσεων ως αναγνωσμένων;}}",
+  "@deleteSelectedNotifications": {
+    "placeholders": {
+      "count": {
+        "type": "int"
+      }
+    }
+  },
+  "@markSelectedNotificationsAsRead": {
+    "placeholders": {
+      "count": {
+        "type": "int"
+      }
+    }
   }
 }

--- a/lib/l10n/intl_el_GR.arb
+++ b/lib/l10n/intl_el_GR.arb
@@ -459,5 +459,13 @@
       }
     }
   },
-  "selectAll": "Επιλογή όλων"
+  "selectAll": "Επιλογή όλων",
+  "failedToPerformOperation": "{count, plural, =1{1 ενέργεια απέτυχε} other{{count} ενέργειες απέτυχαν}}",
+  "@failedToPerformOperation": {
+    "placeholders": {
+      "count": {
+        "type": "int"
+      }
+    }
+  }
 }

--- a/lib/l10n/intl_en.arb
+++ b/lib/l10n/intl_en.arb
@@ -458,7 +458,7 @@
       }
     }
   },
-  "selectAll": "Select all",
+  "selectAll": "Select all loaded",
   "failedToPerformOperation": "{count, plural, =1{1 operation failed} other{{count} operations failed}}",
   "@failedToPerformOperation": {
     "placeholders": {

--- a/lib/l10n/intl_en.arb
+++ b/lib/l10n/intl_en.arb
@@ -458,5 +458,13 @@
       }
     }
   },
-  "selectAll": "Select all"
+  "selectAll": "Select all",
+  "failedToPerformOperation": "{count, plural, =1{1 operation failed} other{{count} operations failed}}",
+  "@failedToPerformOperation": {
+    "placeholders": {
+      "count": {
+        "type": "int"
+      }
+    }
+  }
 }

--- a/lib/l10n/intl_en.arb
+++ b/lib/l10n/intl_en.arb
@@ -466,5 +466,21 @@
         "type": "int"
       }
     }
+  },
+  "deleteSelectedNotifications": "{count, plural, =1{Delete 1 notification?} other{Delete {count} notifications?}}",
+  "@deleteSelectedNotifications": {
+    "placeholders": {
+      "count": {
+        "type": "int"
+      }
+    }
+  },
+  "markSelectedNotificationsAsRead": "{count, plural, =1{Mark 1 notification as read?} other{Mark {count} notifications as read?}}",
+  "@markSelectedNotificationsAsRead": {
+    "placeholders": {
+      "count": {
+        "type": "int"
+      }
+    }
   }
 }

--- a/lib/l10n/intl_en.arb
+++ b/lib/l10n/intl_en.arb
@@ -449,5 +449,14 @@
   "areYouSureYouWantToExit": "Are you sure you want to exit?",
   "confirmToCloseTheApp": "Confirm to close the app",
   "imageSavedToGallery": "Saved to platform 'Image gallery'",
-  "failedToSaveImage": "Failed to save image"
+  "failedToSaveImage": "Failed to save image",
+  "nSelected": "{count} selected",
+  "@nSelected": {
+    "placeholders": {
+      "count": {
+        "type": "int"
+      }
+    }
+  },
+  "selectAll": "Select all"
 }

--- a/lib/l10n/intl_es_ES.arb
+++ b/lib/l10n/intl_es_ES.arb
@@ -459,7 +459,7 @@
       }
     }
   },
-  "selectAll": "Seleccionar todo",
+  "selectAll": "Seleccionar todo lo cargado",
   "failedToPerformOperation": "{count, plural, =1{1 operación falló} other{{count} operaciones fallaron}}",
   "@failedToPerformOperation": {
     "placeholders": {

--- a/lib/l10n/intl_es_ES.arb
+++ b/lib/l10n/intl_es_ES.arb
@@ -450,5 +450,14 @@
   "schedulerEvent": "Evento del planificador",
   "youDontHavePermissionsToPerformThisOperation": "¡No tiene permisos para realizar esta operación!",
   "imageSavedToGallery": "Guardado en 'Galería de imágenes'",
-  "failedToSaveImage": "Error al guardar la imagen"
+  "failedToSaveImage": "Error al guardar la imagen",
+  "nSelected": "{count} seleccionados",
+  "@nSelected": {
+    "placeholders": {
+      "count": {
+        "type": "int"
+      }
+    }
+  },
+  "selectAll": "Seleccionar todo"
 }

--- a/lib/l10n/intl_es_ES.arb
+++ b/lib/l10n/intl_es_ES.arb
@@ -467,5 +467,21 @@
         "type": "int"
       }
     }
+  },
+  "deleteSelectedNotifications": "{count, plural, =1{¿Eliminar 1 notificación?} other{¿Eliminar {count} notificaciones?}}",
+  "markSelectedNotificationsAsRead": "{count, plural, =1{¿Marcar 1 notificación como leída?} other{¿Marcar {count} notificaciones como leídas?}}",
+  "@deleteSelectedNotifications": {
+    "placeholders": {
+      "count": {
+        "type": "int"
+      }
+    }
+  },
+  "@markSelectedNotificationsAsRead": {
+    "placeholders": {
+      "count": {
+        "type": "int"
+      }
+    }
   }
 }

--- a/lib/l10n/intl_es_ES.arb
+++ b/lib/l10n/intl_es_ES.arb
@@ -459,5 +459,13 @@
       }
     }
   },
-  "selectAll": "Seleccionar todo"
+  "selectAll": "Seleccionar todo",
+  "failedToPerformOperation": "{count, plural, =1{1 operación falló} other{{count} operaciones fallaron}}",
+  "@failedToPerformOperation": {
+    "placeholders": {
+      "count": {
+        "type": "int"
+      }
+    }
+  }
 }

--- a/lib/l10n/intl_fr_FR.arb
+++ b/lib/l10n/intl_fr_FR.arb
@@ -450,5 +450,14 @@
   "schedulerEvent": "Événement du planificateur",
   "youDontHavePermissionsToPerformThisOperation": "Vous n'avez pas les autorisations pour effectuer cette opération !",
   "imageSavedToGallery": "Enregistré dans 'Galerie d’images'",
-  "failedToSaveImage": "Échec de l’enregistrement de l’image"
+  "failedToSaveImage": "Échec de l’enregistrement de l’image",
+  "nSelected": "{count} sélectionnés",
+  "@nSelected": {
+    "placeholders": {
+      "count": {
+        "type": "int"
+      }
+    }
+  },
+  "selectAll": "Tout sélectionner"
 }

--- a/lib/l10n/intl_fr_FR.arb
+++ b/lib/l10n/intl_fr_FR.arb
@@ -459,7 +459,7 @@
       }
     }
   },
-  "selectAll": "Tout sélectionner",
+  "selectAll": "Sélectionner tout le chargé",
   "failedToPerformOperation": "{count, plural, =1{1 opération a échoué} other{{count} opérations ont échoué}}",
   "@failedToPerformOperation": {
     "placeholders": {

--- a/lib/l10n/intl_fr_FR.arb
+++ b/lib/l10n/intl_fr_FR.arb
@@ -467,5 +467,21 @@
         "type": "int"
       }
     }
+  },
+  "deleteSelectedNotifications": "{count, plural, =1{Supprimer 1 notification ?} other{Supprimer {count} notifications ?}}",
+  "markSelectedNotificationsAsRead": "{count, plural, =1{Marquer 1 notification comme lue ?} other{Marquer {count} notifications comme lues ?}}",
+  "@deleteSelectedNotifications": {
+    "placeholders": {
+      "count": {
+        "type": "int"
+      }
+    }
+  },
+  "@markSelectedNotificationsAsRead": {
+    "placeholders": {
+      "count": {
+        "type": "int"
+      }
+    }
   }
 }

--- a/lib/l10n/intl_fr_FR.arb
+++ b/lib/l10n/intl_fr_FR.arb
@@ -459,5 +459,13 @@
       }
     }
   },
-  "selectAll": "Tout sélectionner"
+  "selectAll": "Tout sélectionner",
+  "failedToPerformOperation": "{count, plural, =1{1 opération a échoué} other{{count} opérations ont échoué}}",
+  "@failedToPerformOperation": {
+    "placeholders": {
+      "count": {
+        "type": "int"
+      }
+    }
+  }
 }

--- a/lib/l10n/intl_it_IT.arb
+++ b/lib/l10n/intl_it_IT.arb
@@ -450,5 +450,14 @@
   "schedulerEvent": "Evento dello scheduler",
   "youDontHavePermissionsToPerformThisOperation": "Non hai i permessi per eseguire questa operazione!",
   "imageSavedToGallery": "Salvato nella 'Galleria immagini'",
-  "failedToSaveImage": "Impossibile salvare l'immagine"
+  "failedToSaveImage": "Impossibile salvare l'immagine",
+  "nSelected": "{count} selezionati",
+  "@nSelected": {
+    "placeholders": {
+      "count": {
+        "type": "int"
+      }
+    }
+  },
+  "selectAll": "Seleziona tutto"
 }

--- a/lib/l10n/intl_it_IT.arb
+++ b/lib/l10n/intl_it_IT.arb
@@ -459,5 +459,13 @@
       }
     }
   },
-  "selectAll": "Seleziona tutto"
+  "selectAll": "Seleziona tutto",
+  "failedToPerformOperation": "{count, plural, =1{1 operazione non riuscita} other{{count} operazioni non riuscite}}",
+  "@failedToPerformOperation": {
+    "placeholders": {
+      "count": {
+        "type": "int"
+      }
+    }
+  }
 }

--- a/lib/l10n/intl_it_IT.arb
+++ b/lib/l10n/intl_it_IT.arb
@@ -459,7 +459,7 @@
       }
     }
   },
-  "selectAll": "Seleziona tutto",
+  "selectAll": "Seleziona tutti i caricati",
   "failedToPerformOperation": "{count, plural, =1{1 operazione non riuscita} other{{count} operazioni non riuscite}}",
   "@failedToPerformOperation": {
     "placeholders": {

--- a/lib/l10n/intl_it_IT.arb
+++ b/lib/l10n/intl_it_IT.arb
@@ -467,5 +467,21 @@
         "type": "int"
       }
     }
+  },
+  "deleteSelectedNotifications": "{count, plural, =1{Eliminare 1 notifica?} other{Eliminare {count} notifiche?}}",
+  "markSelectedNotificationsAsRead": "{count, plural, =1{Segnare 1 notifica come letta?} other{Segnare {count} notifiche come lette?}}",
+  "@deleteSelectedNotifications": {
+    "placeholders": {
+      "count": {
+        "type": "int"
+      }
+    }
+  },
+  "@markSelectedNotificationsAsRead": {
+    "placeholders": {
+      "count": {
+        "type": "int"
+      }
+    }
   }
 }

--- a/lib/l10n/intl_nl_NL.arb
+++ b/lib/l10n/intl_nl_NL.arb
@@ -459,7 +459,7 @@
       }
     }
   },
-  "selectAll": "Alles selecteren",
+  "selectAll": "Alle geladen selecteren",
   "failedToPerformOperation": "{count, plural, =1{1 bewerking mislukt} other{{count} bewerkingen mislukt}}",
   "@failedToPerformOperation": {
     "placeholders": {

--- a/lib/l10n/intl_nl_NL.arb
+++ b/lib/l10n/intl_nl_NL.arb
@@ -450,5 +450,14 @@
   "schedulerEvent": "Planner-evenement",
   "youDontHavePermissionsToPerformThisOperation": "U heeft geen machtigingen om deze bewerking uit te voeren!",
   "imageSavedToGallery": "Opgeslagen in 'Afbeeldingengalerij'",
-  "failedToSaveImage": "Kan afbeelding niet opslaan"
+  "failedToSaveImage": "Kan afbeelding niet opslaan",
+  "nSelected": "{count} geselecteerd",
+  "@nSelected": {
+    "placeholders": {
+      "count": {
+        "type": "int"
+      }
+    }
+  },
+  "selectAll": "Alles selecteren"
 }

--- a/lib/l10n/intl_nl_NL.arb
+++ b/lib/l10n/intl_nl_NL.arb
@@ -459,5 +459,13 @@
       }
     }
   },
-  "selectAll": "Alles selecteren"
+  "selectAll": "Alles selecteren",
+  "failedToPerformOperation": "{count, plural, =1{1 bewerking mislukt} other{{count} bewerkingen mislukt}}",
+  "@failedToPerformOperation": {
+    "placeholders": {
+      "count": {
+        "type": "int"
+      }
+    }
+  }
 }

--- a/lib/l10n/intl_nl_NL.arb
+++ b/lib/l10n/intl_nl_NL.arb
@@ -467,5 +467,21 @@
         "type": "int"
       }
     }
+  },
+  "deleteSelectedNotifications": "{count, plural, =1{1 melding verwijderen?} other{{count} meldingen verwijderen?}}",
+  "markSelectedNotificationsAsRead": "{count, plural, =1{1 melding als gelezen markeren?} other{{count} meldingen als gelezen markeren?}}",
+  "@deleteSelectedNotifications": {
+    "placeholders": {
+      "count": {
+        "type": "int"
+      }
+    }
+  },
+  "@markSelectedNotificationsAsRead": {
+    "placeholders": {
+      "count": {
+        "type": "int"
+      }
+    }
   }
 }

--- a/lib/l10n/intl_no_NO.arb
+++ b/lib/l10n/intl_no_NO.arb
@@ -459,7 +459,7 @@
       }
     }
   },
-  "selectAll": "Velg alle",
+  "selectAll": "Velg alle lastede",
   "failedToPerformOperation": "{count, plural, =1{1 handling mislyktes} other{{count} handlinger mislyktes}}",
   "@failedToPerformOperation": {
     "placeholders": {

--- a/lib/l10n/intl_no_NO.arb
+++ b/lib/l10n/intl_no_NO.arb
@@ -450,5 +450,14 @@
   "schedulerEvent": "Planlegger-hendelse",
   "youDontHavePermissionsToPerformThisOperation": "Du har ikke tillatelser til å utføre denne operasjonen!",
   "imageSavedToGallery": "Lagret i 'Bildegalleri'",
-  "failedToSaveImage": "Kunne ikke lagre bildet"
+  "failedToSaveImage": "Kunne ikke lagre bildet",
+  "nSelected": "{count} valgt",
+  "@nSelected": {
+    "placeholders": {
+      "count": {
+        "type": "int"
+      }
+    }
+  },
+  "selectAll": "Velg alle"
 }

--- a/lib/l10n/intl_no_NO.arb
+++ b/lib/l10n/intl_no_NO.arb
@@ -467,5 +467,21 @@
         "type": "int"
       }
     }
+  },
+  "deleteSelectedNotifications": "{count, plural, =1{Slette 1 varsling?} other{Slette {count} varslinger?}}",
+  "markSelectedNotificationsAsRead": "{count, plural, =1{Markere 1 varsling som lest?} other{Markere {count} varslinger som lest?}}",
+  "@deleteSelectedNotifications": {
+    "placeholders": {
+      "count": {
+        "type": "int"
+      }
+    }
+  },
+  "@markSelectedNotificationsAsRead": {
+    "placeholders": {
+      "count": {
+        "type": "int"
+      }
+    }
   }
 }

--- a/lib/l10n/intl_no_NO.arb
+++ b/lib/l10n/intl_no_NO.arb
@@ -459,5 +459,13 @@
       }
     }
   },
-  "selectAll": "Velg alle"
+  "selectAll": "Velg alle",
+  "failedToPerformOperation": "{count, plural, =1{1 handling mislyktes} other{{count} handlinger mislyktes}}",
+  "@failedToPerformOperation": {
+    "placeholders": {
+      "count": {
+        "type": "int"
+      }
+    }
+  }
 }

--- a/lib/l10n/intl_vi_VN.arb
+++ b/lib/l10n/intl_vi_VN.arb
@@ -458,5 +458,13 @@
       }
     }
   },
-  "selectAll": "Chọn tất cả"
+  "selectAll": "Chọn tất cả",
+  "failedToPerformOperation": "{count, plural, =1{1 thao tác thất bại} other{{count} thao tác thất bại}}",
+  "@failedToPerformOperation": {
+    "placeholders": {
+      "count": {
+        "type": "int"
+      }
+    }
+  }
 }

--- a/lib/l10n/intl_vi_VN.arb
+++ b/lib/l10n/intl_vi_VN.arb
@@ -466,5 +466,21 @@
         "type": "int"
       }
     }
+  },
+  "deleteSelectedNotifications": "{count, plural, =1{Xóa 1 thông báo?} other{Xóa {count} thông báo?}}",
+  "markSelectedNotificationsAsRead": "{count, plural, =1{Đánh dấu 1 thông báo đã đọc?} other{Đánh dấu {count} thông báo đã đọc?}}",
+  "@deleteSelectedNotifications": {
+    "placeholders": {
+      "count": {
+        "type": "int"
+      }
+    }
+  },
+  "@markSelectedNotificationsAsRead": {
+    "placeholders": {
+      "count": {
+        "type": "int"
+      }
+    }
   }
 }

--- a/lib/l10n/intl_vi_VN.arb
+++ b/lib/l10n/intl_vi_VN.arb
@@ -458,7 +458,7 @@
       }
     }
   },
-  "selectAll": "Chọn tất cả",
+  "selectAll": "Chọn tất cả đã tải",
   "failedToPerformOperation": "{count, plural, =1{1 thao tác thất bại} other{{count} thao tác thất bại}}",
   "@failedToPerformOperation": {
     "placeholders": {

--- a/lib/l10n/intl_vi_VN.arb
+++ b/lib/l10n/intl_vi_VN.arb
@@ -449,5 +449,14 @@
   "schedulerEvent": "Sự kiện lập lịch",
   "youDontHavePermissionsToPerformThisOperation": "Bạn không có quyền để thực hiện thao tác này!",
   "imageSavedToGallery": "Đã lưu vào 'Thư viện ảnh'",
-  "failedToSaveImage": "Không thể lưu ảnh"
+  "failedToSaveImage": "Không thể lưu ảnh",
+  "nSelected": "{count} đã chọn",
+  "@nSelected": {
+    "placeholders": {
+      "count": {
+        "type": "int"
+      }
+    }
+  },
+  "selectAll": "Chọn tất cả"
 }

--- a/lib/l10n/intl_zh.arb
+++ b/lib/l10n/intl_zh.arb
@@ -449,5 +449,13 @@
       }
     }
   },
-  "selectAll": "全选"
+  "selectAll": "全选",
+  "failedToPerformOperation": "{count, plural, =1{1 项操作失败} other{{count} 项操作失败}}",
+  "@failedToPerformOperation": {
+    "placeholders": {
+      "count": {
+        "type": "int"
+      }
+    }
+  }
 }

--- a/lib/l10n/intl_zh.arb
+++ b/lib/l10n/intl_zh.arb
@@ -440,5 +440,14 @@
   "areYouSureYouWantToExit": "Are you sure you want to exit?",
   "confirmToCloseTheApp": "Confirm to close the app",
   "imageSavedToGallery": "已保存到“图片库”",
-  "failedToSaveImage": "保存图片失败"
+  "failedToSaveImage": "保存图片失败",
+  "nSelected": "已选择 {count} 项",
+  "@nSelected": {
+    "placeholders": {
+      "count": {
+        "type": "int"
+      }
+    }
+  },
+  "selectAll": "全选"
 }

--- a/lib/l10n/intl_zh.arb
+++ b/lib/l10n/intl_zh.arb
@@ -457,5 +457,21 @@
         "type": "int"
       }
     }
+  },
+  "deleteSelectedNotifications": "{count, plural, =1{删除 1 条通知？} other{删除 {count} 条通知？}}",
+  "markSelectedNotificationsAsRead": "{count, plural, =1{将 1 条通知标记为已读？} other{将 {count} 条通知标记为已读？}}",
+  "@deleteSelectedNotifications": {
+    "placeholders": {
+      "count": {
+        "type": "int"
+      }
+    }
+  },
+  "@markSelectedNotificationsAsRead": {
+    "placeholders": {
+      "count": {
+        "type": "int"
+      }
+    }
   }
 }

--- a/lib/l10n/intl_zh.arb
+++ b/lib/l10n/intl_zh.arb
@@ -449,7 +449,7 @@
       }
     }
   },
-  "selectAll": "全选",
+  "selectAll": "全选已加载",
   "failedToPerformOperation": "{count, plural, =1{1 项操作失败} other{{count} 项操作失败}}",
   "@failedToPerformOperation": {
     "placeholders": {

--- a/lib/l10n/intl_zh_CN.arb
+++ b/lib/l10n/intl_zh_CN.arb
@@ -466,5 +466,21 @@
         "type": "int"
       }
     }
+  },
+  "deleteSelectedNotifications": "{count, plural, =1{删除 1 条通知？} other{删除 {count} 条通知？}}",
+  "markSelectedNotificationsAsRead": "{count, plural, =1{将 1 条通知标记为已读？} other{将 {count} 条通知标记为已读？}}",
+  "@deleteSelectedNotifications": {
+    "placeholders": {
+      "count": {
+        "type": "int"
+      }
+    }
+  },
+  "@markSelectedNotificationsAsRead": {
+    "placeholders": {
+      "count": {
+        "type": "int"
+      }
+    }
   }
 }

--- a/lib/l10n/intl_zh_CN.arb
+++ b/lib/l10n/intl_zh_CN.arb
@@ -458,7 +458,7 @@
       }
     }
   },
-  "selectAll": "全选",
+  "selectAll": "全选已加载",
   "failedToPerformOperation": "{count, plural, =1{1 项操作失败} other{{count} 项操作失败}}",
   "@failedToPerformOperation": {
     "placeholders": {

--- a/lib/l10n/intl_zh_CN.arb
+++ b/lib/l10n/intl_zh_CN.arb
@@ -449,5 +449,14 @@
   "schedulerEvent": "调度事件",
   "youDontHavePermissionsToPerformThisOperation": "您没有执行此操作的权限！",
   "imageSavedToGallery": "已保存到“图片库”",
-  "failedToSaveImage": "保存图片失败"
+  "failedToSaveImage": "保存图片失败",
+  "nSelected": "已选择 {count} 项",
+  "@nSelected": {
+    "placeholders": {
+      "count": {
+        "type": "int"
+      }
+    }
+  },
+  "selectAll": "全选"
 }

--- a/lib/l10n/intl_zh_CN.arb
+++ b/lib/l10n/intl_zh_CN.arb
@@ -458,5 +458,13 @@
       }
     }
   },
-  "selectAll": "全选"
+  "selectAll": "全选",
+  "failedToPerformOperation": "{count, plural, =1{1 项操作失败} other{{count} 项操作失败}}",
+  "@failedToPerformOperation": {
+    "placeholders": {
+      "count": {
+        "type": "int"
+      }
+    }
+  }
 }

--- a/lib/l10n/intl_zh_TW.arb
+++ b/lib/l10n/intl_zh_TW.arb
@@ -458,5 +458,13 @@
       }
     }
   },
-  "selectAll": "全選"
+  "selectAll": "全選",
+  "failedToPerformOperation": "{count, plural, =1{1 項操作失敗} other{{count} 項操作失敗}}",
+  "@failedToPerformOperation": {
+    "placeholders": {
+      "count": {
+        "type": "int"
+      }
+    }
+  }
 }

--- a/lib/l10n/intl_zh_TW.arb
+++ b/lib/l10n/intl_zh_TW.arb
@@ -449,5 +449,14 @@
   "schedulerEvent": "排程事件",
   "youDontHavePermissionsToPerformThisOperation": "您沒有執行此操作的權限！",
   "imageSavedToGallery": "已儲存至「圖片庫」",
-  "failedToSaveImage": "儲存圖片失敗"
+  "failedToSaveImage": "儲存圖片失敗",
+  "nSelected": "已選擇 {count} 項",
+  "@nSelected": {
+    "placeholders": {
+      "count": {
+        "type": "int"
+      }
+    }
+  },
+  "selectAll": "全選"
 }

--- a/lib/l10n/intl_zh_TW.arb
+++ b/lib/l10n/intl_zh_TW.arb
@@ -466,5 +466,21 @@
         "type": "int"
       }
     }
+  },
+  "deleteSelectedNotifications": "{count, plural, =1{刪除 1 則通知？} other{刪除 {count} 則通知？}}",
+  "markSelectedNotificationsAsRead": "{count, plural, =1{將 1 則通知標記為已讀？} other{將 {count} 則通知標記為已讀？}}",
+  "@deleteSelectedNotifications": {
+    "placeholders": {
+      "count": {
+        "type": "int"
+      }
+    }
+  },
+  "@markSelectedNotificationsAsRead": {
+    "placeholders": {
+      "count": {
+        "type": "int"
+      }
+    }
   }
 }

--- a/lib/l10n/intl_zh_TW.arb
+++ b/lib/l10n/intl_zh_TW.arb
@@ -458,7 +458,7 @@
       }
     }
   },
-  "selectAll": "全選",
+  "selectAll": "全選已載入",
   "failedToPerformOperation": "{count, plural, =1{1 項操作失敗} other{{count} 項操作失敗}}",
   "@failedToPerformOperation": {
     "placeholders": {

--- a/lib/modules/notification/notification_page.dart
+++ b/lib/modules/notification/notification_page.dart
@@ -1,6 +1,7 @@
 import 'dart:async';
 
 import 'package:flutter/material.dart';
+import 'package:thingsboard_app/config/themes/app_colors.dart';
 import 'package:thingsboard_app/generated/l10n.dart';
 import 'package:thingsboard_app/locator.dart';
 import 'package:thingsboard_app/modules/notification/controllers/notification_query_ctrl.dart';
@@ -36,6 +37,8 @@ class _NotificationPageState extends State<NotificationPage> {
   bool isSelectionMode = false;
   Set<String> selectedIds = {};
   bool isProcessing = false;
+  int processedCount = 0;
+  int totalToProcess = 0;
 
   @override
   Widget build(BuildContext context) {
@@ -198,7 +201,10 @@ class _NotificationPageState extends State<NotificationPage> {
       child: Column(
         mainAxisSize: MainAxisSize.min,
         children: [
-          if (isProcessing) const LinearProgressIndicator(),
+          if (isProcessing)
+            LinearProgressIndicator(
+              value: totalToProcess > 0 ? processedCount / totalToProcess : null,
+            ),
           Padding(
             padding: const EdgeInsets.symmetric(horizontal: 16, vertical: 8),
             child: Row(
@@ -212,12 +218,12 @@ class _NotificationPageState extends State<NotificationPage> {
                     icon: const Icon(Icons.delete_outline),
                     label: Text(S.of(context).delete),
                     style: OutlinedButton.styleFrom(
-                      foregroundColor: const Color(0xFFD12730),
+                      foregroundColor: AppColors.notificationError,
                       side: BorderSide(
                         color:
                             isProcessing || selectedIds.isEmpty
                                 ? Colors.grey.shade300
-                                : const Color(0xFFD12730),
+                                : AppColors.notificationError,
                       ),
                     ),
                   ),
@@ -226,18 +232,18 @@ class _NotificationPageState extends State<NotificationPage> {
                 Expanded(
                   child: OutlinedButton.icon(
                     onPressed:
-                        isProcessing || selectedIds.isEmpty
+                        isProcessing || selectedIds.isEmpty || !_hasUnreadSelected
                             ? null
                             : _batchMarkAsRead,
                     icon: const Icon(Icons.check_circle_outline),
                     label: Text(S.of(context).markAsRead),
                     style: OutlinedButton.styleFrom(
-                      foregroundColor: const Color(0xFF198038),
+                      foregroundColor: AppColors.notificationSuccess,
                       side: BorderSide(
                         color:
-                            isProcessing || selectedIds.isEmpty
+                            isProcessing || selectedIds.isEmpty || !_hasUnreadSelected
                                 ? Colors.grey.shade300
-                                : const Color(0xFF198038),
+                                : AppColors.notificationSuccess,
                       ),
                     ),
                   ),
@@ -293,12 +299,37 @@ class _NotificationPageState extends State<NotificationPage> {
     return selectedIds.length == items.length;
   }
 
+  bool get _hasUnreadSelected {
+    final items = paginationRepository.pagingController.itemList;
+    if (items == null || items.isEmpty) return false;
+    return items.any(
+      (n) =>
+          selectedIds.contains(n.id!.id!) &&
+          n.status != PushNotificationStatus.READ,
+    );
+  }
+
   Future<void> _batchDelete() async {
-    setState(() => isProcessing = true);
+    final count = selectedIds.length;
+    final confirmed = await overlayService.showConfirmDialog(
+      content: (_) => DialogContent(
+        title: S.of(context).areYouSure,
+        message: S.of(context).deleteSelectedNotifications(count),
+        ok: S.of(context).delete,
+        cancel: S.of(context).no,
+      ),
+    );
+    if (confirmed != true) return;
 
     final items = paginationRepository.pagingController.itemList ?? [];
     final toDelete =
         items.where((n) => selectedIds.contains(n.id!.id!)).toList();
+
+    setState(() {
+      isProcessing = true;
+      processedCount = 0;
+      totalToProcess = toDelete.length;
+    });
 
     int unreadCount = 0;
     int failCount = 0;
@@ -311,6 +342,7 @@ class _NotificationPageState extends State<NotificationPage> {
       } catch (_) {
         failCount++;
       }
+      if (mounted) setState(() => processedCount++);
     }
 
     for (int i = 0; i < unreadCount; i++) {
@@ -331,8 +363,6 @@ class _NotificationPageState extends State<NotificationPage> {
   }
 
   Future<void> _batchMarkAsRead() async {
-    setState(() => isProcessing = true);
-
     final items = paginationRepository.pagingController.itemList ?? [];
     final toMark = items
         .where(
@@ -341,6 +371,22 @@ class _NotificationPageState extends State<NotificationPage> {
               n.status != PushNotificationStatus.READ,
         )
         .toList();
+
+    final confirmed = await overlayService.showConfirmDialog(
+      content: (_) => DialogContent(
+        title: S.of(context).areYouSure,
+        message: S.of(context).markSelectedNotificationsAsRead(toMark.length),
+        ok: S.of(context).markAsRead,
+        cancel: S.of(context).no,
+      ),
+    );
+    if (confirmed != true) return;
+
+    setState(() {
+      isProcessing = true;
+      processedCount = 0;
+      totalToProcess = toMark.length;
+    });
 
     int failCount = 0;
     for (final notification in toMark) {
@@ -351,6 +397,7 @@ class _NotificationPageState extends State<NotificationPage> {
       } catch (_) {
         failCount++;
       }
+      if (mounted) setState(() => processedCount++);
     }
 
     if (mounted) {

--- a/lib/modules/notification/notification_page.dart
+++ b/lib/modules/notification/notification_page.dart
@@ -195,51 +195,57 @@ class _NotificationPageState extends State<NotificationPage> {
 
   Widget _buildSelectionActionBar() {
     return SafeArea(
-      child: Padding(
-        padding: const EdgeInsets.symmetric(horizontal: 16, vertical: 8),
-        child: Row(
-          children: [
-            Expanded(
-              child: OutlinedButton.icon(
-                onPressed:
-                    isProcessing || selectedIds.isEmpty
-                        ? null
-                        : _batchDelete,
-                icon: const Icon(Icons.delete_outline),
-                label: Text(S.of(context).delete),
-                style: OutlinedButton.styleFrom(
-                  foregroundColor: const Color(0xFFD12730),
-                  side: BorderSide(
-                    color:
+      child: Column(
+        mainAxisSize: MainAxisSize.min,
+        children: [
+          if (isProcessing) const LinearProgressIndicator(),
+          Padding(
+            padding: const EdgeInsets.symmetric(horizontal: 16, vertical: 8),
+            child: Row(
+              children: [
+                Expanded(
+                  child: OutlinedButton.icon(
+                    onPressed:
                         isProcessing || selectedIds.isEmpty
-                            ? Colors.grey.shade300
-                            : const Color(0xFFD12730),
+                            ? null
+                            : _batchDelete,
+                    icon: const Icon(Icons.delete_outline),
+                    label: Text(S.of(context).delete),
+                    style: OutlinedButton.styleFrom(
+                      foregroundColor: const Color(0xFFD12730),
+                      side: BorderSide(
+                        color:
+                            isProcessing || selectedIds.isEmpty
+                                ? Colors.grey.shade300
+                                : const Color(0xFFD12730),
+                      ),
+                    ),
                   ),
                 ),
-              ),
-            ),
-            const SizedBox(width: 12),
-            Expanded(
-              child: OutlinedButton.icon(
-                onPressed:
-                    isProcessing || selectedIds.isEmpty
-                        ? null
-                        : _batchMarkAsRead,
-                icon: const Icon(Icons.check_circle_outline),
-                label: Text(S.of(context).markAsRead),
-                style: OutlinedButton.styleFrom(
-                  foregroundColor: const Color(0xFF198038),
-                  side: BorderSide(
-                    color:
+                const SizedBox(width: 12),
+                Expanded(
+                  child: OutlinedButton.icon(
+                    onPressed:
                         isProcessing || selectedIds.isEmpty
-                            ? Colors.grey.shade300
-                            : const Color(0xFF198038),
+                            ? null
+                            : _batchMarkAsRead,
+                    icon: const Icon(Icons.check_circle_outline),
+                    label: Text(S.of(context).markAsRead),
+                    style: OutlinedButton.styleFrom(
+                      foregroundColor: const Color(0xFF198038),
+                      side: BorderSide(
+                        color:
+                            isProcessing || selectedIds.isEmpty
+                                ? Colors.grey.shade300
+                                : const Color(0xFF198038),
+                      ),
+                    ),
                   ),
                 ),
-              ),
+              ],
             ),
-          ],
-        ),
+          ),
+        ],
       ),
     );
   }
@@ -295,13 +301,16 @@ class _NotificationPageState extends State<NotificationPage> {
         items.where((n) => selectedIds.contains(n.id!.id!)).toList();
 
     int unreadCount = 0;
+    int failCount = 0;
     for (final notification in toDelete) {
       try {
         await notificationRepository.deleteNotification(notification.id!.id!);
         if (notification.status != PushNotificationStatus.READ) {
           unreadCount++;
         }
-      } catch (_) {}
+      } catch (_) {
+        failCount++;
+      }
     }
 
     for (int i = 0; i < unreadCount; i++) {
@@ -312,6 +321,12 @@ class _NotificationPageState extends State<NotificationPage> {
       _exitSelectionMode();
       setState(() => isProcessing = false);
       notificationQueryCtrl.refresh();
+
+      if (failCount > 0) {
+        overlayService.showWarnNotification(
+          (_) => S.of(context).failedToPerformOperation(failCount),
+        );
+      }
     }
   }
 
@@ -327,18 +342,27 @@ class _NotificationPageState extends State<NotificationPage> {
         )
         .toList();
 
+    int failCount = 0;
     for (final notification in toMark) {
       try {
         await notificationRepository
             .markNotificationAsRead(notification.id!.id!);
         await notificationRepository.decreaseNotificationBadgeCount();
-      } catch (_) {}
+      } catch (_) {
+        failCount++;
+      }
     }
 
     if (mounted) {
       _exitSelectionMode();
       setState(() => isProcessing = false);
       notificationQueryCtrl.refresh();
+
+      if (failCount > 0) {
+        overlayService.showWarnNotification(
+          (_) => S.of(context).failedToPerformOperation(failCount),
+        );
+      }
     }
   }
 

--- a/lib/modules/notification/notification_page.dart
+++ b/lib/modules/notification/notification_page.dart
@@ -37,6 +37,7 @@ class _NotificationPageState extends State<NotificationPage> {
   bool isSelectionMode = false;
   Set<String> selectedIds = {};
   bool isProcessing = false;
+  bool _cancelRequested = false;
   int processedCount = 0;
   int totalToProcess = 0;
 
@@ -269,6 +270,9 @@ class _NotificationPageState extends State<NotificationPage> {
     setState(() {
       isSelectionMode = false;
       selectedIds = {};
+      if (isProcessing) {
+        _cancelRequested = true;
+      }
     });
   }
 
@@ -334,6 +338,7 @@ class _NotificationPageState extends State<NotificationPage> {
     int unreadCount = 0;
     int failCount = 0;
     for (final notification in toDelete) {
+      if (_cancelRequested) break;
       try {
         await notificationRepository.deleteNotification(notification.id!.id!);
         if (notification.status != PushNotificationStatus.READ) {
@@ -350,8 +355,13 @@ class _NotificationPageState extends State<NotificationPage> {
     }
 
     if (mounted) {
-      _exitSelectionMode();
-      setState(() => isProcessing = false);
+      if (!_cancelRequested) {
+        _exitSelectionMode();
+      }
+      setState(() {
+        isProcessing = false;
+        _cancelRequested = false;
+      });
       notificationQueryCtrl.refresh();
 
       if (failCount > 0) {
@@ -390,6 +400,7 @@ class _NotificationPageState extends State<NotificationPage> {
 
     int failCount = 0;
     for (final notification in toMark) {
+      if (_cancelRequested) break;
       try {
         await notificationRepository
             .markNotificationAsRead(notification.id!.id!);
@@ -401,8 +412,13 @@ class _NotificationPageState extends State<NotificationPage> {
     }
 
     if (mounted) {
-      _exitSelectionMode();
-      setState(() => isProcessing = false);
+      if (!_cancelRequested) {
+        _exitSelectionMode();
+      }
+      setState(() {
+        isProcessing = false;
+        _cancelRequested = false;
+      });
       notificationQueryCtrl.refresh();
 
       if (failCount > 0) {

--- a/lib/modules/notification/notification_page.dart
+++ b/lib/modules/notification/notification_page.dart
@@ -13,7 +13,6 @@ import 'package:thingsboard_app/modules/notification/widgets/notification_list.d
 import 'package:thingsboard_app/thingsboard_client.dart';
 import 'package:thingsboard_app/utils/services/firebase/i_firebase_service.dart';
 import 'package:thingsboard_app/utils/services/overlay_service/i_overlay_service.dart';
-import 'package:thingsboard_app/utils/services/overlay_service/overlay_service.dart';
 import 'package:thingsboard_app/utils/services/tb_client_service/i_tb_client_service.dart';
 import 'package:thingsboard_app/widgets/tb_app_bar.dart';
 
@@ -33,96 +32,314 @@ class _NotificationPageState extends State<NotificationPage> {
   late final NotificationRepository notificationRepository;
   final overlayService = getIt<IOverlayService>();
   late final StreamSubscription<int> listener;
+
+  bool isSelectionMode = false;
+  Set<String> selectedIds = {};
+  bool isProcessing = false;
+
   @override
   Widget build(BuildContext context) {
-    return Scaffold(
-      appBar: TbAppBar(
-        title: Text(S.of(context).notifications(2)),
-        actions: [
-          TextButton(
-            child: Text(
-              S.of(context).markAllAsRead,
-              style: TextStyle(color: Theme.of(context).primaryColor),
-            ),
-            onPressed: () async {
-              await notificationRepository.markAllAsRead();
+    return PopScope(
+      canPop: !isSelectionMode,
+      onPopInvokedWithResult: (didPop, _) {
+        if (!didPop && isSelectionMode) {
+          _exitSelectionMode();
+        }
+      },
+      child: Scaffold(
+        appBar: isSelectionMode ? _buildSelectionAppBar() : _buildNormalAppBar(),
+        body: RefreshIndicator(
+          onRefresh: () => _refresh(),
+          child: SafeArea(
+            child: Padding(
+              padding: const EdgeInsets.symmetric(horizontal: 5, vertical: 10),
+              child: Column(
+                crossAxisAlignment: CrossAxisAlignment.start,
+                children: [
+                  Padding(
+                    padding: const EdgeInsets.only(top: 10, bottom: 20),
+                    child: FilterSegmentedButton(
+                      selected: notificationsFilter,
+                      onSelectionChanged: (newSelection) {
+                        if (notificationsFilter == newSelection) {
+                          return;
+                        }
 
-              if (mounted) {
-                notificationQueryCtrl.refresh();
-              }
-            },
-          ),
-        ],
-      ),
-      body: RefreshIndicator(
-        onRefresh: () => _refresh(),
-        child: SafeArea(
-          child: Padding(
-            padding: const EdgeInsets.symmetric(horizontal: 5, vertical: 10),
-            child: Column(
-              crossAxisAlignment: CrossAxisAlignment.start,
-              children: [
-                Padding(
-                  padding: const EdgeInsets.only(top: 10, bottom: 20),
-                  child: FilterSegmentedButton(
-                    selected: notificationsFilter,
-                    onSelectionChanged: (newSelection) {
-                      if (notificationsFilter == newSelection) {
-                        return;
-                      }
+                        _exitSelectionMode();
+                        setState(() {
+                          notificationsFilter = newSelection;
 
-                      setState(() {
-                        notificationsFilter = newSelection;
-
-                        notificationRepository.filterByReadStatus(
-                          notificationsFilter == NotificationsFilter.unread,
-                        );
-                      });
-                    },
-                    segments: [
-                      FilterSegments(
-                        label: S.of(context).unread,
-                        value: NotificationsFilter.unread,
-                      ),
-                      FilterSegments(
-                        label: S.of(context).all,
-                        value: NotificationsFilter.all,
-                      ),
-                    ],
+                          notificationRepository.filterByReadStatus(
+                            notificationsFilter == NotificationsFilter.unread,
+                          );
+                        });
+                      },
+                      segments: [
+                        FilterSegments(
+                          label: S.of(context).unread,
+                          value: NotificationsFilter.unread,
+                        ),
+                        FilterSegments(
+                          label: S.of(context).all,
+                          value: NotificationsFilter.all,
+                        ),
+                      ],
+                    ),
                   ),
-                ),
-                Expanded(
-                  child: NotificationsList(
-                    pagingController: paginationRepository.pagingController,
-                    thingsboardClient: getIt<ITbClientService>().client,
-                    onClearNotification: (id, read) async {
-                      await notificationRepository.deleteNotification(id);
-                      if (!read) {
+                  Expanded(
+                    child: NotificationsList(
+                      pagingController: paginationRepository.pagingController,
+                      thingsboardClient: getIt<ITbClientService>().client,
+                      isSelectionMode: isSelectionMode,
+                      selectedIds: selectedIds,
+                      onToggleSelection: _toggleSelection,
+                      onLongPress: _enterSelectionMode,
+                      onClearNotification: (id, read) async {
+                        await notificationRepository.deleteNotification(id);
+                        if (!read) {
+                          await notificationRepository
+                              .decreaseNotificationBadgeCount();
+                        }
+
+                        if (mounted) {
+                          notificationQueryCtrl.refresh();
+                        }
+                      },
+                      onReadNotification: (id) async {
+                        await notificationRepository.markNotificationAsRead(id);
                         await notificationRepository
                             .decreaseNotificationBadgeCount();
-                      }
 
-                      if (mounted) {
-                        notificationQueryCtrl.refresh();
-                      }
-                    },
-                    onReadNotification: (id) async {
-                      await notificationRepository.markNotificationAsRead(id);
-                      await notificationRepository
-                          .decreaseNotificationBadgeCount();
-
-                      if (mounted) {
-                        notificationQueryCtrl.refresh();
-                      }
-                    },
+                        if (mounted) {
+                          notificationQueryCtrl.refresh();
+                        }
+                      },
+                    ),
                   ),
-                ),
-              ],
+                ],
+              ),
             ),
           ),
         ),
+        bottomNavigationBar:
+            isSelectionMode ? _buildSelectionActionBar() : null,
       ),
     );
+  }
+
+  TbAppBar _buildNormalAppBar() {
+    return TbAppBar(
+      title: Text(S.of(context).notifications(2)),
+      actions: [
+        TextButton(
+          child: Text(
+            S.of(context).markAllAsRead,
+            style: TextStyle(color: Theme.of(context).primaryColor),
+          ),
+          onPressed: () async {
+            await notificationRepository.markAllAsRead();
+
+            if (mounted) {
+              notificationQueryCtrl.refresh();
+            }
+          },
+        ),
+      ],
+    );
+  }
+
+  TbAppBar _buildSelectionAppBar() {
+    final allSelected = _allSelected;
+    return TbAppBar(
+      canGoBack: false,
+      leading: IconButton(
+        icon: const Icon(Icons.close),
+        onPressed: _exitSelectionMode,
+      ),
+      title: Text(S.of(context).nSelected(selectedIds.length)),
+      actions: [
+        Row(
+          mainAxisSize: MainAxisSize.min,
+          children: [
+            Checkbox(
+              value: allSelected,
+              onChanged: (_) {
+                if (allSelected) {
+                  _exitSelectionMode();
+                } else {
+                  _selectAll();
+                }
+              },
+            ),
+            Padding(
+              padding: const EdgeInsets.only(right: 8),
+              child: GestureDetector(
+                onTap: () {
+                  if (allSelected) {
+                    _exitSelectionMode();
+                  } else {
+                    _selectAll();
+                  }
+                },
+                child: Text(
+                  S.of(context).selectAll,
+                  style: TextStyle(color: Theme.of(context).primaryColor),
+                ),
+              ),
+            ),
+          ],
+        ),
+      ],
+    );
+  }
+
+  Widget _buildSelectionActionBar() {
+    return SafeArea(
+      child: Padding(
+        padding: const EdgeInsets.symmetric(horizontal: 16, vertical: 8),
+        child: Row(
+          children: [
+            Expanded(
+              child: OutlinedButton.icon(
+                onPressed:
+                    isProcessing || selectedIds.isEmpty
+                        ? null
+                        : _batchDelete,
+                icon: const Icon(Icons.delete_outline),
+                label: Text(S.of(context).delete),
+                style: OutlinedButton.styleFrom(
+                  foregroundColor: const Color(0xFFD12730),
+                  side: BorderSide(
+                    color:
+                        isProcessing || selectedIds.isEmpty
+                            ? Colors.grey.shade300
+                            : const Color(0xFFD12730),
+                  ),
+                ),
+              ),
+            ),
+            const SizedBox(width: 12),
+            Expanded(
+              child: OutlinedButton.icon(
+                onPressed:
+                    isProcessing || selectedIds.isEmpty
+                        ? null
+                        : _batchMarkAsRead,
+                icon: const Icon(Icons.check_circle_outline),
+                label: Text(S.of(context).markAsRead),
+                style: OutlinedButton.styleFrom(
+                  foregroundColor: const Color(0xFF198038),
+                  side: BorderSide(
+                    color:
+                        isProcessing || selectedIds.isEmpty
+                            ? Colors.grey.shade300
+                            : const Color(0xFF198038),
+                  ),
+                ),
+              ),
+            ),
+          ],
+        ),
+      ),
+    );
+  }
+
+  void _enterSelectionMode(String id) {
+    if (isSelectionMode) return;
+    setState(() {
+      isSelectionMode = true;
+      selectedIds = {id};
+    });
+  }
+
+  void _exitSelectionMode() {
+    if (!isSelectionMode) return;
+    setState(() {
+      isSelectionMode = false;
+      selectedIds = {};
+    });
+  }
+
+  void _toggleSelection(String id) {
+    setState(() {
+      if (selectedIds.contains(id)) {
+        selectedIds.remove(id);
+        if (selectedIds.isEmpty) {
+          isSelectionMode = false;
+        }
+      } else {
+        selectedIds.add(id);
+      }
+    });
+  }
+
+  void _selectAll() {
+    final items = paginationRepository.pagingController.itemList;
+    if (items == null || items.isEmpty) return;
+    setState(() {
+      selectedIds = items.map((n) => n.id!.id!).toSet();
+    });
+  }
+
+  bool get _allSelected {
+    final items = paginationRepository.pagingController.itemList;
+    if (items == null || items.isEmpty) return false;
+    return selectedIds.length == items.length;
+  }
+
+  Future<void> _batchDelete() async {
+    setState(() => isProcessing = true);
+
+    final items = paginationRepository.pagingController.itemList ?? [];
+    final toDelete =
+        items.where((n) => selectedIds.contains(n.id!.id!)).toList();
+
+    int unreadCount = 0;
+    for (final notification in toDelete) {
+      try {
+        await notificationRepository.deleteNotification(notification.id!.id!);
+        if (notification.status != PushNotificationStatus.READ) {
+          unreadCount++;
+        }
+      } catch (_) {}
+    }
+
+    for (int i = 0; i < unreadCount; i++) {
+      await notificationRepository.decreaseNotificationBadgeCount();
+    }
+
+    if (mounted) {
+      _exitSelectionMode();
+      setState(() => isProcessing = false);
+      notificationQueryCtrl.refresh();
+    }
+  }
+
+  Future<void> _batchMarkAsRead() async {
+    setState(() => isProcessing = true);
+
+    final items = paginationRepository.pagingController.itemList ?? [];
+    final toMark = items
+        .where(
+          (n) =>
+              selectedIds.contains(n.id!.id!) &&
+              n.status != PushNotificationStatus.READ,
+        )
+        .toList();
+
+    for (final notification in toMark) {
+      try {
+        await notificationRepository
+            .markNotificationAsRead(notification.id!.id!);
+        await notificationRepository.decreaseNotificationBadgeCount();
+      } catch (_) {}
+    }
+
+    if (mounted) {
+      _exitSelectionMode();
+      setState(() => isProcessing = false);
+      notificationQueryCtrl.refresh();
+    }
   }
 
   @override
@@ -178,6 +395,7 @@ class _NotificationPageState extends State<NotificationPage> {
   }
 
   Future<void> _refresh() async {
+    _exitSelectionMode();
     if (mounted) {
       notificationQueryCtrl.refresh();
     }

--- a/lib/modules/notification/widgets/notification_list.dart
+++ b/lib/modules/notification/widgets/notification_list.dart
@@ -12,13 +12,20 @@ class NotificationsList extends StatelessWidget {
     required this.thingsboardClient,
     required this.onClearNotification,
     required this.onReadNotification,
-
+    this.isSelectionMode = false,
+    this.selectedIds = const {},
+    this.onToggleSelection,
+    this.onLongPress,
     super.key,
   });
 
   final ThingsboardClient thingsboardClient;
   final Function(String id, bool read) onClearNotification;
   final ValueChanged<String> onReadNotification;
+  final bool isSelectionMode;
+  final Set<String> selectedIds;
+  final ValueChanged<String>? onToggleSelection;
+  final ValueChanged<String>? onLongPress;
 
   final PagingController<PushNotificationQuery, PushNotification>
   pagingController;
@@ -29,17 +36,22 @@ class NotificationsList extends StatelessWidget {
       pagingController: pagingController,
       builderDelegate: PagedChildBuilderDelegate(
         itemBuilder: (context, item, index) {
+          final id = item.id!.id!;
           return NotificationSlidableWidget(
             notification: item,
             onReadNotification: onReadNotification,
             onClearNotification: onClearNotification,
-
+            isSelectionMode: isSelectionMode,
             thingsboardClient: thingsboardClient,
             child: NotificationWidget(
               notification: item,
               thingsboardClient: thingsboardClient,
               onClearNotification: onClearNotification,
               onReadNotification: onReadNotification,
+              isSelectionMode: isSelectionMode,
+              isSelected: selectedIds.contains(id),
+              onToggleSelection: () => onToggleSelection?.call(id),
+              onLongPress: () => onLongPress?.call(id),
             ),
           );
         },

--- a/lib/modules/notification/widgets/notification_slidable_widget.dart
+++ b/lib/modules/notification/widgets/notification_slidable_widget.dart
@@ -12,7 +12,7 @@ class NotificationSlidableWidget extends StatefulWidget {
     required this.thingsboardClient,
     required this.onClearNotification,
     required this.onReadNotification,
-
+    this.isSelectionMode = false,
     super.key,
   });
 
@@ -21,6 +21,7 @@ class NotificationSlidableWidget extends StatefulWidget {
   final ThingsboardClient thingsboardClient;
   final Function(String id, bool read) onClearNotification;
   final ValueChanged<String> onReadNotification;
+  final bool isSelectionMode;
 
   @override
   State<StatefulWidget> createState() => _NotificationSlidableWidget();
@@ -37,6 +38,10 @@ class _NotificationSlidableWidget extends State<NotificationSlidableWidget> {
         alignment: Alignment.center,
         child: const RefreshProgressIndicator(),
       );
+    }
+
+    if (widget.isSelectionMode) {
+      return widget.child;
     }
 
     return Slidable(

--- a/lib/modules/notification/widgets/notification_slidable_widget.dart
+++ b/lib/modules/notification/widgets/notification_slidable_widget.dart
@@ -1,5 +1,6 @@
 import 'package:flutter/material.dart';
 import 'package:flutter_slidable/flutter_slidable.dart';
+import 'package:thingsboard_app/config/themes/app_colors.dart';
 import 'package:thingsboard_app/generated/l10n.dart';
 import 'package:thingsboard_app/locator.dart';
 import 'package:thingsboard_app/thingsboard_client.dart';
@@ -58,7 +59,7 @@ class _NotificationSlidableWidget extends State<NotificationSlidableWidget> {
                         (context) => widget.onReadNotification(
                           widget.notification.id!.id!,
                         ),
-                    backgroundColor: const Color(0xFF198038),
+                    backgroundColor: AppColors.notificationSuccess,
                     foregroundColor: Colors.white,
                     icon: Icons.check_circle_outline,
                     label: S.of(context).markAsRead,
@@ -79,7 +80,7 @@ class _NotificationSlidableWidget extends State<NotificationSlidableWidget> {
                 widget.notification.status == PushNotificationStatus.READ,
               );
             },
-            backgroundColor: const Color(0xFFD12730).withValues(alpha: 0.94),
+            backgroundColor: AppColors.notificationError.withValues(alpha: 0.94),
             foregroundColor: Colors.white,
             icon: Icons.delete,
             label: S.of(context).delete,
@@ -113,7 +114,7 @@ class _NotificationSlidableWidget extends State<NotificationSlidableWidget> {
           items.add(
             SlidableAction(
               onPressed: (context) => _ackAlarm(id, context),
-              backgroundColor: const Color(0xFF198038),
+              backgroundColor: AppColors.notificationSuccess,
               foregroundColor: Colors.white,
               icon: Icons.done,
               label: S.of(context).acknowledge,

--- a/lib/modules/notification/widgets/notification_widget.dart
+++ b/lib/modules/notification/widgets/notification_widget.dart
@@ -114,36 +114,40 @@ class NotificationWidget extends StatelessWidget {
                       ),
                       textAlign: TextAlign.center,
                     ),
-                    if (!isSelectionMode)
-                      Row(
-                        children: [
-                          Visibility(
-                            visible:
-                                notification.status !=
-                                PushNotificationStatus.READ,
-                            child: SizedBox(
-                              width: 30,
-                              height: 50,
-                              child: IconButton(
-                                onPressed:
-                                    () => onReadNotification(
-                                      notification.id!.id!,
+                    Row(
+                      children: [
+                        Visibility(
+                          visible:
+                              notification.status !=
+                              PushNotificationStatus.READ,
+                          child: SizedBox(
+                            width: 30,
+                            height: 50,
+                            child: isSelectionMode
+                                ? Icon(
+                                    Icons.check_circle_outline,
+                                    color: Colors.black.withValues(alpha: 0.38),
+                                  )
+                                : IconButton(
+                                    onPressed:
+                                        () => onReadNotification(
+                                          notification.id!.id!,
+                                        ),
+                                    icon: Icon(
+                                      Icons.check_circle_outline,
+                                      color: Colors.black.withValues(alpha: 0.38),
                                     ),
-                                icon: Icon(
-                                  Icons.check_circle_outline,
-                                  color: Colors.black.withValues(alpha: 0.38),
-                                ),
-                              ),
-                            ),
+                                  ),
                           ),
-                          Visibility(
-                            visible:
-                                notification.status ==
-                                PushNotificationStatus.READ,
-                            child: const SizedBox(width: 30, height: 50),
-                          ),
-                        ],
-                      ),
+                        ),
+                        Visibility(
+                          visible:
+                              notification.status ==
+                              PushNotificationStatus.READ,
+                          child: const SizedBox(width: 30, height: 50),
+                        ),
+                      ],
+                    ),
                     Visibility(
                       visible: severity != null,
                       child: Container(

--- a/lib/modules/notification/widgets/notification_widget.dart
+++ b/lib/modules/notification/widgets/notification_widget.dart
@@ -15,7 +15,10 @@ class NotificationWidget extends StatelessWidget {
     required this.thingsboardClient,
     required this.onClearNotification,
     required this.onReadNotification,
-
+    this.isSelectionMode = false,
+    this.isSelected = false,
+    this.onToggleSelection,
+    this.onLongPress,
     super.key,
   });
 
@@ -23,6 +26,10 @@ class NotificationWidget extends StatelessWidget {
   final ThingsboardClient thingsboardClient;
   final Function(String id, bool readed) onClearNotification;
   final ValueChanged<String> onReadNotification;
+  final bool isSelectionMode;
+  final bool isSelected;
+  final VoidCallback? onToggleSelection;
+  final VoidCallback? onLongPress;
 
   @override
   Widget build(BuildContext context) {
@@ -33,11 +40,14 @@ class NotificationWidget extends StatelessWidget {
     final severity = notification.info?.alarmSeverity;
 
     return InkWell(
-      onTap: () {
-        getIt<HandleNotificationTapUsecase>().call(
-          HandleNotificationTapParams(notification: notification),
-        );
-      },
+      onTap: isSelectionMode
+          ? onToggleSelection
+          : () {
+              getIt<HandleNotificationTapUsecase>().call(
+                HandleNotificationTapParams(notification: notification),
+              );
+            },
+      onLongPress: onLongPress,
       child: Container(
         padding: const EdgeInsets.symmetric(horizontal: 15, vertical: 10),
         decoration: BoxDecoration(
@@ -59,6 +69,14 @@ class NotificationWidget extends StatelessWidget {
               mainAxisAlignment: MainAxisAlignment.spaceBetween,
               crossAxisAlignment: CrossAxisAlignment.start,
               children: [
+                if (isSelectionMode)
+                  Padding(
+                    padding: const EdgeInsets.only(right: 4),
+                    child: Checkbox(
+                      value: isSelected,
+                      onChanged: (_) => onToggleSelection?.call(),
+                    ),
+                  ),
                 Column(
                   children: [NotificationIcon(notification: notification)],
                 ),
@@ -96,34 +114,36 @@ class NotificationWidget extends StatelessWidget {
                       ),
                       textAlign: TextAlign.center,
                     ),
-                    Row(
-                      children: [
-                        Visibility(
-                          visible:
-                              notification.status !=
-                              PushNotificationStatus.READ,
-                          child: SizedBox(
-                            width: 30,
-                            height: 50,
-                            child: IconButton(
-                              onPressed:
-                                  () =>
-                                      onReadNotification(notification.id!.id!),
-                              icon: Icon(
-                                Icons.check_circle_outline,
-                                color: Colors.black.withValues(alpha: 0.38),
+                    if (!isSelectionMode)
+                      Row(
+                        children: [
+                          Visibility(
+                            visible:
+                                notification.status !=
+                                PushNotificationStatus.READ,
+                            child: SizedBox(
+                              width: 30,
+                              height: 50,
+                              child: IconButton(
+                                onPressed:
+                                    () => onReadNotification(
+                                      notification.id!.id!,
+                                    ),
+                                icon: Icon(
+                                  Icons.check_circle_outline,
+                                  color: Colors.black.withValues(alpha: 0.38),
+                                ),
                               ),
                             ),
                           ),
-                        ),
-                        Visibility(
-                          visible:
-                              notification.status ==
-                              PushNotificationStatus.READ,
-                          child: const SizedBox(width: 30, height: 50),
-                        ),
-                      ],
-                    ),
+                          Visibility(
+                            visible:
+                                notification.status ==
+                                PushNotificationStatus.READ,
+                            child: const SizedBox(width: 30, height: 50),
+                          ),
+                        ],
+                      ),
                     Visibility(
                       visible: severity != null,
                       child: Container(


### PR DESCRIPTION
## Summary
- Adds multi-select mode to the Notifications tab (long-press to enter)
- App bar switches to show selected count, Select All checkbox, and close button
- Bottom action bar with batch **Delete** and **Mark as Read** buttons
- Slidable swipe actions are disabled during selection mode
- Selection mode exits on back press, filter change, or pull-to-refresh

<img width="1080" height="2400" alt="Screenshot_20260409-153045" src="https://github.com/user-attachments/assets/45dd3a54-a9c3-4a0a-97f7-7498ebf06c76" />

Closes #279

## Test plan
- [ ] Long-press a notification → enters selection mode with item checked
- [ ] Tap notifications to toggle selection checkboxes
- [ ] Tap "Select All" checkbox → all loaded items selected
- [ ] Tap "Delete" → selected notifications deleted, badge count updated
- [ ] Tap "Mark as Read" → selected unread notifications marked as read
- [ ] Press X or system back → exits selection mode
- [ ] Switch between All/Unread filter → exits selection mode
- [ ] Pull-to-refresh → exits selection mode