### PR TITLE
fix(dashboard): make system back mirror the AppBar back arrow

### DIFF
--- a/lib/config/routes/v2/route_handlers/route_handler_widget.dart
+++ b/lib/config/routes/v2/route_handlers/route_handler_widget.dart
@@ -8,8 +8,6 @@ import 'package:reactive_phone_form_field/reactive_phone_form_field.dart';
 import 'package:thingsboard_app/config/routes/v2/route_handlers/route_handlers.dart';
 import 'package:thingsboard_app/core/auth/login/provider/login_provider.dart';
 import 'package:thingsboard_app/generated/l10n.dart';
-import 'package:thingsboard_app/locator.dart';
-import 'package:thingsboard_app/utils/services/overlay_service/i_overlay_service.dart';
 
 class RouteHanlderWidget extends HookConsumerWidget {
   const RouteHanlderWidget({super.key, required this.child});
@@ -24,19 +22,9 @@ class RouteHanlderWidget extends HookConsumerWidget {
       return () => disposeHandlers();
     }, []);
     return PopScope(
-      onPopInvokedWithResult: (didPop, res) async {
+      onPopInvokedWithResult: (didPop, res) {
         if (!context.canPop()) {
-          final confirm = await getIt<IOverlayService>().showConfirmDialog(
-            content:
-                (_) => DialogContent(
-                  title: S.of(context).areYouSureYouWantToExit,
-                  message: S.of(context).confirmToCloseTheApp,
-                  cancel: S.of(context).cancel,
-                ),
-          );
-          if (confirm == true && context.mounted) {
-            SystemNavigator.pop();
-          }
+          SystemNavigator.pop();
         }
       },
       canPop: false,

--- a/lib/config/routes/v2/route_handlers/route_handler_widget.dart
+++ b/lib/config/routes/v2/route_handlers/route_handler_widget.dart
@@ -9,8 +9,6 @@ import 'package:thingsboard_app/config/routes/v2/route_handlers/route_handlers.d
 import 'package:thingsboard_app/config/themes/wl_preload_widget.dart';
 import 'package:thingsboard_app/core/auth/login/provider/login_provider.dart';
 import 'package:thingsboard_app/generated/l10n.dart';
-import 'package:thingsboard_app/locator.dart';
-import 'package:thingsboard_app/utils/services/overlay_service/i_overlay_service.dart';
 
 class RouteHanlderWidget extends HookConsumerWidget {
   const RouteHanlderWidget({super.key, required this.child});
@@ -25,19 +23,9 @@ class RouteHanlderWidget extends HookConsumerWidget {
       return () => disposeHandlers();
     }, []);
     return PopScope(
-      onPopInvokedWithResult: (didPop, res) async {
+      onPopInvokedWithResult: (didPop, res) {
         if (!context.canPop()) {
-          final confirm = await getIt<IOverlayService>().showConfirmDialog(
-            content:
-                (_) => DialogContent(
-                  title: S.of(context).areYouSureYouWantToExit,
-                  message: S.of(context).confirmToCloseTheApp,
-                  cancel: S.of(context).cancel,
-                ),
-          );
-          if (confirm == true && context.mounted) {
-            SystemNavigator.pop();
-          }
+          SystemNavigator.pop();
         }
       },
       canPop: false,

--- a/lib/generated/intl/messages_ar.dart
+++ b/lib/generated/intl/messages_ar.dart
@@ -257,9 +257,6 @@ class MessageLookup extends MessageLookupByLibrary {
     "applyChanges": MessageLookupByLibrary.simpleMessage("تطبيق التغييرات"),
     "areYouSure": MessageLookupByLibrary.simpleMessage("هل أنت متأكد؟"),
     "areYouSureYouWantToDeactivate": m3,
-    "areYouSureYouWantToExit": MessageLookupByLibrary.simpleMessage(
-      "هل أنت متأكد أنك تريد الخروج؟",
-    ),
     "asset": MessageLookupByLibrary.simpleMessage("الأصل"),
     "assetName": MessageLookupByLibrary.simpleMessage("اسم الأصل"),
     "assetProfile": MessageLookupByLibrary.simpleMessage("ملف تعريف الأصل"),
@@ -309,9 +306,6 @@ class MessageLookup extends MessageLookupByLibrary {
     ),
     "confirmNotRobotMessage": MessageLookupByLibrary.simpleMessage(
       "يجب أن تؤكد أنك لست روبوت",
-    ),
-    "confirmToCloseTheApp": MessageLookupByLibrary.simpleMessage(
-      "تأكيد لإغلاق التطبيق",
     ),
     "confirmation": MessageLookupByLibrary.simpleMessage("التأكيد"),
     "confirmingWifiConnection": MessageLookupByLibrary.simpleMessage(

--- a/lib/generated/intl/messages_ar.dart
+++ b/lib/generated/intl/messages_ar.dart
@@ -275,9 +275,6 @@ class MessageLookup extends MessageLookupByLibrary {
     "applyChanges": MessageLookupByLibrary.simpleMessage("تطبيق التغييرات"),
     "areYouSure": MessageLookupByLibrary.simpleMessage("هل أنت متأكد؟"),
     "areYouSureYouWantToDeactivate": m3,
-    "areYouSureYouWantToExit": MessageLookupByLibrary.simpleMessage(
-      "هل أنت متأكد أنك تريد الخروج؟",
-    ),
     "asset": MessageLookupByLibrary.simpleMessage("الأصل"),
     "assetName": MessageLookupByLibrary.simpleMessage("اسم الأصل"),
     "assetProfile": MessageLookupByLibrary.simpleMessage("ملف تعريف الأصل"),
@@ -328,9 +325,6 @@ class MessageLookup extends MessageLookupByLibrary {
     ),
     "confirmNotRobotMessage": MessageLookupByLibrary.simpleMessage(
       "يجب أن تؤكد أنك لست روبوت",
-    ),
-    "confirmToCloseTheApp": MessageLookupByLibrary.simpleMessage(
-      "تأكيد لإغلاق التطبيق",
     ),
     "confirmation": MessageLookupByLibrary.simpleMessage("التأكيد"),
     "confirmingWifiConnection": MessageLookupByLibrary.simpleMessage(

--- a/lib/generated/intl/messages_da_DK.dart
+++ b/lib/generated/intl/messages_da_DK.dart
@@ -259,9 +259,6 @@ class MessageLookup extends MessageLookupByLibrary {
     "applyChanges": MessageLookupByLibrary.simpleMessage("Anvend ændringer"),
     "areYouSure": MessageLookupByLibrary.simpleMessage("Er du sikker?"),
     "areYouSureYouWantToDeactivate": m3,
-    "areYouSureYouWantToExit": MessageLookupByLibrary.simpleMessage(
-      "Er du sikker på, at du vil afslutte?",
-    ),
     "asset": MessageLookupByLibrary.simpleMessage("Aktiv"),
     "assetName": MessageLookupByLibrary.simpleMessage("Aktivnavn"),
     "assetProfile": MessageLookupByLibrary.simpleMessage("Aktivprofil"),
@@ -311,9 +308,6 @@ class MessageLookup extends MessageLookupByLibrary {
     ),
     "confirmNotRobotMessage": MessageLookupByLibrary.simpleMessage(
       "Du skal bekræfte, at du ikke er en robot",
-    ),
-    "confirmToCloseTheApp": MessageLookupByLibrary.simpleMessage(
-      "Bekræft for at lukke appen",
     ),
     "confirmation": MessageLookupByLibrary.simpleMessage("Bekræftelse"),
     "confirmingWifiConnection": MessageLookupByLibrary.simpleMessage(

--- a/lib/generated/intl/messages_da_DK.dart
+++ b/lib/generated/intl/messages_da_DK.dart
@@ -277,9 +277,6 @@ class MessageLookup extends MessageLookupByLibrary {
     "applyChanges": MessageLookupByLibrary.simpleMessage("Anvend ændringer"),
     "areYouSure": MessageLookupByLibrary.simpleMessage("Er du sikker?"),
     "areYouSureYouWantToDeactivate": m3,
-    "areYouSureYouWantToExit": MessageLookupByLibrary.simpleMessage(
-      "Er du sikker på, at du vil afslutte?",
-    ),
     "asset": MessageLookupByLibrary.simpleMessage("Aktiv"),
     "assetName": MessageLookupByLibrary.simpleMessage("Aktivnavn"),
     "assetProfile": MessageLookupByLibrary.simpleMessage("Aktivprofil"),
@@ -330,9 +327,6 @@ class MessageLookup extends MessageLookupByLibrary {
     ),
     "confirmNotRobotMessage": MessageLookupByLibrary.simpleMessage(
       "Du skal bekræfte, at du ikke er en robot",
-    ),
-    "confirmToCloseTheApp": MessageLookupByLibrary.simpleMessage(
-      "Bekræft for at lukke appen",
     ),
     "confirmation": MessageLookupByLibrary.simpleMessage("Bekræftelse"),
     "confirmingWifiConnection": MessageLookupByLibrary.simpleMessage(

--- a/lib/generated/intl/messages_de_DE.dart
+++ b/lib/generated/intl/messages_de_DE.dart
@@ -263,9 +263,6 @@ class MessageLookup extends MessageLookupByLibrary {
     ),
     "areYouSure": MessageLookupByLibrary.simpleMessage("Sind Sie sicher?"),
     "areYouSureYouWantToDeactivate": m3,
-    "areYouSureYouWantToExit": MessageLookupByLibrary.simpleMessage(
-      "Möchten Sie wirklich beenden?",
-    ),
     "asset": MessageLookupByLibrary.simpleMessage("Asset"),
     "assetName": MessageLookupByLibrary.simpleMessage("Asset-Name"),
     "assetProfile": MessageLookupByLibrary.simpleMessage("Asset-Profil"),
@@ -319,9 +316,6 @@ class MessageLookup extends MessageLookupByLibrary {
     ),
     "confirmNotRobotMessage": MessageLookupByLibrary.simpleMessage(
       "Sie müssen bestätigen, dass Sie kein Roboter sind",
-    ),
-    "confirmToCloseTheApp": MessageLookupByLibrary.simpleMessage(
-      "Bestätigen Sie, um die App zu schließen",
     ),
     "confirmation": MessageLookupByLibrary.simpleMessage("Bestätigung"),
     "confirmingWifiConnection": MessageLookupByLibrary.simpleMessage(

--- a/lib/generated/intl/messages_de_DE.dart
+++ b/lib/generated/intl/messages_de_DE.dart
@@ -281,9 +281,6 @@ class MessageLookup extends MessageLookupByLibrary {
     ),
     "areYouSure": MessageLookupByLibrary.simpleMessage("Sind Sie sicher?"),
     "areYouSureYouWantToDeactivate": m3,
-    "areYouSureYouWantToExit": MessageLookupByLibrary.simpleMessage(
-      "Möchten Sie wirklich beenden?",
-    ),
     "asset": MessageLookupByLibrary.simpleMessage("Asset"),
     "assetName": MessageLookupByLibrary.simpleMessage("Asset-Name"),
     "assetProfile": MessageLookupByLibrary.simpleMessage("Asset-Profil"),
@@ -338,9 +335,6 @@ class MessageLookup extends MessageLookupByLibrary {
     ),
     "confirmNotRobotMessage": MessageLookupByLibrary.simpleMessage(
       "Sie müssen bestätigen, dass Sie kein Roboter sind",
-    ),
-    "confirmToCloseTheApp": MessageLookupByLibrary.simpleMessage(
-      "Bestätigen Sie, um die App zu schließen",
     ),
     "confirmation": MessageLookupByLibrary.simpleMessage("Bestätigung"),
     "confirmingWifiConnection": MessageLookupByLibrary.simpleMessage(

--- a/lib/generated/intl/messages_el_GR.dart
+++ b/lib/generated/intl/messages_el_GR.dart
@@ -271,9 +271,6 @@ class MessageLookup extends MessageLookupByLibrary {
     "applyChanges": MessageLookupByLibrary.simpleMessage("Εφαρμογή αλλαγών"),
     "areYouSure": MessageLookupByLibrary.simpleMessage("Είστε σίγουροι;"),
     "areYouSureYouWantToDeactivate": m3,
-    "areYouSureYouWantToExit": MessageLookupByLibrary.simpleMessage(
-      "Είστε σίγουροι ότι θέλετε να βγείτε;",
-    ),
     "asset": MessageLookupByLibrary.simpleMessage("Περιουσιακό στοιχείο"),
     "assetName": MessageLookupByLibrary.simpleMessage(
       "Όνομα περιουσιακού στοιχείου",
@@ -335,9 +332,6 @@ class MessageLookup extends MessageLookupByLibrary {
     ),
     "confirmNotRobotMessage": MessageLookupByLibrary.simpleMessage(
       "Πρέπει να επιβεβαιώσετε ότι δεν είστε ρομπότ",
-    ),
-    "confirmToCloseTheApp": MessageLookupByLibrary.simpleMessage(
-      "Επιβεβαίωση για κλείσιμο της εφαρμογής",
     ),
     "confirmation": MessageLookupByLibrary.simpleMessage("Επιβεβαίωση"),
     "confirmingWifiConnection": MessageLookupByLibrary.simpleMessage(

--- a/lib/generated/intl/messages_el_GR.dart
+++ b/lib/generated/intl/messages_el_GR.dart
@@ -289,9 +289,6 @@ class MessageLookup extends MessageLookupByLibrary {
     "applyChanges": MessageLookupByLibrary.simpleMessage("Εφαρμογή αλλαγών"),
     "areYouSure": MessageLookupByLibrary.simpleMessage("Είστε σίγουροι;"),
     "areYouSureYouWantToDeactivate": m3,
-    "areYouSureYouWantToExit": MessageLookupByLibrary.simpleMessage(
-      "Είστε σίγουροι ότι θέλετε να βγείτε;",
-    ),
     "asset": MessageLookupByLibrary.simpleMessage("Περιουσιακό στοιχείο"),
     "assetName": MessageLookupByLibrary.simpleMessage(
       "Όνομα περιουσιακού στοιχείου",
@@ -354,9 +351,6 @@ class MessageLookup extends MessageLookupByLibrary {
     ),
     "confirmNotRobotMessage": MessageLookupByLibrary.simpleMessage(
       "Πρέπει να επιβεβαιώσετε ότι δεν είστε ρομπότ",
-    ),
-    "confirmToCloseTheApp": MessageLookupByLibrary.simpleMessage(
-      "Επιβεβαίωση για κλείσιμο της εφαρμογής",
     ),
     "confirmation": MessageLookupByLibrary.simpleMessage("Επιβεβαίωση"),
     "confirmingWifiConnection": MessageLookupByLibrary.simpleMessage(

--- a/lib/generated/intl/messages_en.dart
+++ b/lib/generated/intl/messages_en.dart
@@ -258,9 +258,6 @@ class MessageLookup extends MessageLookupByLibrary {
     "applyChanges": MessageLookupByLibrary.simpleMessage("Apply changes"),
     "areYouSure": MessageLookupByLibrary.simpleMessage("Are you sure?"),
     "areYouSureYouWantToDeactivate": m3,
-    "areYouSureYouWantToExit": MessageLookupByLibrary.simpleMessage(
-      "Are you sure you want to exit?",
-    ),
     "asset": MessageLookupByLibrary.simpleMessage("Asset"),
     "assetName": MessageLookupByLibrary.simpleMessage("Asset name"),
     "assetProfile": MessageLookupByLibrary.simpleMessage("Asset profile"),
@@ -312,9 +309,6 @@ class MessageLookup extends MessageLookupByLibrary {
     ),
     "confirmNotRobotMessage": MessageLookupByLibrary.simpleMessage(
       "You must confirm that you are not a robot",
-    ),
-    "confirmToCloseTheApp": MessageLookupByLibrary.simpleMessage(
-      "Confirm to close the app",
     ),
     "confirmation": MessageLookupByLibrary.simpleMessage("Confirmation"),
     "confirmingWifiConnection": MessageLookupByLibrary.simpleMessage(

--- a/lib/generated/intl/messages_en.dart
+++ b/lib/generated/intl/messages_en.dart
@@ -274,9 +274,6 @@ class MessageLookup extends MessageLookupByLibrary {
     "applyChanges": MessageLookupByLibrary.simpleMessage("Apply changes"),
     "areYouSure": MessageLookupByLibrary.simpleMessage("Are you sure?"),
     "areYouSureYouWantToDeactivate": m3,
-    "areYouSureYouWantToExit": MessageLookupByLibrary.simpleMessage(
-      "Are you sure you want to exit?",
-    ),
     "asset": MessageLookupByLibrary.simpleMessage("Asset"),
     "assetName": MessageLookupByLibrary.simpleMessage("Asset name"),
     "assetProfile": MessageLookupByLibrary.simpleMessage("Asset profile"),
@@ -329,9 +326,6 @@ class MessageLookup extends MessageLookupByLibrary {
     ),
     "confirmNotRobotMessage": MessageLookupByLibrary.simpleMessage(
       "You must confirm that you are not a robot",
-    ),
-    "confirmToCloseTheApp": MessageLookupByLibrary.simpleMessage(
-      "Confirm to close the app",
     ),
     "confirmation": MessageLookupByLibrary.simpleMessage("Confirmation"),
     "confirmingWifiConnection": MessageLookupByLibrary.simpleMessage(

--- a/lib/generated/intl/messages_es_ES.dart
+++ b/lib/generated/intl/messages_es_ES.dart
@@ -268,9 +268,6 @@ class MessageLookup extends MessageLookupByLibrary {
     "applyChanges": MessageLookupByLibrary.simpleMessage("Aplicar cambios"),
     "areYouSure": MessageLookupByLibrary.simpleMessage("¿Estás seguro?"),
     "areYouSureYouWantToDeactivate": m3,
-    "areYouSureYouWantToExit": MessageLookupByLibrary.simpleMessage(
-      "¿Estás seguro de que quieres salir?",
-    ),
     "asset": MessageLookupByLibrary.simpleMessage("Activo"),
     "assetName": MessageLookupByLibrary.simpleMessage("Nombre del activo"),
     "assetProfile": MessageLookupByLibrary.simpleMessage("Perfil del activo"),
@@ -326,9 +323,6 @@ class MessageLookup extends MessageLookupByLibrary {
     ),
     "confirmNotRobotMessage": MessageLookupByLibrary.simpleMessage(
       "Debes confirmar que no eres un robot",
-    ),
-    "confirmToCloseTheApp": MessageLookupByLibrary.simpleMessage(
-      "Confirmar para cerrar la aplicación",
     ),
     "confirmation": MessageLookupByLibrary.simpleMessage("Confirmación"),
     "confirmingWifiConnection": MessageLookupByLibrary.simpleMessage(

--- a/lib/generated/intl/messages_es_ES.dart
+++ b/lib/generated/intl/messages_es_ES.dart
@@ -286,9 +286,6 @@ class MessageLookup extends MessageLookupByLibrary {
     "applyChanges": MessageLookupByLibrary.simpleMessage("Aplicar cambios"),
     "areYouSure": MessageLookupByLibrary.simpleMessage("¿Estás seguro?"),
     "areYouSureYouWantToDeactivate": m3,
-    "areYouSureYouWantToExit": MessageLookupByLibrary.simpleMessage(
-      "¿Estás seguro de que quieres salir?",
-    ),
     "asset": MessageLookupByLibrary.simpleMessage("Activo"),
     "assetName": MessageLookupByLibrary.simpleMessage("Nombre del activo"),
     "assetProfile": MessageLookupByLibrary.simpleMessage("Perfil del activo"),
@@ -345,9 +342,6 @@ class MessageLookup extends MessageLookupByLibrary {
     ),
     "confirmNotRobotMessage": MessageLookupByLibrary.simpleMessage(
       "Debes confirmar que no eres un robot",
-    ),
-    "confirmToCloseTheApp": MessageLookupByLibrary.simpleMessage(
-      "Confirmar para cerrar la aplicación",
     ),
     "confirmation": MessageLookupByLibrary.simpleMessage("Confirmación"),
     "confirmingWifiConnection": MessageLookupByLibrary.simpleMessage(

--- a/lib/generated/intl/messages_fr_FR.dart
+++ b/lib/generated/intl/messages_fr_FR.dart
@@ -269,9 +269,6 @@ class MessageLookup extends MessageLookupByLibrary {
     ),
     "areYouSure": MessageLookupByLibrary.simpleMessage("Êtes-vous sûr ?"),
     "areYouSureYouWantToDeactivate": m3,
-    "areYouSureYouWantToExit": MessageLookupByLibrary.simpleMessage(
-      "Êtes-vous sûr de vouloir quitter ?",
-    ),
     "asset": MessageLookupByLibrary.simpleMessage("Actif"),
     "assetName": MessageLookupByLibrary.simpleMessage("Nom de l\'actif"),
     "assetProfile": MessageLookupByLibrary.simpleMessage("Profil de l\'actif"),
@@ -327,9 +324,6 @@ class MessageLookup extends MessageLookupByLibrary {
     ),
     "confirmNotRobotMessage": MessageLookupByLibrary.simpleMessage(
       "Vous devez confirmer que vous n\'êtes pas un robot",
-    ),
-    "confirmToCloseTheApp": MessageLookupByLibrary.simpleMessage(
-      "Confirmer pour fermer l\'application",
     ),
     "confirmation": MessageLookupByLibrary.simpleMessage("Confirmation"),
     "confirmingWifiConnection": MessageLookupByLibrary.simpleMessage(

--- a/lib/generated/intl/messages_fr_FR.dart
+++ b/lib/generated/intl/messages_fr_FR.dart
@@ -287,9 +287,6 @@ class MessageLookup extends MessageLookupByLibrary {
     ),
     "areYouSure": MessageLookupByLibrary.simpleMessage("Êtes-vous sûr ?"),
     "areYouSureYouWantToDeactivate": m3,
-    "areYouSureYouWantToExit": MessageLookupByLibrary.simpleMessage(
-      "Êtes-vous sûr de vouloir quitter ?",
-    ),
     "asset": MessageLookupByLibrary.simpleMessage("Actif"),
     "assetName": MessageLookupByLibrary.simpleMessage("Nom de l\'actif"),
     "assetProfile": MessageLookupByLibrary.simpleMessage("Profil de l\'actif"),
@@ -346,9 +343,6 @@ class MessageLookup extends MessageLookupByLibrary {
     ),
     "confirmNotRobotMessage": MessageLookupByLibrary.simpleMessage(
       "Vous devez confirmer que vous n\'êtes pas un robot",
-    ),
-    "confirmToCloseTheApp": MessageLookupByLibrary.simpleMessage(
-      "Confirmer pour fermer l\'application",
     ),
     "confirmation": MessageLookupByLibrary.simpleMessage("Confirmation"),
     "confirmingWifiConnection": MessageLookupByLibrary.simpleMessage(

--- a/lib/generated/intl/messages_it_IT.dart
+++ b/lib/generated/intl/messages_it_IT.dart
@@ -262,9 +262,6 @@ class MessageLookup extends MessageLookupByLibrary {
     "applyChanges": MessageLookupByLibrary.simpleMessage("Applica modifiche"),
     "areYouSure": MessageLookupByLibrary.simpleMessage("Sei sicuro?"),
     "areYouSureYouWantToDeactivate": m3,
-    "areYouSureYouWantToExit": MessageLookupByLibrary.simpleMessage(
-      "Sei sicuro di voler uscire?",
-    ),
     "asset": MessageLookupByLibrary.simpleMessage("Asset"),
     "assetName": MessageLookupByLibrary.simpleMessage("Nome asset"),
     "assetProfile": MessageLookupByLibrary.simpleMessage("Profilo asset"),
@@ -318,9 +315,6 @@ class MessageLookup extends MessageLookupByLibrary {
     ),
     "confirmNotRobotMessage": MessageLookupByLibrary.simpleMessage(
       "Devi confermare di non essere un robot",
-    ),
-    "confirmToCloseTheApp": MessageLookupByLibrary.simpleMessage(
-      "Conferma per chiudere l\'app",
     ),
     "confirmation": MessageLookupByLibrary.simpleMessage("Conferma"),
     "confirmingWifiConnection": MessageLookupByLibrary.simpleMessage(

--- a/lib/generated/intl/messages_it_IT.dart
+++ b/lib/generated/intl/messages_it_IT.dart
@@ -280,9 +280,6 @@ class MessageLookup extends MessageLookupByLibrary {
     "applyChanges": MessageLookupByLibrary.simpleMessage("Applica modifiche"),
     "areYouSure": MessageLookupByLibrary.simpleMessage("Sei sicuro?"),
     "areYouSureYouWantToDeactivate": m3,
-    "areYouSureYouWantToExit": MessageLookupByLibrary.simpleMessage(
-      "Sei sicuro di voler uscire?",
-    ),
     "asset": MessageLookupByLibrary.simpleMessage("Asset"),
     "assetName": MessageLookupByLibrary.simpleMessage("Nome asset"),
     "assetProfile": MessageLookupByLibrary.simpleMessage("Profilo asset"),
@@ -337,9 +334,6 @@ class MessageLookup extends MessageLookupByLibrary {
     ),
     "confirmNotRobotMessage": MessageLookupByLibrary.simpleMessage(
       "Devi confermare di non essere un robot",
-    ),
-    "confirmToCloseTheApp": MessageLookupByLibrary.simpleMessage(
-      "Conferma per chiudere l\'app",
     ),
     "confirmation": MessageLookupByLibrary.simpleMessage("Conferma"),
     "confirmingWifiConnection": MessageLookupByLibrary.simpleMessage(

--- a/lib/generated/intl/messages_nl_NL.dart
+++ b/lib/generated/intl/messages_nl_NL.dart
@@ -261,9 +261,6 @@ class MessageLookup extends MessageLookupByLibrary {
     ),
     "areYouSure": MessageLookupByLibrary.simpleMessage("Weet u het zeker?"),
     "areYouSureYouWantToDeactivate": m3,
-    "areYouSureYouWantToExit": MessageLookupByLibrary.simpleMessage(
-      "Weet u zeker dat u wilt afsluiten?",
-    ),
     "asset": MessageLookupByLibrary.simpleMessage("Asset"),
     "assetName": MessageLookupByLibrary.simpleMessage("Assetnaam"),
     "assetProfile": MessageLookupByLibrary.simpleMessage("Assetprofiel"),
@@ -317,9 +314,6 @@ class MessageLookup extends MessageLookupByLibrary {
     ),
     "confirmNotRobotMessage": MessageLookupByLibrary.simpleMessage(
       "U moet bevestigen dat u geen robot bent",
-    ),
-    "confirmToCloseTheApp": MessageLookupByLibrary.simpleMessage(
-      "Bevestig om de app te sluiten",
     ),
     "confirmation": MessageLookupByLibrary.simpleMessage("Bevestiging"),
     "confirmingWifiConnection": MessageLookupByLibrary.simpleMessage(

--- a/lib/generated/intl/messages_nl_NL.dart
+++ b/lib/generated/intl/messages_nl_NL.dart
@@ -279,9 +279,6 @@ class MessageLookup extends MessageLookupByLibrary {
     ),
     "areYouSure": MessageLookupByLibrary.simpleMessage("Weet u het zeker?"),
     "areYouSureYouWantToDeactivate": m3,
-    "areYouSureYouWantToExit": MessageLookupByLibrary.simpleMessage(
-      "Weet u zeker dat u wilt afsluiten?",
-    ),
     "asset": MessageLookupByLibrary.simpleMessage("Asset"),
     "assetName": MessageLookupByLibrary.simpleMessage("Assetnaam"),
     "assetProfile": MessageLookupByLibrary.simpleMessage("Assetprofiel"),
@@ -336,9 +333,6 @@ class MessageLookup extends MessageLookupByLibrary {
     ),
     "confirmNotRobotMessage": MessageLookupByLibrary.simpleMessage(
       "U moet bevestigen dat u geen robot bent",
-    ),
-    "confirmToCloseTheApp": MessageLookupByLibrary.simpleMessage(
-      "Bevestig om de app te sluiten",
     ),
     "confirmation": MessageLookupByLibrary.simpleMessage("Bevestiging"),
     "confirmingWifiConnection": MessageLookupByLibrary.simpleMessage(

--- a/lib/generated/intl/messages_no_NO.dart
+++ b/lib/generated/intl/messages_no_NO.dart
@@ -258,9 +258,6 @@ class MessageLookup extends MessageLookupByLibrary {
     "applyChanges": MessageLookupByLibrary.simpleMessage("Bruk endringer"),
     "areYouSure": MessageLookupByLibrary.simpleMessage("Er du sikker?"),
     "areYouSureYouWantToDeactivate": m3,
-    "areYouSureYouWantToExit": MessageLookupByLibrary.simpleMessage(
-      "Er du sikker på at du vil avslutte?",
-    ),
     "asset": MessageLookupByLibrary.simpleMessage("Eiendel"),
     "assetName": MessageLookupByLibrary.simpleMessage("Eiendelsnavn"),
     "assetProfile": MessageLookupByLibrary.simpleMessage("Eiendelsprofil"),
@@ -312,9 +309,6 @@ class MessageLookup extends MessageLookupByLibrary {
     ),
     "confirmNotRobotMessage": MessageLookupByLibrary.simpleMessage(
       "Du må bekrefte at du ikke er en robot",
-    ),
-    "confirmToCloseTheApp": MessageLookupByLibrary.simpleMessage(
-      "Bekreft for å lukke appen",
     ),
     "confirmation": MessageLookupByLibrary.simpleMessage("Bekreftelse"),
     "confirmingWifiConnection": MessageLookupByLibrary.simpleMessage(

--- a/lib/generated/intl/messages_no_NO.dart
+++ b/lib/generated/intl/messages_no_NO.dart
@@ -276,9 +276,6 @@ class MessageLookup extends MessageLookupByLibrary {
     "applyChanges": MessageLookupByLibrary.simpleMessage("Bruk endringer"),
     "areYouSure": MessageLookupByLibrary.simpleMessage("Er du sikker?"),
     "areYouSureYouWantToDeactivate": m3,
-    "areYouSureYouWantToExit": MessageLookupByLibrary.simpleMessage(
-      "Er du sikker på at du vil avslutte?",
-    ),
     "asset": MessageLookupByLibrary.simpleMessage("Eiendel"),
     "assetName": MessageLookupByLibrary.simpleMessage("Eiendelsnavn"),
     "assetProfile": MessageLookupByLibrary.simpleMessage("Eiendelsprofil"),
@@ -331,9 +328,6 @@ class MessageLookup extends MessageLookupByLibrary {
     ),
     "confirmNotRobotMessage": MessageLookupByLibrary.simpleMessage(
       "Du må bekrefte at du ikke er en robot",
-    ),
-    "confirmToCloseTheApp": MessageLookupByLibrary.simpleMessage(
-      "Bekreft for å lukke appen",
     ),
     "confirmation": MessageLookupByLibrary.simpleMessage("Bekreftelse"),
     "confirmingWifiConnection": MessageLookupByLibrary.simpleMessage(

--- a/lib/generated/intl/messages_vi_VN.dart
+++ b/lib/generated/intl/messages_vi_VN.dart
@@ -261,9 +261,6 @@ class MessageLookup extends MessageLookupByLibrary {
     "applyChanges": MessageLookupByLibrary.simpleMessage("Áp dụng thay đổi"),
     "areYouSure": MessageLookupByLibrary.simpleMessage("Bạn có chắc chắn?"),
     "areYouSureYouWantToDeactivate": m3,
-    "areYouSureYouWantToExit": MessageLookupByLibrary.simpleMessage(
-      "Bạn có chắc chắn muốn thoát?",
-    ),
     "asset": MessageLookupByLibrary.simpleMessage("Tài sản"),
     "assetName": MessageLookupByLibrary.simpleMessage("Tên tài sản"),
     "assetProfile": MessageLookupByLibrary.simpleMessage("Hồ sơ tài sản"),
@@ -319,9 +316,6 @@ class MessageLookup extends MessageLookupByLibrary {
     ),
     "confirmNotRobotMessage": MessageLookupByLibrary.simpleMessage(
       "Bạn phải xác nhận rằng bạn không phải là rô bốt",
-    ),
-    "confirmToCloseTheApp": MessageLookupByLibrary.simpleMessage(
-      "Xác nhận để đóng ứng dụng",
     ),
     "confirmation": MessageLookupByLibrary.simpleMessage("Xác nhận"),
     "confirmingWifiConnection": MessageLookupByLibrary.simpleMessage(

--- a/lib/generated/intl/messages_vi_VN.dart
+++ b/lib/generated/intl/messages_vi_VN.dart
@@ -279,9 +279,6 @@ class MessageLookup extends MessageLookupByLibrary {
     "applyChanges": MessageLookupByLibrary.simpleMessage("Áp dụng thay đổi"),
     "areYouSure": MessageLookupByLibrary.simpleMessage("Bạn có chắc chắn?"),
     "areYouSureYouWantToDeactivate": m3,
-    "areYouSureYouWantToExit": MessageLookupByLibrary.simpleMessage(
-      "Bạn có chắc chắn muốn thoát?",
-    ),
     "asset": MessageLookupByLibrary.simpleMessage("Tài sản"),
     "assetName": MessageLookupByLibrary.simpleMessage("Tên tài sản"),
     "assetProfile": MessageLookupByLibrary.simpleMessage("Hồ sơ tài sản"),
@@ -338,9 +335,6 @@ class MessageLookup extends MessageLookupByLibrary {
     ),
     "confirmNotRobotMessage": MessageLookupByLibrary.simpleMessage(
       "Bạn phải xác nhận rằng bạn không phải là rô bốt",
-    ),
-    "confirmToCloseTheApp": MessageLookupByLibrary.simpleMessage(
-      "Xác nhận để đóng ứng dụng",
     ),
     "confirmation": MessageLookupByLibrary.simpleMessage("Xác nhận"),
     "confirmingWifiConnection": MessageLookupByLibrary.simpleMessage(

--- a/lib/generated/intl/messages_zh.dart
+++ b/lib/generated/intl/messages_zh.dart
@@ -232,9 +232,6 @@ class MessageLookup extends MessageLookupByLibrary {
     "applyChanges": MessageLookupByLibrary.simpleMessage("Apply changes"),
     "areYouSure": MessageLookupByLibrary.simpleMessage("您确定吗?"),
     "areYouSureYouWantToDeactivate": m3,
-    "areYouSureYouWantToExit": MessageLookupByLibrary.simpleMessage(
-      "Are you sure you want to exit?",
-    ),
     "asset": MessageLookupByLibrary.simpleMessage("Asset"),
     "assetName": MessageLookupByLibrary.simpleMessage("资产名"),
     "assetProfile": MessageLookupByLibrary.simpleMessage("资产配置文件"),
@@ -277,9 +274,6 @@ class MessageLookup extends MessageLookupByLibrary {
     ),
     "confirmNotRobotMessage": MessageLookupByLibrary.simpleMessage(
       "您必须确认您不是机器人",
-    ),
-    "confirmToCloseTheApp": MessageLookupByLibrary.simpleMessage(
-      "Confirm to close the app",
     ),
     "confirmation": MessageLookupByLibrary.simpleMessage("确认"),
     "confirmingWifiConnection": MessageLookupByLibrary.simpleMessage(

--- a/lib/generated/intl/messages_zh_CN.dart
+++ b/lib/generated/intl/messages_zh_CN.dart
@@ -203,7 +203,6 @@ class MessageLookup extends MessageLookupByLibrary {
     "applyChanges": MessageLookupByLibrary.simpleMessage("应用更改"),
     "areYouSure": MessageLookupByLibrary.simpleMessage("您确定吗?"),
     "areYouSureYouWantToDeactivate": m3,
-    "areYouSureYouWantToExit": MessageLookupByLibrary.simpleMessage("您确定要退出吗？"),
     "asset": MessageLookupByLibrary.simpleMessage("资产"),
     "assetName": MessageLookupByLibrary.simpleMessage("资产名"),
     "assetProfile": MessageLookupByLibrary.simpleMessage("资产配置文件"),
@@ -242,7 +241,6 @@ class MessageLookup extends MessageLookupByLibrary {
     "confirmNotRobotMessage": MessageLookupByLibrary.simpleMessage(
       "您必须确认您不是机器人",
     ),
-    "confirmToCloseTheApp": MessageLookupByLibrary.simpleMessage("确认关闭应用"),
     "confirmation": MessageLookupByLibrary.simpleMessage("确认"),
     "confirmingWifiConnection": MessageLookupByLibrary.simpleMessage(
       "确认 Wi-Fi 连接",

--- a/lib/generated/intl/messages_zh_CN.dart
+++ b/lib/generated/intl/messages_zh_CN.dart
@@ -215,7 +215,6 @@ class MessageLookup extends MessageLookupByLibrary {
     "applyChanges": MessageLookupByLibrary.simpleMessage("应用更改"),
     "areYouSure": MessageLookupByLibrary.simpleMessage("您确定吗?"),
     "areYouSureYouWantToDeactivate": m3,
-    "areYouSureYouWantToExit": MessageLookupByLibrary.simpleMessage("您确定要退出吗？"),
     "asset": MessageLookupByLibrary.simpleMessage("资产"),
     "assetName": MessageLookupByLibrary.simpleMessage("资产名"),
     "assetProfile": MessageLookupByLibrary.simpleMessage("资产配置文件"),
@@ -255,7 +254,6 @@ class MessageLookup extends MessageLookupByLibrary {
     "confirmNotRobotMessage": MessageLookupByLibrary.simpleMessage(
       "您必须确认您不是机器人",
     ),
-    "confirmToCloseTheApp": MessageLookupByLibrary.simpleMessage("确认关闭应用"),
     "confirmation": MessageLookupByLibrary.simpleMessage("确认"),
     "confirmingWifiConnection": MessageLookupByLibrary.simpleMessage(
       "确认 Wi-Fi 连接",

--- a/lib/generated/intl/messages_zh_TW.dart
+++ b/lib/generated/intl/messages_zh_TW.dart
@@ -205,7 +205,6 @@ class MessageLookup extends MessageLookupByLibrary {
     "applyChanges": MessageLookupByLibrary.simpleMessage("套用變更"),
     "areYouSure": MessageLookupByLibrary.simpleMessage("您確定嗎？"),
     "areYouSureYouWantToDeactivate": m3,
-    "areYouSureYouWantToExit": MessageLookupByLibrary.simpleMessage("您確定要退出嗎？"),
     "asset": MessageLookupByLibrary.simpleMessage("資產"),
     "assetName": MessageLookupByLibrary.simpleMessage("資產名稱"),
     "assetProfile": MessageLookupByLibrary.simpleMessage("資產設定檔"),
@@ -244,7 +243,6 @@ class MessageLookup extends MessageLookupByLibrary {
     "confirmNotRobotMessage": MessageLookupByLibrary.simpleMessage(
       "您必須確認您不是機器人",
     ),
-    "confirmToCloseTheApp": MessageLookupByLibrary.simpleMessage("確認關閉應用程式"),
     "confirmation": MessageLookupByLibrary.simpleMessage("確認"),
     "confirmingWifiConnection": MessageLookupByLibrary.simpleMessage(
       "確認 Wi-Fi 連線",

--- a/lib/generated/intl/messages_zh_TW.dart
+++ b/lib/generated/intl/messages_zh_TW.dart
@@ -217,7 +217,6 @@ class MessageLookup extends MessageLookupByLibrary {
     "applyChanges": MessageLookupByLibrary.simpleMessage("套用變更"),
     "areYouSure": MessageLookupByLibrary.simpleMessage("您確定嗎？"),
     "areYouSureYouWantToDeactivate": m3,
-    "areYouSureYouWantToExit": MessageLookupByLibrary.simpleMessage("您確定要退出嗎？"),
     "asset": MessageLookupByLibrary.simpleMessage("資產"),
     "assetName": MessageLookupByLibrary.simpleMessage("資產名稱"),
     "assetProfile": MessageLookupByLibrary.simpleMessage("資產設定檔"),
@@ -257,7 +256,6 @@ class MessageLookup extends MessageLookupByLibrary {
     "confirmNotRobotMessage": MessageLookupByLibrary.simpleMessage(
       "您必須確認您不是機器人",
     ),
-    "confirmToCloseTheApp": MessageLookupByLibrary.simpleMessage("確認關閉應用程式"),
     "confirmation": MessageLookupByLibrary.simpleMessage("確認"),
     "confirmingWifiConnection": MessageLookupByLibrary.simpleMessage(
       "確認 Wi-Fi 連線",

--- a/lib/generated/l10n.dart
+++ b/lib/generated/l10n.dart
@@ -3238,26 +3238,6 @@ class S {
     );
   }
 
-  /// `Are you sure you want to exit?`
-  String get areYouSureYouWantToExit {
-    return Intl.message(
-      'Are you sure you want to exit?',
-      name: 'areYouSureYouWantToExit',
-      desc: '',
-      args: [],
-    );
-  }
-
-  /// `Confirm to close the app`
-  String get confirmToCloseTheApp {
-    return Intl.message(
-      'Confirm to close the app',
-      name: 'confirmToCloseTheApp',
-      desc: '',
-      args: [],
-    );
-  }
-
   /// `Saved to platform 'Image gallery'`
   String get imageSavedToGallery {
     return Intl.message(

--- a/lib/generated/l10n.dart
+++ b/lib/generated/l10n.dart
@@ -3378,26 +3378,6 @@ class S {
     );
   }
 
-  /// `Are you sure you want to exit?`
-  String get areYouSureYouWantToExit {
-    return Intl.message(
-      'Are you sure you want to exit?',
-      name: 'areYouSureYouWantToExit',
-      desc: '',
-      args: [],
-    );
-  }
-
-  /// `Confirm to close the app`
-  String get confirmToCloseTheApp {
-    return Intl.message(
-      'Confirm to close the app',
-      name: 'confirmToCloseTheApp',
-      desc: '',
-      args: [],
-    );
-  }
-
   /// `Saved to platform 'Image gallery'`
   String get imageSavedToGallery {
     return Intl.message(

--- a/lib/l10n/intl_ar.arb
+++ b/lib/l10n/intl_ar.arb
@@ -430,8 +430,6 @@
   "phoneIsRequired": "رقم الهاتف مطلوب",
   "phoneIsInvalid": "رقم الهاتف غير صالح",
   "addVerificationMethod": "إضافة طريقة تحقق",
-  "areYouSureYouWantToExit": "هل أنت متأكد أنك تريد الخروج؟",
-  "confirmToCloseTheApp": "تأكيد لإغلاق التطبيق",
   "nSelected": "{count} محدد",
   "@nSelected": {
     "placeholders": {

--- a/lib/l10n/intl_ar.arb
+++ b/lib/l10n/intl_ar.arb
@@ -430,8 +430,6 @@
   "phoneIsRequired": "رقم الهاتف مطلوب",
   "phoneIsInvalid": "رقم الهاتف غير صالح",
   "addVerificationMethod": "إضافة طريقة تحقق",
-  "areYouSureYouWantToExit": "هل أنت متأكد أنك تريد الخروج؟",
-  "confirmToCloseTheApp": "تأكيد لإغلاق التطبيق",
   "actionTypeAddedToEntityGroup": "تمت الإضافة إلى مجموعة الكيانات",
   "actionTypeChangeOwner": "تم تغيير المالك",
   "actionTypeMadePrivate": "تم جعله خاصاً",

--- a/lib/l10n/intl_da_DK.arb
+++ b/lib/l10n/intl_da_DK.arb
@@ -430,8 +430,6 @@
   "phoneIsRequired": "Telefon er påkrævet",
   "phoneIsInvalid": "Telefonnummer er ugyldigt",
   "addVerificationMethod": "Tilføj verifikationsmetode",
-  "areYouSureYouWantToExit": "Er du sikker på, at du vil afslutte?",
-  "confirmToCloseTheApp": "Bekræft for at lukke appen",
   "loginNotification": "Log ind på din konto",
   "nSelected": "{count} valgt",
   "@nSelected": {

--- a/lib/l10n/intl_da_DK.arb
+++ b/lib/l10n/intl_da_DK.arb
@@ -430,8 +430,6 @@
   "phoneIsRequired": "Telefon er påkrævet",
   "phoneIsInvalid": "Telefonnummer er ugyldigt",
   "addVerificationMethod": "Tilføj verifikationsmetode",
-  "areYouSureYouWantToExit": "Er du sikker på, at du vil afslutte?",
-  "confirmToCloseTheApp": "Bekræft for at lukke appen",
   "loginNotification": "Log ind på din konto",
   "actionTypeAddedToEntityGroup": "Tilføjet til entitetsgruppe",
   "actionTypeChangeOwner": "Ejer ændret",

--- a/lib/l10n/intl_de_DE.arb
+++ b/lib/l10n/intl_de_DE.arb
@@ -430,8 +430,6 @@
   "phoneIsRequired": "Telefon ist erforderlich",
   "phoneIsInvalid": "Telefonnummer ist ungültig",
   "addVerificationMethod": "Verifizierungsmethode hinzufügen",
-  "areYouSureYouWantToExit": "Möchten Sie wirklich beenden?",
-  "confirmToCloseTheApp": "Bestätigen Sie, um die App zu schließen",
   "loginNotification": "Melden Sie sich bei Ihrem Konto an",
   "nSelected": "{count} ausgewählt",
   "@nSelected": {

--- a/lib/l10n/intl_de_DE.arb
+++ b/lib/l10n/intl_de_DE.arb
@@ -430,8 +430,6 @@
   "phoneIsRequired": "Telefon ist erforderlich",
   "phoneIsInvalid": "Telefonnummer ist ungültig",
   "addVerificationMethod": "Verifizierungsmethode hinzufügen",
-  "areYouSureYouWantToExit": "Möchten Sie wirklich beenden?",
-  "confirmToCloseTheApp": "Bestätigen Sie, um die App zu schließen",
   "loginNotification": "Melden Sie sich bei Ihrem Konto an",
   "actionTypeAddedToEntityGroup": "Zur Entitätsgruppe hinzugefügt",
   "actionTypeChangeOwner": "Eigentümer geändert",

--- a/lib/l10n/intl_el_GR.arb
+++ b/lib/l10n/intl_el_GR.arb
@@ -430,8 +430,6 @@
   "phoneIsRequired": "Το τηλέφωνο είναι υποχρεωτικό",
   "phoneIsInvalid": "Ο αριθμός τηλεφώνου δεν είναι έγκυρος",
   "addVerificationMethod": "Προσθήκη μεθόδου επαλήθευσης",
-  "areYouSureYouWantToExit": "Είστε σίγουροι ότι θέλετε να βγείτε;",
-  "confirmToCloseTheApp": "Επιβεβαίωση για κλείσιμο της εφαρμογής",
   "loginNotification": "Συνδεθείτε στον λογαριασμό σας",
   "nSelected": "{count} επιλεγμένα",
   "@nSelected": {

--- a/lib/l10n/intl_el_GR.arb
+++ b/lib/l10n/intl_el_GR.arb
@@ -430,8 +430,6 @@
   "phoneIsRequired": "Το τηλέφωνο είναι υποχρεωτικό",
   "phoneIsInvalid": "Ο αριθμός τηλεφώνου δεν είναι έγκυρος",
   "addVerificationMethod": "Προσθήκη μεθόδου επαλήθευσης",
-  "areYouSureYouWantToExit": "Είστε σίγουροι ότι θέλετε να βγείτε;",
-  "confirmToCloseTheApp": "Επιβεβαίωση για κλείσιμο της εφαρμογής",
   "loginNotification": "Συνδεθείτε στον λογαριασμό σας",
   "actionTypeAddedToEntityGroup": "Προστέθηκε στην ομάδα οντοτήτων",
   "actionTypeChangeOwner": "Αλλαγή ιδιοκτήτη",

--- a/lib/l10n/intl_en.arb
+++ b/lib/l10n/intl_en.arb
@@ -436,8 +436,6 @@
   "phoneIsRequired": "Phone is required",
   "phoneIsInvalid": "Phone is invalid",
   "addVerificationMethod": "Add verification method",
-  "areYouSureYouWantToExit": "Are you sure you want to exit?",
-  "confirmToCloseTheApp": "Confirm to close the app",
   "imageSavedToGallery": "Saved to platform 'Image gallery'",
   "failedToSaveImage": "Failed to save image",
   "nSelected": "{count} selected",

--- a/lib/l10n/intl_en.arb
+++ b/lib/l10n/intl_en.arb
@@ -452,8 +452,6 @@
   "phoneIsRequired": "Phone is required",
   "phoneIsInvalid": "Phone is invalid",
   "addVerificationMethod": "Add verification method",
-  "areYouSureYouWantToExit": "Are you sure you want to exit?",
-  "confirmToCloseTheApp": "Confirm to close the app",
   "imageSavedToGallery": "Saved to platform 'Image gallery'",
   "failedToSaveImage": "Failed to save image",
   "nSelected": "{count} selected",

--- a/lib/l10n/intl_es_ES.arb
+++ b/lib/l10n/intl_es_ES.arb
@@ -430,8 +430,6 @@
   "phoneIsRequired": "El teléfono es obligatorio",
   "phoneIsInvalid": "El número de teléfono no es válido",
   "addVerificationMethod": "Añadir método de verificación",
-  "areYouSureYouWantToExit": "¿Estás seguro de que quieres salir?",
-  "confirmToCloseTheApp": "Confirmar para cerrar la aplicación",
   "loginNotification": "Inicia sesión en tu cuenta",
   "nSelected": "{count} seleccionados",
   "@nSelected": {

--- a/lib/l10n/intl_es_ES.arb
+++ b/lib/l10n/intl_es_ES.arb
@@ -430,8 +430,6 @@
   "phoneIsRequired": "El teléfono es obligatorio",
   "phoneIsInvalid": "El número de teléfono no es válido",
   "addVerificationMethod": "Añadir método de verificación",
-  "areYouSureYouWantToExit": "¿Estás seguro de que quieres salir?",
-  "confirmToCloseTheApp": "Confirmar para cerrar la aplicación",
   "loginNotification": "Inicia sesión en tu cuenta",
   "actionTypeAddedToEntityGroup": "Añadido al grupo de entidades",
   "actionTypeChangeOwner": "Propietario cambiado",

--- a/lib/l10n/intl_fr_FR.arb
+++ b/lib/l10n/intl_fr_FR.arb
@@ -430,8 +430,6 @@
   "phoneIsRequired": "Le téléphone est requis",
   "phoneIsInvalid": "Le numéro de téléphone est invalide",
   "addVerificationMethod": "Ajouter une méthode de vérification",
-  "areYouSureYouWantToExit": "Êtes-vous sûr de vouloir quitter ?",
-  "confirmToCloseTheApp": "Confirmer pour fermer l'application",
   "loginNotification": "Connectez-vous à votre compte",
   "nSelected": "{count} sélectionnés",
   "@nSelected": {

--- a/lib/l10n/intl_fr_FR.arb
+++ b/lib/l10n/intl_fr_FR.arb
@@ -430,8 +430,6 @@
   "phoneIsRequired": "Le téléphone est requis",
   "phoneIsInvalid": "Le numéro de téléphone est invalide",
   "addVerificationMethod": "Ajouter une méthode de vérification",
-  "areYouSureYouWantToExit": "Êtes-vous sûr de vouloir quitter ?",
-  "confirmToCloseTheApp": "Confirmer pour fermer l'application",
   "loginNotification": "Connectez-vous à votre compte",
   "actionTypeAddedToEntityGroup": "Ajouté au groupe d'entités",
   "actionTypeChangeOwner": "Propriétaire modifié",

--- a/lib/l10n/intl_it_IT.arb
+++ b/lib/l10n/intl_it_IT.arb
@@ -430,8 +430,6 @@
   "phoneIsRequired": "Il telefono è obbligatorio",
   "phoneIsInvalid": "Il numero di telefono non è valido",
   "addVerificationMethod": "Aggiungi metodo di verifica",
-  "areYouSureYouWantToExit": "Sei sicuro di voler uscire?",
-  "confirmToCloseTheApp": "Conferma per chiudere l'app",
   "loginNotification": "Accedi al tuo account",
   "nSelected": "{count} selezionati",
   "@nSelected": {

--- a/lib/l10n/intl_it_IT.arb
+++ b/lib/l10n/intl_it_IT.arb
@@ -430,8 +430,6 @@
   "phoneIsRequired": "Il telefono è obbligatorio",
   "phoneIsInvalid": "Il numero di telefono non è valido",
   "addVerificationMethod": "Aggiungi metodo di verifica",
-  "areYouSureYouWantToExit": "Sei sicuro di voler uscire?",
-  "confirmToCloseTheApp": "Conferma per chiudere l'app",
   "loginNotification": "Accedi al tuo account",
   "actionTypeAddedToEntityGroup": "Aggiunto al gruppo di entità",
   "actionTypeChangeOwner": "Proprietario cambiato",

--- a/lib/l10n/intl_nl_NL.arb
+++ b/lib/l10n/intl_nl_NL.arb
@@ -430,8 +430,6 @@
   "phoneIsRequired": "Telefoon is verplicht",
   "phoneIsInvalid": "Telefoonnummer is ongeldig",
   "addVerificationMethod": "Verificatiemethode toevoegen",
-  "areYouSureYouWantToExit": "Weet u zeker dat u wilt afsluiten?",
-  "confirmToCloseTheApp": "Bevestig om de app te sluiten",
   "loginNotification": "Log in op uw account",
   "nSelected": "{count} geselecteerd",
   "@nSelected": {

--- a/lib/l10n/intl_nl_NL.arb
+++ b/lib/l10n/intl_nl_NL.arb
@@ -430,8 +430,6 @@
   "phoneIsRequired": "Telefoon is verplicht",
   "phoneIsInvalid": "Telefoonnummer is ongeldig",
   "addVerificationMethod": "Verificatiemethode toevoegen",
-  "areYouSureYouWantToExit": "Weet u zeker dat u wilt afsluiten?",
-  "confirmToCloseTheApp": "Bevestig om de app te sluiten",
   "loginNotification": "Log in op uw account",
   "actionTypeAddedToEntityGroup": "Toegevoegd aan entiteitsgroep",
   "actionTypeChangeOwner": "Eigenaar gewijzigd",

--- a/lib/l10n/intl_no_NO.arb
+++ b/lib/l10n/intl_no_NO.arb
@@ -430,8 +430,6 @@
   "phoneIsRequired": "Telefon er påkrevd",
   "phoneIsInvalid": "Telefonnummer er ugyldig",
   "addVerificationMethod": "Legg til verifiseringsmetode",
-  "areYouSureYouWantToExit": "Er du sikker på at du vil avslutte?",
-  "confirmToCloseTheApp": "Bekreft for å lukke appen",
   "loginNotification": "Logg inn på kontoen din",
   "nSelected": "{count} valgt",
   "@nSelected": {

--- a/lib/l10n/intl_no_NO.arb
+++ b/lib/l10n/intl_no_NO.arb
@@ -430,8 +430,6 @@
   "phoneIsRequired": "Telefon er påkrevd",
   "phoneIsInvalid": "Telefonnummer er ugyldig",
   "addVerificationMethod": "Legg til verifiseringsmetode",
-  "areYouSureYouWantToExit": "Er du sikker på at du vil avslutte?",
-  "confirmToCloseTheApp": "Bekreft for å lukke appen",
   "loginNotification": "Logg inn på kontoen din",
   "actionTypeAddedToEntityGroup": "Lagt til i entitetsgruppe",
   "actionTypeChangeOwner": "Eier endret",

--- a/lib/l10n/intl_vi_VN.arb
+++ b/lib/l10n/intl_vi_VN.arb
@@ -430,8 +430,6 @@
   "phoneIsRequired": "Vui lòng nhập số điện thoại",
   "phoneIsInvalid": "Số điện thoại không hợp lệ",
   "addVerificationMethod": "Thêm phương thức xác minh",
-  "areYouSureYouWantToExit": "Bạn có chắc chắn muốn thoát?",
-  "confirmToCloseTheApp": "Xác nhận để đóng ứng dụng",
   "nSelected": "{count} đã chọn",
   "@nSelected": {
     "placeholders": {

--- a/lib/l10n/intl_vi_VN.arb
+++ b/lib/l10n/intl_vi_VN.arb
@@ -430,8 +430,6 @@
   "phoneIsRequired": "Vui lòng nhập số điện thoại",
   "phoneIsInvalid": "Số điện thoại không hợp lệ",
   "addVerificationMethod": "Thêm phương thức xác minh",
-  "areYouSureYouWantToExit": "Bạn có chắc chắn muốn thoát?",
-  "confirmToCloseTheApp": "Xác nhận để đóng ứng dụng",
   "actionTypeAddedToEntityGroup": "Đã thêm vào nhóm thực thể",
   "actionTypeChangeOwner": "Đã thay đổi chủ sở hữu",
   "actionTypeMadePrivate": "Đã chuyển sang riêng tư",

--- a/lib/l10n/intl_zh.arb
+++ b/lib/l10n/intl_zh.arb
@@ -437,8 +437,6 @@
   "phoneIsRequired": "Phone is required",
   "phoneIsInvalid": "Phone is invalid",
   "addVerificationMethod": "Add verification method",
-  "areYouSureYouWantToExit": "Are you sure you want to exit?",
-  "confirmToCloseTheApp": "Confirm to close the app",
   "imageSavedToGallery": "已保存到“图片库”",
   "failedToSaveImage": "保存图片失败"
 }

--- a/lib/l10n/intl_zh_CN.arb
+++ b/lib/l10n/intl_zh_CN.arb
@@ -430,8 +430,6 @@
   "phoneIsRequired": "手机号码是必填项",
   "phoneIsInvalid": "手机号码无效",
   "addVerificationMethod": "添加验证方式",
-  "areYouSureYouWantToExit": "您确定要退出吗？",
-  "confirmToCloseTheApp": "确认关闭应用",
   "nSelected": "已选择 {count} 项",
   "@nSelected": {
     "placeholders": {

--- a/lib/l10n/intl_zh_CN.arb
+++ b/lib/l10n/intl_zh_CN.arb
@@ -430,8 +430,6 @@
   "phoneIsRequired": "手机号码是必填项",
   "phoneIsInvalid": "手机号码无效",
   "addVerificationMethod": "添加验证方式",
-  "areYouSureYouWantToExit": "您确定要退出吗？",
-  "confirmToCloseTheApp": "确认关闭应用",
   "actionTypeAddedToEntityGroup": "已添加到实体组",
   "actionTypeChangeOwner": "所有者已更改",
   "actionTypeMadePrivate": "已设为私有",

--- a/lib/l10n/intl_zh_TW.arb
+++ b/lib/l10n/intl_zh_TW.arb
@@ -430,8 +430,6 @@
   "phoneIsRequired": "手機號碼為必填項目",
   "phoneIsInvalid": "手機號碼無效",
   "addVerificationMethod": "新增驗證方式",
-  "areYouSureYouWantToExit": "您確定要退出嗎？",
-  "confirmToCloseTheApp": "確認關閉應用程式",
   "nSelected": "已選擇 {count} 項",
   "@nSelected": {
     "placeholders": {

--- a/lib/l10n/intl_zh_TW.arb
+++ b/lib/l10n/intl_zh_TW.arb
@@ -430,8 +430,6 @@
   "phoneIsRequired": "手機號碼為必填項目",
   "phoneIsInvalid": "手機號碼無效",
   "addVerificationMethod": "新增驗證方式",
-  "areYouSureYouWantToExit": "您確定要退出嗎？",
-  "confirmToCloseTheApp": "確認關閉應用程式",
   "actionTypeAddedToEntityGroup": "已新增至實體群組",
   "actionTypeChangeOwner": "擁有者已變更",
   "actionTypeMadePrivate": "已設為私有",

--- a/lib/modules/dashboard/main_dashboard_page.dart
+++ b/lib/modules/dashboard/main_dashboard_page.dart
@@ -33,6 +33,7 @@ class _MainDashboardPageState extends State<MainDashboardPage>
       return;
     }
     await widget.controller.closeDashboard();
+    if (!mounted) return;
     _dashboardLoadingCtrl?.value = true;
   }
 

--- a/lib/modules/dashboard/main_dashboard_page.dart
+++ b/lib/modules/dashboard/main_dashboard_page.dart
@@ -3,6 +3,7 @@ import 'package:thingsboard_app/config/themes/tb_text_styles.dart';
 import 'package:thingsboard_app/locator.dart';
 import 'package:thingsboard_app/modules/dashboard/presentation/controller/dashboard_controller.dart';
 import 'package:thingsboard_app/modules/dashboard/presentation/controller/dashboard_page_controller.dart';
+import 'package:thingsboard_app/modules/dashboard/presentation/widgets/dashboard_back_handler.dart';
 import 'package:thingsboard_app/modules/dashboard/presentation/widgets/dashboard_widget.dart';
 import 'package:thingsboard_app/utils/services/endpoint/i_endpoint_service.dart';
 import 'package:thingsboard_app/widgets/tb_app_bar.dart';
@@ -27,6 +28,14 @@ class _MainDashboardPageState extends State<MainDashboardPage>
   DashboardController? _dashboardController;
   ValueNotifier<bool>? _dashboardLoadingCtrl;
 
+  Future<void> _handleBack() async {
+    if (await DashboardBackHandler.tryNavigateBack(_dashboardController)) {
+      return;
+    }
+    await widget.controller.closeDashboard();
+    _dashboardLoadingCtrl?.value = true;
+  }
+
   @override
   Widget build(BuildContext context) {
     return ValueListenableBuilder<String>(
@@ -36,21 +45,7 @@ class _MainDashboardPageState extends State<MainDashboardPage>
           appBar: TbAppBar(
             leading: IconButton(
               icon: const Icon(Icons.arrow_back),
-              onPressed: () async {
-                if (_dashboardController?.rightLayoutOpened.value == true) {
-                  await _dashboardController?.toggleRightLayout();
-                  return;
-                }
-
-                final controller = _dashboardController?.controller;
-                if (await controller?.canGoBack() == true) {
-                  await controller?.goBack();
-                } else {
-                  widget.controller.closeDashboard().then(
-                    (_) => _dashboardLoadingCtrl?.value = true,
-                  );
-                }
-              },
+              onPressed: _handleBack,
             ),
             elevation: 1,
             shadowColor: Colors.transparent,
@@ -75,35 +70,45 @@ class _MainDashboardPageState extends State<MainDashboardPage>
               ),
             ],
           ),
-          body: ValueListenableBuilder<String?>(
-            valueListenable: getIt<IEndpointService>().listenEndpointChanges,
-            builder: (context, value, _) {
-              return SafeArea(
-                bottom: false,
-                child: DashboardWidget(
-                  titleCallback: (title) {
-                    dashboardTitleValue.value = title;
-                  },
-                  pageController: widget.controller,
-                  controllerCallback: (controller, loadingCtrl) {
-                    _dashboardController = controller;
-                    _dashboardLoadingCtrl = loadingCtrl;
-                    widget.controller.setDashboardController(controller);
-
-                    controller.hasRightLayout.addListener(() {
-                      hasRightLayout.value = controller.hasRightLayout.value;
-                    });
-                    controller.rightLayoutOpened.addListener(() {
-                      if (controller.rightLayoutOpened.value) {
-                        rightLayoutMenuController.forward();
-                      } else {
-                        rightLayoutMenuController.reverse();
-                      }
-                    });
-                  },
-                ),
+          body: ValueListenableBuilder<int>(
+            valueListenable: widget.controller.pageCtrl.currentIndex,
+            builder: (context, pageIndex, child) {
+              return DashboardBackHandler(
+                enabled: pageIndex == 1,
+                onBack: _handleBack,
+                child: child!,
               );
             },
+            child: ValueListenableBuilder<String?>(
+              valueListenable: getIt<IEndpointService>().listenEndpointChanges,
+              builder: (context, value, _) {
+                return SafeArea(
+                  bottom: false,
+                  child: DashboardWidget(
+                    titleCallback: (title) {
+                      dashboardTitleValue.value = title;
+                    },
+                    pageController: widget.controller,
+                    controllerCallback: (controller, loadingCtrl) {
+                      _dashboardController = controller;
+                      _dashboardLoadingCtrl = loadingCtrl;
+                      widget.controller.setDashboardController(controller);
+
+                      controller.hasRightLayout.addListener(() {
+                        hasRightLayout.value = controller.hasRightLayout.value;
+                      });
+                      controller.rightLayoutOpened.addListener(() {
+                        if (controller.rightLayoutOpened.value) {
+                          rightLayoutMenuController.forward();
+                        } else {
+                          rightLayoutMenuController.reverse();
+                        }
+                      });
+                    },
+                  ),
+                );
+              },
+            ),
           ),
         );
       },

--- a/lib/modules/dashboard/main_dashboard_page.dart
+++ b/lib/modules/dashboard/main_dashboard_page.dart
@@ -75,7 +75,7 @@ class _MainDashboardPageState extends State<MainDashboardPage>
             valueListenable: widget.controller.pageCtrl.currentIndex,
             builder: (context, pageIndex, child) {
               return DashboardBackHandler(
-                enabled: pageIndex == 1,
+                interceptBack: pageIndex == 1,
                 onBack: _handleBack,
                 child: child!,
               );

--- a/lib/modules/dashboard/presentation/view/dashboards_page.dart
+++ b/lib/modules/dashboard/presentation/view/dashboards_page.dart
@@ -43,6 +43,7 @@ class _DashboardsPageState extends State<DashboardsPage> {
   @override
   void dispose() {
     DashboardsDi.dispose(diKey);
+    pageViewCtrl.dispose();
     super.dispose();
   }
 }

--- a/lib/modules/dashboard/presentation/view/dashboards_page.dart
+++ b/lib/modules/dashboard/presentation/view/dashboards_page.dart
@@ -52,6 +52,7 @@ class _DashboardsPageState extends State<DashboardsPage> {
   @override
   void dispose() {
     DashboardsDi.dispose(diKey);
+    pageViewCtrl.dispose();
     super.dispose();
   }
 }

--- a/lib/modules/dashboard/presentation/view/fullscreen_dashboard_page.dart
+++ b/lib/modules/dashboard/presentation/view/fullscreen_dashboard_page.dart
@@ -3,6 +3,7 @@ import 'package:thingsboard_app/config/routes/router.dart';
 import 'package:thingsboard_app/locator.dart';
 import 'package:thingsboard_app/modules/dashboard/di/dashboards_di.dart';
 import 'package:thingsboard_app/modules/dashboard/presentation/controller/dashboard_controller.dart';
+import 'package:thingsboard_app/modules/dashboard/presentation/widgets/dashboard_back_handler.dart';
 import 'package:thingsboard_app/modules/dashboard/presentation/widgets/dashboard_widget.dart';
 import 'package:thingsboard_app/utils/services/endpoint/i_endpoint_service.dart';
 import 'package:thingsboard_app/utils/services/tb_client_service/i_tb_client_service.dart';
@@ -38,17 +39,7 @@ class _FullscreenDashboardPageState extends State<FullscreenDashboardPage> {
             return TbAppBar(
               leading: IconButton(
             icon: const Icon(Icons.arrow_back),
-                onPressed: () async {
-                  if (_dashboardController?.rightLayoutOpened.value == true) {
-                    await _dashboardController?.toggleRightLayout();
-                    return;
-                  }
-
-                  final controller = _dashboardController?.controller;
-                  if (await controller?.canGoBack() == true) {
-                    await controller?.goBack();
-                  }
-                },
+                onPressed: _handleBack,
               ),
               elevation: 1,
               shadowColor: Colors.transparent,
@@ -77,9 +68,11 @@ class _FullscreenDashboardPageState extends State<FullscreenDashboardPage> {
           },
         ),
       ),
-      body: ValueListenableBuilder<String?>(
-        valueListenable: getIt<IEndpointService>().listenEndpointChanges,
-        builder:
+      body: DashboardBackHandler(
+        onBack: _handleBack,
+        child: ValueListenableBuilder<String?>(
+          valueListenable: getIt<IEndpointService>().listenEndpointChanges,
+          builder:
             (context, _, _) => DashboardWidget(
               titleCallback: (title) {
                 dashboardTitleValue.value = title;
@@ -96,6 +89,7 @@ class _FullscreenDashboardPageState extends State<FullscreenDashboardPage> {
                 );
               },
             ),
+        ),
       ),
     );
   }
@@ -118,5 +112,9 @@ class _FullscreenDashboardPageState extends State<FullscreenDashboardPage> {
 
   void _onCanGoBack(bool canGoBack) {
     showBackValue.value = canGoBack;
+  }
+
+  Future<void> _handleBack() async {
+    await DashboardBackHandler.tryNavigateBack(_dashboardController);
   }
 }

--- a/lib/modules/dashboard/presentation/view/fullscreen_dashboard_page.dart
+++ b/lib/modules/dashboard/presentation/view/fullscreen_dashboard_page.dart
@@ -1,4 +1,5 @@
 import 'package:flutter/material.dart';
+import 'package:go_router/go_router.dart';
 import 'package:thingsboard_app/config/routes/router.dart';
 import 'package:thingsboard_app/locator.dart';
 import 'package:thingsboard_app/modules/dashboard/di/dashboards_di.dart';
@@ -115,6 +116,11 @@ class _FullscreenDashboardPageState extends State<FullscreenDashboardPage> {
   }
 
   Future<void> _handleBack() async {
-    await DashboardBackHandler.tryNavigateBack(_dashboardController);
+    if (await DashboardBackHandler.tryNavigateBack(_dashboardController)) {
+      return;
+    }
+    if (mounted && context.canPop()) {
+      Navigator.of(context).pop();
+    }
   }
 }

--- a/lib/modules/dashboard/presentation/view/fullscreen_dashboard_page.dart
+++ b/lib/modules/dashboard/presentation/view/fullscreen_dashboard_page.dart
@@ -4,6 +4,7 @@ import 'package:thingsboard_app/locator.dart';
 import 'package:thingsboard_app/modules/dashboard/di/dashboards_di.dart';
 import 'package:thingsboard_app/modules/dashboard/presentation/controller/dashboard_controller.dart';
 import 'package:thingsboard_app/modules/dashboard/presentation/view/dashboard_permission_error_view.dart';
+import 'package:thingsboard_app/modules/dashboard/presentation/widgets/dashboard_back_handler.dart';
 import 'package:thingsboard_app/modules/dashboard/presentation/widgets/dashboard_widget.dart';
 import 'package:thingsboard_app/utils/services/custom_translation/i_custom_translation_service.dart';
 import 'package:thingsboard_app/utils/services/endpoint/i_endpoint_service.dart';
@@ -46,17 +47,7 @@ class _FullscreenDashboardPageState extends State<FullscreenDashboardPage> {
             return TbAppBar(
               leading: IconButton(
             icon: const Icon(Icons.arrow_back),
-                onPressed: () async {
-                  if (_dashboardController?.rightLayoutOpened.value == true) {
-                    await _dashboardController?.toggleRightLayout();
-                    return;
-                  }
-
-                  final controller = _dashboardController?.controller;
-                  if (await controller?.canGoBack() == true) {
-                    await controller?.goBack();
-                  }
-                },
+                onPressed: _handleBack,
               ),
               elevation: 1,
               shadowColor: Colors.transparent,
@@ -85,9 +76,11 @@ class _FullscreenDashboardPageState extends State<FullscreenDashboardPage> {
           },
         ),
       ),
-      body: ValueListenableBuilder<String?>(
-        valueListenable: getIt<IEndpointService>().listenEndpointChanges,
-        builder:
+      body: DashboardBackHandler(
+        onBack: _handleBack,
+        child: ValueListenableBuilder<String?>(
+          valueListenable: getIt<IEndpointService>().listenEndpointChanges,
+          builder:
             (context, _, _) => DashboardWidget(
               titleCallback: (title) {
                 dashboardTitleValue.value = title;
@@ -104,6 +97,7 @@ class _FullscreenDashboardPageState extends State<FullscreenDashboardPage> {
                 );
               },
             ),
+        ),
       ),
     );
   }
@@ -131,5 +125,9 @@ class _FullscreenDashboardPageState extends State<FullscreenDashboardPage> {
 
   void _onCanGoBack(bool canGoBack) {
     showBackValue.value = canGoBack;
+  }
+
+  Future<void> _handleBack() async {
+    await DashboardBackHandler.tryNavigateBack(_dashboardController);
   }
 }

--- a/lib/modules/dashboard/presentation/view/fullscreen_dashboard_page.dart
+++ b/lib/modules/dashboard/presentation/view/fullscreen_dashboard_page.dart
@@ -1,4 +1,5 @@
 import 'package:flutter/material.dart';
+import 'package:go_router/go_router.dart';
 import 'package:thingsboard_app/config/routes/router.dart';
 import 'package:thingsboard_app/locator.dart';
 import 'package:thingsboard_app/modules/dashboard/di/dashboards_di.dart';
@@ -128,6 +129,11 @@ class _FullscreenDashboardPageState extends State<FullscreenDashboardPage> {
   }
 
   Future<void> _handleBack() async {
-    await DashboardBackHandler.tryNavigateBack(_dashboardController);
+    if (await DashboardBackHandler.tryNavigateBack(_dashboardController)) {
+      return;
+    }
+    if (mounted && context.canPop()) {
+      Navigator.of(context).pop();
+    }
   }
 }

--- a/lib/modules/dashboard/presentation/view/home_dashboard_page.dart
+++ b/lib/modules/dashboard/presentation/view/home_dashboard_page.dart
@@ -1,7 +1,9 @@
 import 'package:flutter/material.dart';
+import 'package:flutter/services.dart';
 import 'package:thingsboard_app/locator.dart';
 import 'package:thingsboard_app/modules/dashboard/di/dashboards_di.dart';
 import 'package:thingsboard_app/modules/dashboard/presentation/controller/dashboard_controller.dart';
+import 'package:thingsboard_app/modules/dashboard/presentation/widgets/dashboard_back_handler.dart';
 import 'package:thingsboard_app/modules/dashboard/presentation/widgets/dashboard_widget.dart';
 import 'package:thingsboard_app/modules/dashboard/presentation/widgets/dashboards_appbar.dart';
 import 'package:thingsboard_app/thingsboard_client.dart';
@@ -37,6 +39,13 @@ class _HomeDashboardState extends State<HomeDashboardPage> {
   late final home =
       '${getIt<IEndpointService>().getCachedEndpoint()}/dashboards/${widget.dashboard.dashboardId!}${widget.dashboard.hideDashboardToolbar ? '?hideToolbar=true' : ''}';
 
+  Future<void> _handleBack() async {
+    if (await DashboardBackHandler.tryNavigateBack(_dashboardController)) {
+      return;
+    }
+    await SystemNavigator.pop();
+  }
+
   @override
   Widget build(BuildContext context) {
     return ValueListenableBuilder(
@@ -46,51 +55,43 @@ class _HomeDashboardState extends State<HomeDashboardPage> {
               value
                   ? IconButton(
                     icon: const Icon(Icons.arrow_back),
-                    onPressed: () async {
-                      if (_dashboardController?.rightLayoutOpened.value ==
-                          true) {
-                        await _dashboardController?.toggleRightLayout();
-                        return;
-                      }
-
-                      final controller = _dashboardController?.controller;
-                      if (await controller?.canGoBack() == true) {
-                        await controller?.goBack();
-                      }
-                    },
+                    onPressed: _handleBack,
                   )
                   : null,
 
           dashboardState: true,
-          body: DashboardWidget(
-            onUrlChanged: () async {
-              final url = await _dashboardController?.controller?.getUrl();
-              if (url.toString() == home) {
-                canGoback.value = false;
-                return;
-              }
-              final newVal =
-                  await _dashboardController?.controller?.canGoBack() ?? false;
-              canGoback.value = newVal;
-            },
-            controllerCallback: (controller, loadingCtrl) async {
-              _dashboardController = controller;
+          body: DashboardBackHandler(
+            onBack: _handleBack,
+            child: DashboardWidget(
+              onUrlChanged: () async {
+                final url = await _dashboardController?.controller?.getUrl();
+                if (url.toString() == home) {
+                  canGoback.value = false;
+                  return;
+                }
+                final newVal =
+                    await _dashboardController?.controller?.canGoBack() ?? false;
+                canGoback.value = newVal;
+              },
+              controllerCallback: (controller, loadingCtrl) async {
+                _dashboardController = controller;
 
-              if (_loaded) {
-                final canGoBack =
-                    await _dashboardController?.controller?.canGoBack();
-                canGoback.value = canGoBack ?? false;
-                return;
-              }
-              await controller.openDashboard(
-                widget.dashboard.dashboardId!.id!,
-                hideToolbar: widget.dashboard.hideDashboardToolbar,
-              );
+                if (_loaded) {
+                  final canGoBack =
+                      await _dashboardController?.controller?.canGoBack();
+                  canGoback.value = canGoBack ?? false;
+                  return;
+                }
+                await controller.openDashboard(
+                  widget.dashboard.dashboardId!.id!,
+                  hideToolbar: widget.dashboard.hideDashboardToolbar,
+                );
 
-              setState(() {
-                _loaded = true;
-              });
-            },
+                setState(() {
+                  _loaded = true;
+                });
+              },
+            ),
           ),
         );
       },

--- a/lib/modules/dashboard/presentation/view/single_dashboard_view.dart
+++ b/lib/modules/dashboard/presentation/view/single_dashboard_view.dart
@@ -3,6 +3,7 @@ import 'package:go_router/go_router.dart';
 import 'package:thingsboard_app/locator.dart';
 import 'package:thingsboard_app/modules/dashboard/di/dashboards_di.dart';
 import 'package:thingsboard_app/modules/dashboard/presentation/controller/dashboard_controller.dart';
+import 'package:thingsboard_app/modules/dashboard/presentation/widgets/dashboard_back_handler.dart';
 import 'package:thingsboard_app/modules/dashboard/presentation/widgets/dashboard_widget.dart';
 import 'package:thingsboard_app/utils/services/tb_client_service/i_tb_client_service.dart';
 import 'package:thingsboard_app/widgets/tb_app_bar.dart';
@@ -43,20 +44,7 @@ class _SingleDashboardViewState extends State<SingleDashboardView>
         leading: context.canPop()
           ? IconButton(
               icon: const Icon(Icons.arrow_back),
-              onPressed: () async {
-                if (_dashboardController?.rightLayoutOpened.value == true) {
-                  await _dashboardController?.toggleRightLayout();
-                  return;
-                }
-                final controller = _dashboardController?.controller;
-                if (await controller?.canGoBack() == true) {
-                  await controller?.goBack();
-                } else {
-                  if (context.mounted) {
-                    Navigator.of(context).pop();
-                  }
-                }
-              },
+              onPressed: _handleBack,
             )
           : null,
         elevation: 1,
@@ -87,39 +75,51 @@ class _SingleDashboardViewState extends State<SingleDashboardView>
         ],
         canGoBack: canGoBack,
       ),
-      body: SafeArea(
-        child: DashboardWidget(
-          titleCallback: (title) {
-            dashboardTitleValue.value = widget.title ?? title;
-          },
-          controllerCallback: (controller, _) {
-            _dashboardController = controller;
-            controller.hasRightLayout.addListener(() {
-              hasRightLayout.value = controller.hasRightLayout.value;
-            });
-            controller.rightLayoutOpened.addListener(() {
-              if (controller.rightLayoutOpened.value) {
-                rightLayoutMenuController.forward();
-              } else {
-                rightLayoutMenuController.reverse();
-              }
-            });
-
-            controller.canGoBack.addListener(() {
-              setState(() {
-                canGoBack = controller.canGoBack.value;
+      body: DashboardBackHandler(
+        onBack: _handleBack,
+        child: SafeArea(
+          child: DashboardWidget(
+            titleCallback: (title) {
+              dashboardTitleValue.value = widget.title ?? title;
+            },
+            controllerCallback: (controller, _) {
+              _dashboardController = controller;
+              controller.hasRightLayout.addListener(() {
+                hasRightLayout.value = controller.hasRightLayout.value;
               });
-            });
+              controller.rightLayoutOpened.addListener(() {
+                if (controller.rightLayoutOpened.value) {
+                  rightLayoutMenuController.forward();
+                } else {
+                  rightLayoutMenuController.reverse();
+                }
+              });
 
-            controller.openDashboard(
-              widget.id,
-              state: widget.state,
-              hideToolbar: widget.hideToolbar,
-            );
-          },
+              controller.canGoBack.addListener(() {
+                setState(() {
+                  canGoBack = controller.canGoBack.value;
+                });
+              });
+
+              controller.openDashboard(
+                widget.id,
+                state: widget.state,
+                hideToolbar: widget.hideToolbar,
+              );
+            },
+          ),
         ),
       ),
     );
+  }
+
+  Future<void> _handleBack() async {
+    if (await DashboardBackHandler.tryNavigateBack(_dashboardController)) {
+      return;
+    }
+    if (mounted && context.canPop()) {
+      Navigator.of(context).pop();
+    }
   }
 
   @override

--- a/lib/modules/dashboard/presentation/view/single_dashboard_view.dart
+++ b/lib/modules/dashboard/presentation/view/single_dashboard_view.dart
@@ -4,6 +4,7 @@ import 'package:thingsboard_app/locator.dart';
 import 'package:thingsboard_app/modules/dashboard/di/dashboards_di.dart';
 import 'package:thingsboard_app/modules/dashboard/presentation/controller/dashboard_controller.dart';
 import 'package:thingsboard_app/modules/dashboard/presentation/view/dashboard_permission_error_view.dart';
+import 'package:thingsboard_app/modules/dashboard/presentation/widgets/dashboard_back_handler.dart';
 import 'package:thingsboard_app/modules/dashboard/presentation/widgets/dashboard_widget.dart';
 import 'package:thingsboard_app/utils/services/custom_translation/i_custom_translation_service.dart';
 import 'package:thingsboard_app/utils/services/tb_client_service/i_tb_client_service.dart';
@@ -51,20 +52,7 @@ class _SingleDashboardViewState extends State<SingleDashboardView>
         leading: context.canPop()
           ? IconButton(
               icon: const Icon(Icons.arrow_back),
-              onPressed: () async {
-                if (_dashboardController?.rightLayoutOpened.value == true) {
-                  await _dashboardController?.toggleRightLayout();
-                  return;
-                }
-                final controller = _dashboardController?.controller;
-                if (await controller?.canGoBack() == true) {
-                  await controller?.goBack();
-                } else {
-                  if (context.mounted) {
-                    Navigator.of(context).pop();
-                  }
-                }
-              },
+              onPressed: _handleBack,
             )
           : null,
         elevation: 1,
@@ -95,40 +83,52 @@ class _SingleDashboardViewState extends State<SingleDashboardView>
         ],
         canGoBack: canGoBack,
       ),
-      body: SafeArea(
-        child: DashboardWidget(
-          titleCallback: (title) {
-            dashboardTitleValue.value = getIt<ICustomTranslationService>()
-                .translate(widget.title ?? title);
-          },
-          controllerCallback: (controller, _) {
-            _dashboardController = controller;
-            controller.hasRightLayout.addListener(() {
-              hasRightLayout.value = controller.hasRightLayout.value;
-            });
-            controller.rightLayoutOpened.addListener(() {
-              if (controller.rightLayoutOpened.value) {
-                rightLayoutMenuController.forward();
-              } else {
-                rightLayoutMenuController.reverse();
-              }
-            });
-
-            controller.canGoBack.addListener(() {
-              setState(() {
-                canGoBack = controller.canGoBack.value;
+      body: DashboardBackHandler(
+        onBack: _handleBack,
+        child: SafeArea(
+          child: DashboardWidget(
+            titleCallback: (title) {
+              dashboardTitleValue.value = getIt<ICustomTranslationService>()
+                  .translate(widget.title ?? title);
+            },
+            controllerCallback: (controller, _) {
+              _dashboardController = controller;
+              controller.hasRightLayout.addListener(() {
+                hasRightLayout.value = controller.hasRightLayout.value;
               });
-            });
+              controller.rightLayoutOpened.addListener(() {
+                if (controller.rightLayoutOpened.value) {
+                  rightLayoutMenuController.forward();
+                } else {
+                  rightLayoutMenuController.reverse();
+                }
+              });
 
-            controller.openDashboard(
-              widget.id,
-              state: widget.state,
-              hideToolbar: widget.hideToolbar,
-            );
-          },
+              controller.canGoBack.addListener(() {
+                setState(() {
+                  canGoBack = controller.canGoBack.value;
+                });
+              });
+
+              controller.openDashboard(
+                widget.id,
+                state: widget.state,
+                hideToolbar: widget.hideToolbar,
+              );
+            },
+          ),
         ),
       ),
     );
+  }
+
+  Future<void> _handleBack() async {
+    if (await DashboardBackHandler.tryNavigateBack(_dashboardController)) {
+      return;
+    }
+    if (mounted && context.canPop()) {
+      Navigator.of(context).pop();
+    }
   }
 
   @override

--- a/lib/modules/dashboard/presentation/widgets/dashboard_back_handler.dart
+++ b/lib/modules/dashboard/presentation/widgets/dashboard_back_handler.dart
@@ -5,13 +5,13 @@ class DashboardBackHandler extends StatelessWidget {
   const DashboardBackHandler({
     required this.onBack,
     required this.child,
-    this.enabled = true,
+    this.interceptBack = true,
     super.key,
   });
 
   final Future<void> Function() onBack;
   final Widget child;
-  final bool enabled;
+  final bool interceptBack;
 
   static Future<bool> tryNavigateBack(DashboardController? controller) async {
     if (controller == null) return false;
@@ -30,7 +30,7 @@ class DashboardBackHandler extends StatelessWidget {
   @override
   Widget build(BuildContext context) {
     return PopScope(
-      canPop: !enabled,
+      canPop: !interceptBack,
       onPopInvokedWithResult: (didPop, _) async {
         if (didPop) return;
         await onBack();

--- a/lib/modules/dashboard/presentation/widgets/dashboard_back_handler.dart
+++ b/lib/modules/dashboard/presentation/widgets/dashboard_back_handler.dart
@@ -15,7 +15,7 @@ class DashboardBackHandler extends StatelessWidget {
 
   static Future<bool> tryNavigateBack(DashboardController? controller) async {
     if (controller == null) return false;
-    if (controller.rightLayoutOpened.value == true) {
+    if (controller.rightLayoutOpened.value) {
       await controller.toggleRightLayout();
       return true;
     }

--- a/lib/modules/dashboard/presentation/widgets/dashboard_back_handler.dart
+++ b/lib/modules/dashboard/presentation/widgets/dashboard_back_handler.dart
@@ -1,0 +1,41 @@
+import 'package:flutter/material.dart';
+import 'package:thingsboard_app/modules/dashboard/presentation/controller/dashboard_controller.dart';
+
+class DashboardBackHandler extends StatelessWidget {
+  const DashboardBackHandler({
+    required this.onBack,
+    required this.child,
+    this.enabled = true,
+    super.key,
+  });
+
+  final Future<void> Function() onBack;
+  final Widget child;
+  final bool enabled;
+
+  static Future<bool> tryNavigateBack(DashboardController? controller) async {
+    if (controller == null) return false;
+    if (controller.rightLayoutOpened.value == true) {
+      await controller.toggleRightLayout();
+      return true;
+    }
+    final web = controller.controller;
+    if (web != null && await web.canGoBack()) {
+      await web.goBack();
+      return true;
+    }
+    return false;
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    return PopScope(
+      canPop: !enabled,
+      onPopInvokedWithResult: (didPop, _) async {
+        if (didPop) return;
+        await onBack();
+      },
+      child: child,
+    );
+  }
+}

--- a/lib/modules/main/navigation_page.dart
+++ b/lib/modules/main/navigation_page.dart
@@ -4,7 +4,6 @@ import 'package:flutter_hooks/flutter_hooks.dart';
 import 'package:go_router/go_router.dart';
 import 'package:hooks_riverpod/hooks_riverpod.dart';
 import 'package:thingsboard_app/constants/app_constants.dart';
-import 'package:thingsboard_app/generated/l10n.dart';
 import 'package:thingsboard_app/locator.dart';
 import 'package:thingsboard_app/modules/main/model/main_navigation_item.dart';
 import 'package:thingsboard_app/modules/main/model/navigation_type.dart';
@@ -13,7 +12,6 @@ import 'package:thingsboard_app/modules/main/providers/navigation_provider.dart'
 import 'package:thingsboard_app/modules/main/widgets/navigation_badge_widget.dart';
 import 'package:thingsboard_app/modules/main/widgets/tb_navigation_bar_widget.dart';
 import 'package:thingsboard_app/utils/services/notification_service.dart';
-import 'package:thingsboard_app/utils/services/overlay_service/i_overlay_service.dart';
 
 class NavigationPage extends HookConsumerWidget {
   const NavigationPage({super.key, required this.child});
@@ -52,22 +50,12 @@ class NavigationPage extends HookConsumerWidget {
     }, [GoRouterState.of(context).uri, items]);
 
     return PopScope(
-      onPopInvokedWithResult: (didPop, res) async {
+      onPopInvokedWithResult: (didPop, res) {
         if (!context.canPop()) {
           if (currentIndex.value != 0) {
             return context.pushReplacement(items.first.path);
           }
-          final confirm = await getIt<IOverlayService>().showConfirmDialog(
-            content:
-                (_) => DialogContent(
-                  title: 'Are you sure you want te exit?',
-                  message: 'Confirm to close the app',
-                  cancel: S.of(context).cancel,
-                ),
-          );
-          if (confirm == true && context.mounted) {
-            SystemNavigator.pop();
-          }
+          SystemNavigator.pop();
         }
       },
       canPop: false,

--- a/lib/modules/main/navigation_page.dart
+++ b/lib/modules/main/navigation_page.dart
@@ -4,8 +4,6 @@ import 'package:flutter_hooks/flutter_hooks.dart';
 import 'package:go_router/go_router.dart';
 import 'package:hooks_riverpod/hooks_riverpod.dart';
 import 'package:thingsboard_app/constants/app_constants.dart';
-import 'package:thingsboard_app/core/auth/login/provider/login_provider.dart';
-import 'package:thingsboard_app/generated/l10n.dart';
 import 'package:thingsboard_app/locator.dart';
 import 'package:thingsboard_app/modules/main/model/main_navigation_item.dart';
 import 'package:thingsboard_app/modules/main/model/navigation_item_data.dart';
@@ -15,7 +13,6 @@ import 'package:thingsboard_app/modules/main/providers/navigation_provider.dart'
 import 'package:thingsboard_app/modules/main/widgets/navigation_badge_widget.dart';
 import 'package:thingsboard_app/modules/main/widgets/tb_navigation_bar_widget.dart';
 import 'package:thingsboard_app/utils/services/notification_service.dart';
-import 'package:thingsboard_app/utils/services/overlay_service/i_overlay_service.dart';
 
 class NavigationPage extends HookConsumerWidget {
   const NavigationPage({super.key, required this.child});
@@ -54,22 +51,12 @@ class NavigationPage extends HookConsumerWidget {
     }, [GoRouterState.of(context).uri, items]);
 
     return PopScope(
-      onPopInvokedWithResult: (didPop, res) async {
+      onPopInvokedWithResult: (didPop, res) {
         if (!context.canPop()) {
           if (currentIndex.value != 0) {
             return context.pushReplacement(items.first.path);
           }
-          final confirm = await getIt<IOverlayService>().showConfirmDialog(
-            content:
-                (_) => DialogContent(
-                  title: 'Are you sure you want te exit?',
-                  message: 'Confirm to close the app',
-                  cancel: S.of(context).cancel,
-                ),
-          );
-          if (confirm == true && context.mounted) {
-            SystemNavigator.pop();
-          }
+          SystemNavigator.pop();
         }
       },
       canPop: false,

--- a/lib/widgets/two_page_view.dart
+++ b/lib/widgets/two_page_view.dart
@@ -3,6 +3,7 @@ import 'package:preload_page_view/preload_page_view.dart';
 
 class TwoPageViewController {
   _TwoPageViewState? _state;
+  final ValueNotifier<int> currentIndex = ValueNotifier<int>(0);
 
  void  setTransitionIndexedStackState(_TwoPageViewState state) {
     _state = state;
@@ -23,6 +24,10 @@ class TwoPageViewController {
   }
 
   int? get index => _state?._selectedIndex;
+
+  void dispose() {
+    currentIndex.dispose();
+  }
 }
 
 class TwoPageView extends StatefulWidget {
@@ -65,6 +70,7 @@ class _TwoPageViewState extends State<TwoPageView> {
   Future<bool> _open(int index, {bool animate = true}) async {
     if (_selectedIndex != index) {
       _selectedIndex = index;
+      widget.controller?.currentIndex.value = _selectedIndex;
       if (index == 0) {
         setState(() {
           _reverse = true;
@@ -83,6 +89,7 @@ class _TwoPageViewState extends State<TwoPageView> {
   Future<bool> _close(int index, {bool animate = true}) async {
     if (_selectedIndex == index) {
       _selectedIndex = index == 1 ? 0 : 1;
+      widget.controller?.currentIndex.value = _selectedIndex;
       await _pageController.animateToPage(
         _selectedIndex,
         duration: widget.duration,
@@ -111,6 +118,7 @@ class _TwoPageViewState extends State<TwoPageView> {
       reverse: _reverse,
       onPageChanged: (int position) {
         _selectedIndex = position;
+        widget.controller?.currentIndex.value = _selectedIndex;
       },
       preloadPagesCount: 2,
       controller: _pageController,

--- a/lib/widgets/two_page_view.dart
+++ b/lib/widgets/two_page_view.dart
@@ -1,9 +1,12 @@
+import 'package:flutter/foundation.dart';
 import 'package:flutter/widgets.dart';
 import 'package:preload_page_view/preload_page_view.dart';
 
 class TwoPageViewController {
   _TwoPageViewState? _state;
-  final ValueNotifier<int> currentIndex = ValueNotifier<int>(0);
+  final ValueNotifier<int> _currentIndex = ValueNotifier<int>(0);
+
+  ValueListenable<int> get currentIndex => _currentIndex;
 
  void  setTransitionIndexedStackState(_TwoPageViewState state) {
     _state = state;
@@ -26,7 +29,7 @@ class TwoPageViewController {
   int? get index => _state?._selectedIndex;
 
   void dispose() {
-    currentIndex.dispose();
+    _currentIndex.dispose();
   }
 }
 
@@ -70,7 +73,7 @@ class _TwoPageViewState extends State<TwoPageView> {
   Future<bool> _open(int index, {bool animate = true}) async {
     if (_selectedIndex != index) {
       _selectedIndex = index;
-      widget.controller?.currentIndex.value = _selectedIndex;
+      widget.controller?._currentIndex.value = _selectedIndex;
       if (index == 0) {
         setState(() {
           _reverse = true;
@@ -89,7 +92,7 @@ class _TwoPageViewState extends State<TwoPageView> {
   Future<bool> _close(int index, {bool animate = true}) async {
     if (_selectedIndex == index) {
       _selectedIndex = index == 1 ? 0 : 1;
-      widget.controller?.currentIndex.value = _selectedIndex;
+      widget.controller?._currentIndex.value = _selectedIndex;
       await _pageController.animateToPage(
         _selectedIndex,
         duration: widget.duration,
@@ -118,7 +121,7 @@ class _TwoPageViewState extends State<TwoPageView> {
       reverse: _reverse,
       onPageChanged: (int position) {
         _selectedIndex = position;
-        widget.controller?.currentIndex.value = _selectedIndex;
+        widget.controller?._currentIndex.value = _selectedIndex;
       },
       preloadPagesCount: 2,
       controller: _pageController,


### PR DESCRIPTION
## Summary

The Android system back button (and iOS edge-swipe) now navigates through dashboard state exactly like the in-app AppBar back arrow, instead of immediately popping the route or showing the exit dialog. This is the PE counterpart of thingsboard/flutter_thingsboard_app#244.

Addresses the remaining system-back behavior reported in #285 — the AppBar arrow was already fixed in v1.8.0, but the hardware/gesture back still diverged.

## Changes

- **Shared `DashboardBackHandler`** — wraps each dashboard page in a `PopScope` and centralizes the back logic (close right layout → WebView `goBack()` → page-specific fallback). Reused by `MainDashboardPage`, `HomeDashboardPage`, `SingleDashboardView`, and `FullscreenDashboardPage`, so the AppBar arrow and system back share one code path.
- **Reactive `TwoPageViewController.currentIndex`** — `MainDashboardPage` now only intercepts back while the dashboard (not the dashboards list) is visible, letting the bottom-nav shell handle tab-switch/exit back as before.
- **Exit dialog removed** — replaced the "Are you sure you want to exit?" confirmation dialogs with a direct app exit, matching standard Android apps (Gmail/YouTube/Slack) and Material guidance. Removed the now-unused `areYouSureYouWantToExit` / `confirmToCloseTheApp` l10n keys across all locales.

PE-specific merge notes: kept `DashboardPermissionErrorView` and `ICustomTranslationService.translate(...)` in the dashboard views, combined with the new `DashboardBackHandler` wrapper.

## Test plan

- [ ] Open a dashboard → system back walks through dashboard states, then closes the dashboard (matches AppBar arrow)
- [ ] Dashboard with a right layout open → system back closes the panel first, then continues
- [ ] Non-home tab (e.g. Alarms) → system back returns to Home tab; from Home → app exits (no dialog)
- [ ] Home dashboard, single dashboard view, and fullscreen dashboard all behave consistently
- [ ] Verify on both Android and iOS