### PR TITLE
fix: resolve i18n placeholders in dashboard titles on mobile

### DIFF
--- a/lib/core/auth/login/provider/login_provider.dart
+++ b/lib/core/auth/login/provider/login_provider.dart
@@ -11,6 +11,7 @@ import 'package:thingsboard_app/locator.dart';
 import 'package:thingsboard_app/thingsboard_client.dart';
 import 'package:thingsboard_app/utils/services/communication/events/user_loaded_event.dart';
 import 'package:thingsboard_app/utils/services/communication/i_communication_service.dart';
+import 'package:thingsboard_app/utils/services/custom_translation/i_custom_translation_service.dart';
 import 'package:thingsboard_app/utils/services/device_info/i_device_info_service.dart';
 import 'package:thingsboard_app/utils/services/firebase/i_firebase_service.dart';
 import 'package:thingsboard_app/utils/services/notification_service.dart';
@@ -42,6 +43,7 @@ class Login extends _$Login {
         state.isFullyAuthenticated()) {
       await getIt<NotificationService>().logout();
     }
+    getIt<ICustomTranslationService>().clear();
     await _tbClient.logout(requestConfig: RequestConfig(ignoreErrors: true));
   }
 
@@ -94,6 +96,9 @@ class Login extends _$Login {
     );
 
     await S.load(locale ?? const Locale('en'));
+    await getIt<ICustomTranslationService>().load(
+      localeCode: (langStr != null && langStr.isNotEmpty) ? langStr : 'en_US',
+    );
     final userPermissions =
         await _tbClient.getUserPermissionsService().getAllowedPermissions();
     state = state.copyWith(

--- a/lib/locator.dart
+++ b/lib/locator.dart
@@ -6,6 +6,8 @@ import 'package:thingsboard_app/core/usecases/user_details_usecase.dart';
 import 'package:thingsboard_app/thingsboard_client.dart' hide UserService;
 import 'package:thingsboard_app/utils/services/communication/communication_service.dart';
 import 'package:thingsboard_app/utils/services/communication/i_communication_service.dart';
+import 'package:thingsboard_app/utils/services/custom_translation/custom_translation_service.dart';
+import 'package:thingsboard_app/utils/services/custom_translation/i_custom_translation_service.dart';
 import 'package:thingsboard_app/utils/services/device_info/device_info_service.dart';
 import 'package:thingsboard_app/utils/services/device_info/i_device_info_service.dart';
 import 'package:thingsboard_app/utils/services/endpoint/endpoint_service.dart';
@@ -77,6 +79,9 @@ Future<void> setUpRootDependencies() async {
       () => PermissionService(),
     )
     ..registerLazySingleton<ILayoutService>(() => LayoutService(getIt()))
+    ..registerLazySingleton<ICustomTranslationService>(
+      () => TbCustomTranslationService(),
+    )
     ..registerFactory(() => const UserDetailsUseCase());
   await getIt.getAsync<ITbClientService>();
 }

--- a/lib/modules/dashboard/presentation/view/fullscreen_dashboard_page.dart
+++ b/lib/modules/dashboard/presentation/view/fullscreen_dashboard_page.dart
@@ -5,6 +5,7 @@ import 'package:thingsboard_app/modules/dashboard/di/dashboards_di.dart';
 import 'package:thingsboard_app/modules/dashboard/presentation/controller/dashboard_controller.dart';
 import 'package:thingsboard_app/modules/dashboard/presentation/view/dashboard_permission_error_view.dart';
 import 'package:thingsboard_app/modules/dashboard/presentation/widgets/dashboard_widget.dart';
+import 'package:thingsboard_app/utils/services/custom_translation/i_custom_translation_service.dart';
 import 'package:thingsboard_app/utils/services/endpoint/i_endpoint_service.dart';
 import 'package:thingsboard_app/utils/services/tb_client_service/i_tb_client_service.dart';
 import 'package:thingsboard_app/utils/services/permission/i_permission_service.dart';
@@ -114,7 +115,10 @@ class _FullscreenDashboardPageState extends State<FullscreenDashboardPage> {
     DashboardsDi.init(diKey, tbClient: getIt<ITbClientService>().client);
     havePermission = getIt<IPermissionService>()
         .haveViewDashboardPermission();
-    dashboardTitleValue = ValueNotifier(widget._dashboardTitle ?? 'Dashboard');
+    dashboardTitleValue = ValueNotifier(
+      getIt<ICustomTranslationService>()
+          .translate(widget._dashboardTitle ?? 'Dashboard'),
+    );
   }
 
   @override

--- a/lib/modules/dashboard/presentation/view/single_dashboard_view.dart
+++ b/lib/modules/dashboard/presentation/view/single_dashboard_view.dart
@@ -5,6 +5,7 @@ import 'package:thingsboard_app/modules/dashboard/di/dashboards_di.dart';
 import 'package:thingsboard_app/modules/dashboard/presentation/controller/dashboard_controller.dart';
 import 'package:thingsboard_app/modules/dashboard/presentation/view/dashboard_permission_error_view.dart';
 import 'package:thingsboard_app/modules/dashboard/presentation/widgets/dashboard_widget.dart';
+import 'package:thingsboard_app/utils/services/custom_translation/i_custom_translation_service.dart';
 import 'package:thingsboard_app/utils/services/tb_client_service/i_tb_client_service.dart';
 import 'package:thingsboard_app/utils/services/permission/i_permission_service.dart';
 import 'package:thingsboard_app/widgets/tb_app_bar.dart';
@@ -97,7 +98,8 @@ class _SingleDashboardViewState extends State<SingleDashboardView>
       body: SafeArea(
         child: DashboardWidget(
           titleCallback: (title) {
-            dashboardTitleValue.value = widget.title ?? title;
+            dashboardTitleValue.value = getIt<ICustomTranslationService>()
+                .translate(widget.title ?? title);
           },
           controllerCallback: (controller, _) {
             _dashboardController = controller;
@@ -148,7 +150,8 @@ class _SingleDashboardViewState extends State<SingleDashboardView>
     );
 
     if (widget.title != null) {
-      dashboardTitleValue.value = widget.title!;
+      dashboardTitleValue.value = getIt<ICustomTranslationService>()
+          .translate(widget.title);
     }
   }
 

--- a/lib/modules/dashboard/presentation/widgets/dashboard_grid_card.dart
+++ b/lib/modules/dashboard/presentation/widgets/dashboard_grid_card.dart
@@ -4,6 +4,7 @@ import 'package:flutter_svg/flutter_svg.dart';
 import 'package:thingsboard_app/constants/assets_path.dart';
 import 'package:thingsboard_app/locator.dart';
 import 'package:thingsboard_app/thingsboard_client.dart';
+import 'package:thingsboard_app/utils/services/custom_translation/i_custom_translation_service.dart';
 import 'package:thingsboard_app/utils/services/tb_client_service/i_tb_client_service.dart';
 import 'package:thingsboard_app/utils/utils.dart';
 
@@ -64,7 +65,8 @@ class _DashboardGridCardState extends State<DashboardGridCard> {
               padding: const EdgeInsets.symmetric(horizontal: 6),
               child: Center(
                 child: AutoSizeText(
-                  widget.dashboard.title,
+                  getIt<ICustomTranslationService>()
+                      .translate(widget.dashboard.title),
                   textAlign: TextAlign.center,
                   maxLines: 1,
                   overflow: TextOverflow.ellipsis,

--- a/lib/modules/dashboard/presentation/widgets/dashboards_grid.dart
+++ b/lib/modules/dashboard/presentation/widgets/dashboards_grid.dart
@@ -8,6 +8,7 @@ import 'package:thingsboard_app/modules/dashboard/domain/pagination/dashboards_p
 import 'package:thingsboard_app/modules/dashboard/presentation/controller/dashboard_page_controller.dart';
 import 'package:thingsboard_app/modules/dashboard/presentation/widgets/dashboard_grid_card.dart';
 import 'package:thingsboard_app/thingsboard_client.dart';
+import 'package:thingsboard_app/utils/services/custom_translation/i_custom_translation_service.dart';
 import 'package:thingsboard_app/utils/services/overlay_service/i_overlay_service.dart';
 import 'package:thingsboard_app/utils/services/permission/i_permission_service.dart';
 import 'package:thingsboard_app/utils/ui/pagination_widgets/first_page_exception_widget.dart';
@@ -46,7 +47,8 @@ class DashboardsGridWidget extends StatelessWidget {
                 if (havePermission) {
                   dashboardPageCtrl.openDashboard(
                     dashboard.id!.id!,
-                    title: dashboard.title,
+                    title: getIt<ICustomTranslationService>()
+                        .translate(dashboard.title),
                   );
                 } else {
                   getIt<IOverlayService>().showErrorNotification( (_) =>

--- a/lib/modules/profile/widget/profile_edit_page.dart
+++ b/lib/modules/profile/widget/profile_edit_page.dart
@@ -20,6 +20,7 @@ import 'package:thingsboard_app/modules/profile/widget/tb_bottom_sheet_builder.d
 import 'package:thingsboard_app/modules/profile/widget/tb_country_picker.dart';
 import 'package:thingsboard_app/modules/profile/widget/tb_drop_down_text_field.dart';
 import 'package:thingsboard_app/thingsboard_client.dart';
+import 'package:thingsboard_app/utils/services/custom_translation/i_custom_translation_service.dart';
 import 'package:thingsboard_app/utils/services/overlay_service/i_overlay_service.dart';
 import 'package:thingsboard_app/utils/services/tb_client_service/i_tb_client_service.dart';
 import 'package:thingsboard_app/utils/ui/visibility_widget.dart';
@@ -320,7 +321,9 @@ class ProfileEditPage extends HookConsumerWidget {
                                     child: TbDropDownTextField<DashboardInfo>(
                                       formControlName:
                                           'additionalInfo.homeDashboardId',
-                                      selectedItemBuilder: (val) => val?.title,
+                                      selectedItemBuilder: (val) =>
+                                          getIt<ICustomTranslationService>()
+                                              .translate(val?.title),
                                       hint: S.of(context).homeDashboard,
 
                                       bottomSheetBuilder:
@@ -336,7 +339,10 @@ class ProfileEditPage extends HookConsumerWidget {
                                                 >(),
                                             title: S.of(context).homeDashboard,
                                             listTitleBuilder:
-                                                (context, item) => item.title,
+                                                (context, item) =>
+                                                    getIt<
+                                                      ICustomTranslationService
+                                                    >().translate(item.title),
                                           ),
                                     ),
                                   ),

--- a/lib/utils/services/custom_translation/custom_translation_service.dart
+++ b/lib/utils/services/custom_translation/custom_translation_service.dart
@@ -1,0 +1,59 @@
+import 'package:thingsboard_app/core/logger/tb_logger.dart';
+import 'package:thingsboard_app/locator.dart';
+import 'package:thingsboard_app/utils/services/custom_translation/i_custom_translation_service.dart';
+import 'package:thingsboard_app/utils/services/tb_client_service/i_tb_client_service.dart';
+
+class TbCustomTranslationService implements ICustomTranslationService {
+  static final _i18nRegExp = RegExp(r'\{i18n:([^{}]+)\}');
+
+  Map<String, dynamic> _translations = const {};
+
+  @override
+  Future<void> load({String? localeCode}) async {
+    final code = (localeCode == null || localeCode.isEmpty) ? 'en_US' : localeCode;
+    try {
+      final response = await getIt<ITbClientService>()
+          .client
+          .get<Map<String, dynamic>>('/api/translation/full/$code');
+      _translations = response.data ?? const {};
+    } catch (e) {
+      getIt<TbLogger>().debug('Failed to load custom translations: $e');
+      _translations = const {};
+    }
+  }
+
+  @override
+  String translate(String? value) {
+    if (value == null || value.isEmpty) {
+      return value ?? '';
+    }
+    if (!value.contains('{i18n:')) {
+      return value;
+    }
+    return value.replaceAllMapped(_i18nRegExp, (match) {
+      final key = match.group(1);
+      if (key == null || key.isEmpty) {
+        return match.group(0)!;
+      }
+      final translated = _lookup(key);
+      return translated ?? match.group(0)!;
+    });
+  }
+
+  @override
+  void clear() {
+    _translations = const {};
+  }
+
+  String? _lookup(String key) {
+    dynamic current = _translations;
+    for (final part in key.split('.')) {
+      if (current is Map<String, dynamic> && current.containsKey(part)) {
+        current = current[part];
+      } else {
+        return null;
+      }
+    }
+    return current is String ? current : null;
+  }
+}

--- a/lib/utils/services/custom_translation/i_custom_translation_service.dart
+++ b/lib/utils/services/custom_translation/i_custom_translation_service.dart
@@ -1,0 +1,7 @@
+abstract interface class ICustomTranslationService {
+  Future<void> load({String? localeCode});
+
+  String translate(String? value);
+
+  void clear();
+}


### PR DESCRIPTION
## Summary
- Resolve i18n placeholders (e.g. `{i18n:...}`) in dashboard titles so translated names render correctly across mobile views.
- Wire a `CustomTranslationService` (with interface) into the locator and invoke it from login to fetch custom translations.
- Apply translation resolution in dashboard grid cards, single/fullscreen dashboard pages, and the profile edit page.

## Test plan
- [ ] Log in and verify dashboards list shows translated titles (no raw `{i18n:...}` tokens).
- [ ] Open a dashboard in both single and fullscreen views; confirm the app bar title is translated.
- [ ] Switch UI language and reload — titles update to the new locale.
- [ ] Profile edit page renders translated labels.