### PR TITLE
Fix raw i18n translation keys displayed for Assets, Devices, Alarms and Customers

### DIFF
--- a/lib/core/entity/entities_base.dart
+++ b/lib/core/entity/entities_base.dart
@@ -12,6 +12,7 @@ import 'package:thingsboard_app/generated/l10n.dart';
 import 'package:thingsboard_app/locator.dart';
 import 'package:thingsboard_app/thingsboard_client.dart' hide Direction;
 import 'package:thingsboard_pe_client/src/model/page/sort_order.dart';
+import 'package:thingsboard_app/utils/services/custom_translation/i_custom_translation_service.dart';
 import 'package:thingsboard_app/utils/services/overlay_service/i_overlay_service.dart';
 import 'package:thingsboard_app/utils/ui/pagination_widgets/first_page_exception_widget.dart';
 
@@ -85,7 +86,9 @@ mixin ContactBasedBase<T, P> on EntitiesBase<T, P> {
                   children: [
                     Expanded(
                       child: Text(
-                        info?.name ?? '',
+                        getIt<ICustomTranslationService>().translate(
+                          info?.name,
+                        ),
                         maxLines: 2,
                         overflow: TextOverflow.ellipsis,
                         style: TbTextStyles.labelLarge.copyWith(

--- a/lib/core/entity/entities_base.dart
+++ b/lib/core/entity/entities_base.dart
@@ -27,6 +27,7 @@ class EntityCardSettings {
 
 mixin EntitiesBase<T, P> {
   final entityDateFormat = DateFormat('yyyy-MM-dd');
+  final ICustomTranslationService customTranslationService = getIt();
 
   String title(BuildContext context);
 
@@ -86,9 +87,7 @@ mixin ContactBasedBase<T, P> on EntitiesBase<T, P> {
                   children: [
                     Expanded(
                       child: Text(
-                        getIt<ICustomTranslationService>().translate(
-                          info?.name,
-                        ),
+                        customTranslationService.translate(info?.name),
                         maxLines: 2,
                         overflow: TextOverflow.ellipsis,
                         style: TbTextStyles.labelLarge.copyWith(

--- a/lib/core/entity/entity_details_page.dart
+++ b/lib/core/entity/entity_details_page.dart
@@ -66,9 +66,7 @@ class _EntityDetailsPageState<T extends Object>
       titleValue = ValueNotifier(widget._defaultTitle);
       entityFuture.then((value) {
         if (value is HasName) {
-          titleValue.value = getIt<ICustomTranslationService>().translate(
-            (value! as HasName).getName(),
-          );
+          titleValue.value = (value! as HasName).getName();
         }
       });
     } else {
@@ -93,7 +91,7 @@ class _EntityDetailsPageState<T extends Object>
                       crossAxisAlignment: CrossAxisAlignment.start,
                       children: [
                         Text(
-                          title,
+                          getIt<ICustomTranslationService>().translate(title),
                           style:
                               widget._subTitle != null
                                   ? Theme.of(context)

--- a/lib/core/entity/entity_details_page.dart
+++ b/lib/core/entity/entity_details_page.dart
@@ -56,6 +56,7 @@ class _EntityDetailsPageState<T extends Object>
     extends State<EntityDetailsPage<T>> {
   late Future<T?> entityFuture;
   late ValueNotifier<String> titleValue;
+  final ICustomTranslationService customTranslationService = getIt();
 
   @override
   void initState() {
@@ -91,7 +92,7 @@ class _EntityDetailsPageState<T extends Object>
                       crossAxisAlignment: CrossAxisAlignment.start,
                       children: [
                         Text(
-                          getIt<ICustomTranslationService>().translate(title),
+                          customTranslationService.translate(title),
                           style:
                               widget._subTitle != null
                                   ? Theme.of(context)

--- a/lib/core/entity/entity_details_page.dart
+++ b/lib/core/entity/entity_details_page.dart
@@ -1,6 +1,8 @@
 import 'package:flutter/material.dart';
 import 'package:thingsboard_app/generated/l10n.dart';
+import 'package:thingsboard_app/locator.dart';
 import 'package:thingsboard_app/thingsboard_client.dart';
+import 'package:thingsboard_app/utils/services/custom_translation/i_custom_translation_service.dart';
 import 'package:thingsboard_app/widgets/tb_app_bar.dart';
 import 'package:thingsboard_app/widgets/tb_progress_indicator.dart';
 
@@ -64,7 +66,9 @@ class _EntityDetailsPageState<T extends Object>
       titleValue = ValueNotifier(widget._defaultTitle);
       entityFuture.then((value) {
         if (value is HasName) {
-          titleValue.value = (value! as HasName).getName();
+          titleValue.value = getIt<ICustomTranslationService>().translate(
+            (value! as HasName).getName(),
+          );
         }
       });
     } else {
@@ -160,7 +164,9 @@ abstract class ContactBasedDetailsPage<T extends Object>
         children: [
           Text(S.of(context).title, style: labelTextStyle),
           Text(
-            entity is HasName ? entity.getName() : (e.name as String? ?? ''),
+            getIt<ICustomTranslationService>().translate(
+              entity is HasName ? entity.getName() : e.name as String?,
+            ),
             style: valueTextStyle,
           ),
           const SizedBox(height: 16),

--- a/lib/modules/alarm/presentation/view/alarm_details_page.dart
+++ b/lib/modules/alarm/presentation/view/alarm_details_page.dart
@@ -13,6 +13,7 @@ import 'package:thingsboard_app/modules/alarm/presentation/widgets/details/alarm
 import 'package:thingsboard_app/modules/alarm/presentation/widgets/details/alarm_details_widget.dart';
 import 'package:thingsboard_app/modules/alarm/presentation/widgets/tb_error_widget.dart';
 import 'package:thingsboard_app/thingsboard_client.dart';
+import 'package:thingsboard_app/utils/services/custom_translation/i_custom_translation_service.dart';
 import 'package:thingsboard_app/utils/services/tb_client_service/i_tb_client_service.dart';
 import 'package:thingsboard_app/widgets/tb_app_bar.dart';
 import 'package:thingsboard_app/widgets/tb_progress_indicator.dart';
@@ -63,7 +64,9 @@ class _AlarmDetailsPageState extends State<AlarmDetailsPage> {
               return Scaffold(
                 appBar: TbAppBar(
                   title: Text(
-                    state.alarmInfo.type,
+                    getIt<ICustomTranslationService>().translate(
+                      state.alarmInfo.type,
+                    ),
                     style: TbTextStyles.titleXs.copyWith(
                       color: Colors.black.withValues(alpha: .87),
                     ),

--- a/lib/modules/alarm/presentation/widgets/alarm_types/alarm_types_widget.dart
+++ b/lib/modules/alarm/presentation/widgets/alarm_types/alarm_types_widget.dart
@@ -5,6 +5,7 @@ import 'package:thingsboard_app/locator.dart';
 import 'package:thingsboard_app/modules/alarm/presentation/bloc/alarm_types/bloc.dart';
 import 'package:thingsboard_app/modules/alarm/presentation/widgets/alarm_filter_widget.dart';
 import 'package:thingsboard_app/modules/alarm/presentation/widgets/alarm_types/types_list_widget.dart';
+import 'package:thingsboard_app/utils/services/custom_translation/i_custom_translation_service.dart';
 import 'package:thingsboard_app/utils/ui/ui_utils.dart';
 
 class AlarmTypesWidget extends StatelessWidget {
@@ -93,7 +94,9 @@ class AlarmTypesWidget extends StatelessWidget {
                             children: [
                               Flexible(
                                 child: Text(
-                                  state.selectedTypes.elementAt(index),
+                                  getIt<ICustomTranslationService>().translate(
+                                    state.selectedTypes.elementAt(index),
+                                  ),
                                   style: TextStyle(
                                     color: Colors.black.withValues(alpha: 0.87),
                                     fontWeight: FontWeight.w400,

--- a/lib/modules/alarm/presentation/widgets/alarm_types/alarm_types_widget.dart
+++ b/lib/modules/alarm/presentation/widgets/alarm_types/alarm_types_widget.dart
@@ -19,6 +19,7 @@ class AlarmTypesWidget extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
+    final customTranslationService = getIt<ICustomTranslationService>();
     return AlarmFilterWidget(
       filterTitle: S.of(context).alarmTypeList,
       child: Container(
@@ -94,7 +95,7 @@ class AlarmTypesWidget extends StatelessWidget {
                             children: [
                               Flexible(
                                 child: Text(
-                                  getIt<ICustomTranslationService>().translate(
+                                  customTranslationService.translate(
                                     state.selectedTypes.elementAt(index),
                                   ),
                                   style: TextStyle(

--- a/lib/modules/alarm/presentation/widgets/alarm_types/types_list_widget.dart
+++ b/lib/modules/alarm/presentation/widgets/alarm_types/types_list_widget.dart
@@ -14,6 +14,7 @@ class TypesListWidget extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
+    final customTranslationService = getIt<ICustomTranslationService>();
     return ConstrainedBox(
       constraints: BoxConstraints(
         maxHeight: MediaQuery.of(context).size.height * 0.7,
@@ -75,9 +76,7 @@ class TypesListWidget extends StatelessWidget {
                         children: [
                           Flexible(
                             child: Text(
-                              getIt<ICustomTranslationService>().translate(
-                                item.type,
-                              ),
+                              customTranslationService.translate(item.type),
                               style: const TextStyle(fontSize: 16, height: 1.5),
                             ),
                           ),

--- a/lib/modules/alarm/presentation/widgets/alarm_types/types_list_widget.dart
+++ b/lib/modules/alarm/presentation/widgets/alarm_types/types_list_widget.dart
@@ -4,6 +4,7 @@ import 'package:thingsboard_app/generated/l10n.dart';
 import 'package:thingsboard_app/locator.dart';
 import 'package:thingsboard_app/modules/alarm/presentation/bloc/alarm_types/bloc.dart';
 import 'package:thingsboard_app/thingsboard_client.dart';
+import 'package:thingsboard_app/utils/services/custom_translation/i_custom_translation_service.dart';
 import 'package:thingsboard_app/widgets/tb_progress_indicator.dart';
 
 class TypesListWidget extends StatelessWidget {
@@ -74,7 +75,9 @@ class TypesListWidget extends StatelessWidget {
                         children: [
                           Flexible(
                             child: Text(
-                              item.type ?? '',
+                              getIt<ICustomTranslationService>().translate(
+                                item.type,
+                              ),
                               style: const TextStyle(fontSize: 16, height: 1.5),
                             ),
                           ),

--- a/lib/modules/alarm/presentation/widgets/alarms_card.dart
+++ b/lib/modules/alarm/presentation/widgets/alarms_card.dart
@@ -18,6 +18,7 @@ class AlarmCard extends StatefulWidget {
 
 class _AlarmCardState extends State<AlarmCard> {
   final entityDateFormat = DateFormat('yyyy-MM-dd');
+  final ICustomTranslationService customTranslationService = getIt();
 
   @override
   Widget build(BuildContext context) {
@@ -54,8 +55,9 @@ class _AlarmCardState extends State<AlarmCard> {
                                 Flexible(
                                   fit: FlexFit.tight,
                                   child: Text(
-                                    getIt<ICustomTranslationService>()
-                                        .translate(widget.alarm.type),
+                                    customTranslationService.translate(
+                                      widget.alarm.type,
+                                    ),
                                     maxLines: 2,
                                     overflow: TextOverflow.ellipsis,
                                     style: TbTextStyles.labelLarge,
@@ -81,8 +83,9 @@ class _AlarmCardState extends State<AlarmCard> {
                                 Flexible(
                                   fit: FlexFit.tight,
                                   child: Text(
-                                    getIt<ICustomTranslationService>()
-                                        .translate(widget.alarm.originatorName),
+                                    customTranslationService.translate(
+                                      widget.alarm.originatorName,
+                                    ),
                                     style: TbTextStyles.bodyMedium.copyWith(
                                       color: Colors.black.withValues(
                                         alpha: .54,

--- a/lib/modules/alarm/presentation/widgets/alarms_card.dart
+++ b/lib/modules/alarm/presentation/widgets/alarms_card.dart
@@ -5,6 +5,7 @@ import 'package:thingsboard_app/config/themes/tb_text_styles.dart';
 import 'package:thingsboard_app/locator.dart';
 import 'package:thingsboard_app/modules/alarm/alarms_base.dart';
 import 'package:thingsboard_app/thingsboard_client.dart';
+import 'package:thingsboard_app/utils/services/custom_translation/i_custom_translation_service.dart';
 import 'package:thingsboard_app/utils/translation_utils.dart';
 
 class AlarmCard extends StatefulWidget {
@@ -53,7 +54,8 @@ class _AlarmCardState extends State<AlarmCard> {
                                 Flexible(
                                   fit: FlexFit.tight,
                                   child: Text(
-                                    widget.alarm.type,
+                                    getIt<ICustomTranslationService>()
+                                        .translate(widget.alarm.type),
                                     maxLines: 2,
                                     overflow: TextOverflow.ellipsis,
                                     style: TbTextStyles.labelLarge,
@@ -79,9 +81,8 @@ class _AlarmCardState extends State<AlarmCard> {
                                 Flexible(
                                   fit: FlexFit.tight,
                                   child: Text(
-                                    widget.alarm.originatorName != null
-                                        ? widget.alarm.originatorName!
-                                        : '',
+                                    getIt<ICustomTranslationService>()
+                                        .translate(widget.alarm.originatorName),
                                     style: TbTextStyles.bodyMedium.copyWith(
                                       color: Colors.black.withValues(
                                         alpha: .54,

--- a/lib/modules/alarm/presentation/widgets/details/alarm_details_widget.dart
+++ b/lib/modules/alarm/presentation/widgets/details/alarm_details_widget.dart
@@ -10,6 +10,7 @@ import 'package:thingsboard_app/locator.dart';
 import 'package:thingsboard_app/modules/alarm/alarms_base.dart';
 import 'package:thingsboard_app/modules/alarm/presentation/widgets/details/alarm_details_content_widget.dart';
 import 'package:thingsboard_app/thingsboard_client.dart';
+import 'package:thingsboard_app/utils/services/custom_translation/i_custom_translation_service.dart';
 import 'package:thingsboard_app/utils/translation_utils.dart';
 import 'package:thingsboard_app/utils/utils.dart';
 
@@ -88,7 +89,9 @@ class _AlarmDetailsWidgetState extends State<AlarmDetailsWidget>
                   ),
                   AlarmDetailsContentWidget(
                     title: S.of(context).type,
-                    details: widget.alarmInfo.type,
+                    details: getIt<ICustomTranslationService>().translate(
+                      widget.alarmInfo.type,
+                    ),
                   ),
                   AlarmDetailsContentWidget(
                     title: S.of(context).severity,
@@ -100,7 +103,9 @@ class _AlarmDetailsWidgetState extends State<AlarmDetailsWidget>
                   ),
                   AlarmDetailsContentWidget(
                     title: S.of(context).originator,
-                    details: widget.alarmInfo.originatorName ?? '',
+                    details: getIt<ICustomTranslationService>().translate(
+                      widget.alarmInfo.originatorName,
+                    ),
                   ),
                   AlarmDetailsContentWidget(
                     title: S.of(context).startTime,

--- a/lib/modules/asset/asset_details_page.dart
+++ b/lib/modules/asset/asset_details_page.dart
@@ -4,6 +4,7 @@ import 'package:thingsboard_app/core/entity/entity_details_page.dart';
 import 'package:thingsboard_app/generated/l10n.dart';
 import 'package:thingsboard_app/locator.dart';
 import 'package:thingsboard_app/thingsboard_client.dart';
+import 'package:thingsboard_app/utils/services/custom_translation/i_custom_translation_service.dart';
 import 'package:thingsboard_app/utils/services/tb_client_service/i_tb_client_service.dart';
 
 class AssetDetailsPage extends EntityDetailsPage<Asset> {
@@ -28,13 +29,19 @@ class AssetDetailsPage extends EntityDetailsPage<Asset> {
         crossAxisAlignment: CrossAxisAlignment.start,
         children: [
           Text(S.of(context).assetName, style: labelTextStyle),
-          Text(entity.name ?? '', style: valueTextStyle),
+          Text(
+            getIt<ICustomTranslationService>().translate(entity.name),
+            style: valueTextStyle,
+          ),
           const SizedBox(height: 16),
           Text(S.of(context).type, style: labelTextStyle),
           Text(entity.type ?? '', style: valueTextStyle),
           const SizedBox(height: 16),
           Text(S.of(context).label, style: labelTextStyle),
-          Text(entity.label ?? '', style: valueTextStyle),
+          Text(
+            getIt<ICustomTranslationService>().translate(entity.label),
+            style: valueTextStyle,
+          ),
         ],
       ),
     );

--- a/lib/modules/asset/assets_base.dart
+++ b/lib/modules/asset/assets_base.dart
@@ -5,7 +5,6 @@ import 'package:thingsboard_app/core/entity/entities_base.dart';
 import 'package:thingsboard_app/generated/l10n.dart';
 import 'package:thingsboard_app/locator.dart';
 import 'package:thingsboard_app/thingsboard_client.dart';
-import 'package:thingsboard_app/utils/services/custom_translation/i_custom_translation_service.dart';
 import 'package:thingsboard_app/utils/services/new_client_page_data.dart';
 import 'package:thingsboard_app/utils/services/tb_client_service/i_tb_client_service.dart';
 
@@ -58,10 +57,12 @@ mixin AssetsBase on EntitiesBase<Asset, PageLink> {
 
   @override
   Widget buildEntityGridCard(BuildContext context, Asset asset) {
-    return Text(getIt<ICustomTranslationService>().translate(asset.name));
+    return Text(customTranslationService.translate(asset.name));
   }
 
   Widget _buildCard(BuildContext context, Asset asset) {
+    final name = customTranslationService.translate(asset.name);
+    final label = customTranslationService.translate(asset.label);
     return Row(
       children: [
         Flexible(
@@ -81,9 +82,7 @@ mixin AssetsBase on EntitiesBase<Asset, PageLink> {
                         children: [
                           Flexible(
                             child: Text(
-                              getIt<ICustomTranslationService>().translate(
-                                asset.name,
-                              ),
+                              name,
                               maxLines: 1,
                               overflow: TextOverflow.ellipsis,
                               style: const TextStyle(
@@ -109,13 +108,11 @@ mixin AssetsBase on EntitiesBase<Asset, PageLink> {
                           ),
                         ],
                       ),
-                      if (asset.label?.isNotEmpty == true)
+                      if (label.isNotEmpty)
                         Padding(
                           padding: const EdgeInsets.only(top: 2),
                           child: Text(
-                            getIt<ICustomTranslationService>().translate(
-                              asset.label,
-                            ),
+                            label,
                             maxLines: 1,
                             overflow: TextOverflow.ellipsis,
                             style: const TextStyle(
@@ -152,6 +149,8 @@ mixin AssetsBase on EntitiesBase<Asset, PageLink> {
   }
 
   Widget _buildListWidgetCard(BuildContext context, Asset asset) {
+    final name = customTranslationService.translate(asset.name);
+    final label = customTranslationService.translate(asset.label);
     return Row(
       mainAxisSize: MainAxisSize.min,
       children: [
@@ -166,9 +165,7 @@ mixin AssetsBase on EntitiesBase<Asset, PageLink> {
                     crossAxisAlignment: CrossAxisAlignment.start,
                     children: [
                       Text(
-                        getIt<ICustomTranslationService>().translate(
-                          asset.name,
-                        ),
+                        name,
                         maxLines: 1,
                         overflow: TextOverflow.ellipsis,
                         style: const TextStyle(
@@ -178,13 +175,11 @@ mixin AssetsBase on EntitiesBase<Asset, PageLink> {
                           height: 1.7,
                         ),
                       ),
-                      if (asset.label?.isNotEmpty == true)
+                      if (label.isNotEmpty)
                         Padding(
                           padding: const EdgeInsets.only(top: 2),
                           child: Text(
-                            getIt<ICustomTranslationService>().translate(
-                              asset.label,
-                            ),
+                            label,
                             maxLines: 1,
                             overflow: TextOverflow.ellipsis,
                             style: const TextStyle(

--- a/lib/modules/asset/assets_base.dart
+++ b/lib/modules/asset/assets_base.dart
@@ -5,6 +5,7 @@ import 'package:thingsboard_app/core/entity/entities_base.dart';
 import 'package:thingsboard_app/generated/l10n.dart';
 import 'package:thingsboard_app/locator.dart';
 import 'package:thingsboard_app/thingsboard_client.dart';
+import 'package:thingsboard_app/utils/services/custom_translation/i_custom_translation_service.dart';
 import 'package:thingsboard_app/utils/services/new_client_page_data.dart';
 import 'package:thingsboard_app/utils/services/tb_client_service/i_tb_client_service.dart';
 
@@ -57,7 +58,7 @@ mixin AssetsBase on EntitiesBase<Asset, PageLink> {
 
   @override
   Widget buildEntityGridCard(BuildContext context, Asset asset) {
-    return Text(asset.name ?? '');
+    return Text(getIt<ICustomTranslationService>().translate(asset.name));
   }
 
   Widget _buildCard(BuildContext context, Asset asset) {
@@ -80,7 +81,9 @@ mixin AssetsBase on EntitiesBase<Asset, PageLink> {
                         children: [
                           Flexible(
                             child: Text(
-                              asset.name ?? '',
+                              getIt<ICustomTranslationService>().translate(
+                                asset.name,
+                              ),
                               maxLines: 1,
                               overflow: TextOverflow.ellipsis,
                               style: const TextStyle(
@@ -110,7 +113,9 @@ mixin AssetsBase on EntitiesBase<Asset, PageLink> {
                         Padding(
                           padding: const EdgeInsets.only(top: 2),
                           child: Text(
-                            asset.label!,
+                            getIt<ICustomTranslationService>().translate(
+                              asset.label,
+                            ),
                             maxLines: 1,
                             overflow: TextOverflow.ellipsis,
                             style: const TextStyle(
@@ -161,7 +166,9 @@ mixin AssetsBase on EntitiesBase<Asset, PageLink> {
                     crossAxisAlignment: CrossAxisAlignment.start,
                     children: [
                       Text(
-                        asset.name,
+                        getIt<ICustomTranslationService>().translate(
+                          asset.name,
+                        ),
                         maxLines: 1,
                         overflow: TextOverflow.ellipsis,
                         style: const TextStyle(
@@ -175,7 +182,9 @@ mixin AssetsBase on EntitiesBase<Asset, PageLink> {
                         Padding(
                           padding: const EdgeInsets.only(top: 2),
                           child: Text(
-                            asset.label!,
+                            getIt<ICustomTranslationService>().translate(
+                              asset.label,
+                            ),
                             maxLines: 1,
                             overflow: TextOverflow.ellipsis,
                             style: const TextStyle(

--- a/lib/modules/device/device_details_page.dart
+++ b/lib/modules/device/device_details_page.dart
@@ -2,6 +2,7 @@ import 'package:flutter/material.dart';
 import 'package:thingsboard_app/core/entity/entity_details_page.dart';
 import 'package:thingsboard_app/locator.dart';
 import 'package:thingsboard_app/thingsboard_client.dart';
+import 'package:thingsboard_app/utils/services/custom_translation/i_custom_translation_service.dart';
 import 'package:thingsboard_app/utils/services/tb_client_service/i_tb_client_service.dart';
 
 class DeviceDetailsPage extends EntityDetailsPage<Device> {
@@ -18,7 +19,7 @@ class DeviceDetailsPage extends EntityDetailsPage<Device> {
   @override
   Widget buildEntityDetails(BuildContext context, Device entity) {
     return ListTile(
-      title: Text(entity.name ?? ''),
+      title: Text(getIt<ICustomTranslationService>().translate(entity.name)),
       subtitle: Text(entity.type ?? ''),
     );
   }

--- a/lib/modules/device/devices_base.dart
+++ b/lib/modules/device/devices_base.dart
@@ -106,9 +106,7 @@ mixin DevicesBase on EntitiesBase<EntityData, EntityDataQuery> {
 
   @override
   Widget buildEntityGridCard(BuildContext context, EntityData device) {
-    return Text(
-      getIt<ICustomTranslationService>().translate(device.field('name')),
-    );
+    return Text(customTranslationService.translate(device.field('name')));
   }
 
   bool displayCardImage(bool listWidgetCard) => listWidgetCard;
@@ -184,6 +182,7 @@ class _DeviceCardState extends State<DeviceCard> {
 
   late Future<CachedDeviceProfileInfo> deviceProfileFuture;
   final tbClient = getIt<ITbClientService>().client;
+  final ICustomTranslationService customTranslationService = getIt();
   @override
   void initState() {
     super.initState();
@@ -222,6 +221,12 @@ class _DeviceCardState extends State<DeviceCard> {
   }
 
   Widget buildCard(BuildContext context) {
+    final name = customTranslationService.translate(
+      widget.device.field('name'),
+    );
+    final label = customTranslationService.translate(
+      widget.device.field('label'),
+    );
     return Stack(
       children: [
         Positioned.fill(
@@ -315,10 +320,7 @@ class _DeviceCardState extends State<DeviceCard> {
                                       Flexible(
                                         fit: FlexFit.tight,
                                         child: Text(
-                                          getIt<ICustomTranslationService>()
-                                              .translate(
-                                                widget.device.field('name'),
-                                              ),
+                                          name,
                                           maxLines: 1,
                                           overflow: TextOverflow.ellipsis,
                                           style: const TextStyle(
@@ -351,17 +353,11 @@ class _DeviceCardState extends State<DeviceCard> {
                                       ),
                                     ],
                                   ),
-                                  if (widget.device
-                                          .field('label')
-                                          ?.isNotEmpty ==
-                                      true)
+                                  if (label.isNotEmpty)
                                     Padding(
                                       padding: const EdgeInsets.only(top: 2),
                                       child: Text(
-                                        getIt<ICustomTranslationService>()
-                                            .translate(
-                                              widget.device.field('label'),
-                                            ),
+                                        label,
                                         maxLines: 1,
                                         overflow: TextOverflow.ellipsis,
                                         style: const TextStyle(
@@ -444,6 +440,12 @@ class _DeviceCardState extends State<DeviceCard> {
   }
 
   Widget buildListWidgetCard(BuildContext context) {
+    final name = customTranslationService.translate(
+      widget.device.field('name'),
+    );
+    final label = customTranslationService.translate(
+      widget.device.field('label'),
+    );
     return Row(
       mainAxisSize: MainAxisSize.min,
       children: [
@@ -516,9 +518,7 @@ class _DeviceCardState extends State<DeviceCard> {
                   children: [
                     Flexible(
                       child: Text(
-                        getIt<ICustomTranslationService>().translate(
-                          widget.device.field('name'),
-                        ),
+                        name,
                         maxLines: 1,
                         overflow: TextOverflow.ellipsis,
                         style: const TextStyle(
@@ -531,13 +531,11 @@ class _DeviceCardState extends State<DeviceCard> {
                     ),
                   ],
                 ),
-                if (widget.device.field('label')?.isNotEmpty == true)
+                if (label.isNotEmpty)
                   Padding(
                     padding: const EdgeInsets.only(top: 2),
                     child: Text(
-                      getIt<ICustomTranslationService>().translate(
-                        widget.device.field('label'),
-                      ),
+                      label,
                       maxLines: 1,
                       overflow: TextOverflow.ellipsis,
                       style: const TextStyle(

--- a/lib/modules/device/devices_base.dart
+++ b/lib/modules/device/devices_base.dart
@@ -15,6 +15,7 @@ import 'package:thingsboard_app/locator.dart';
 import 'package:thingsboard_app/modules/dashboard/domain/entites/dashboard_arguments.dart';
 import 'package:thingsboard_app/thingsboard_client.dart';
 import 'package:thingsboard_app/thingsboard_client_extensions.dart';
+import 'package:thingsboard_app/utils/services/custom_translation/i_custom_translation_service.dart';
 import 'package:thingsboard_app/utils/services/device_profile/device_profile_cache.dart';
 import 'package:thingsboard_app/utils/services/device_profile/model/cached_device_profile.dart';
 import 'package:thingsboard_app/utils/services/entity_query_api.dart';
@@ -105,7 +106,9 @@ mixin DevicesBase on EntitiesBase<EntityData, EntityDataQuery> {
 
   @override
   Widget buildEntityGridCard(BuildContext context, EntityData device) {
-    return Text(device.field('name')!);
+    return Text(
+      getIt<ICustomTranslationService>().translate(device.field('name')),
+    );
   }
 
   bool displayCardImage(bool listWidgetCard) => listWidgetCard;
@@ -312,7 +315,10 @@ class _DeviceCardState extends State<DeviceCard> {
                                       Flexible(
                                         fit: FlexFit.tight,
                                         child: Text(
-                                          widget.device.field('name')!,
+                                          getIt<ICustomTranslationService>()
+                                              .translate(
+                                                widget.device.field('name'),
+                                              ),
                                           maxLines: 1,
                                           overflow: TextOverflow.ellipsis,
                                           style: const TextStyle(
@@ -352,7 +358,10 @@ class _DeviceCardState extends State<DeviceCard> {
                                     Padding(
                                       padding: const EdgeInsets.only(top: 2),
                                       child: Text(
-                                        widget.device.field('label')!,
+                                        getIt<ICustomTranslationService>()
+                                            .translate(
+                                              widget.device.field('label'),
+                                            ),
                                         maxLines: 1,
                                         overflow: TextOverflow.ellipsis,
                                         style: const TextStyle(
@@ -507,7 +516,9 @@ class _DeviceCardState extends State<DeviceCard> {
                   children: [
                     Flexible(
                       child: Text(
-                        widget.device.field('name')!,
+                        getIt<ICustomTranslationService>().translate(
+                          widget.device.field('name'),
+                        ),
                         maxLines: 1,
                         overflow: TextOverflow.ellipsis,
                         style: const TextStyle(
@@ -524,7 +535,9 @@ class _DeviceCardState extends State<DeviceCard> {
                   Padding(
                     padding: const EdgeInsets.only(top: 2),
                     child: Text(
-                      widget.device.field('label')!,
+                      getIt<ICustomTranslationService>().translate(
+                        widget.device.field('label'),
+                      ),
                       maxLines: 1,
                       overflow: TextOverflow.ellipsis,
                       style: const TextStyle(

--- a/lib/utils/services/custom_translation/custom_translation_service.dart
+++ b/lib/utils/services/custom_translation/custom_translation_service.dart
@@ -45,15 +45,22 @@ class TbCustomTranslationService implements ICustomTranslationService {
     _translations = const {};
   }
 
+  /// Accumulates dotted segments on a miss, like ngx-translate's `getValue`:
+  /// PATCH `/translation/custom` expands `a.b` into nested maps, while the
+  /// advanced editor and file upload store the dotted key verbatim.
   String? _lookup(String key) {
     dynamic current = _translations;
-    for (final part in key.split('.')) {
-      if (current is Map<String, dynamic> && current.containsKey(part)) {
-        current = current[part];
-      } else {
-        return null;
+    String? pending;
+    final parts = key.split('.');
+    for (var i = 0; i < parts.length; i++) {
+      pending = pending == null ? parts[i] : '$pending.${parts[i]}';
+      final isLast = i == parts.length - 1;
+      final next = current is Map<String, dynamic> ? current[pending] : null;
+      if (next is Map<String, dynamic> || (isLast && next != null)) {
+        current = next;
+        pending = null;
       }
     }
-    return current is String ? current : null;
+    return pending == null && current is String ? current : null;
   }
 }

--- a/lib/utils/services/custom_translation/i_custom_translation_service.dart
+++ b/lib/utils/services/custom_translation/i_custom_translation_service.dart
@@ -1,6 +1,16 @@
 abstract interface class ICustomTranslationService {
   Future<void> load({String? localeCode});
 
+  /// Resolves `{i18n:key}` White Labeling markers in [value] for display.
+  ///
+  /// Returns `''` for a null or empty [value], the value untouched when it has
+  /// no marker, and leaves a marker in place when its key has no translation.
+  ///
+  /// Display-only: apply at render time and keep raw values for anything the
+  /// backend consumes (search text, alarm type filters, dashboard state).
+  ///
+  /// Unlike web's `UtilsService.customTranslation()`, a marker-free value is
+  /// not looked up as `custom.<value>`, and a null input yields `''`.
   String translate(String? value);
 
   void clear();


### PR DESCRIPTION
## Summary

Fixes PROD-8501 — the mobile app displayed raw `{i18n:custom.translation.key}` strings instead of resolving them via White Labeling custom translations.

Applies the existing `ICustomTranslationService.translate()` (already used by dashboard views) at render time in:

- **Assets** — list/grid cards and details page (name, label)
- **Devices** — list/grid cards and details page (name, label)
- **Alarms** — list card, details page and details widget (type, originator name), plus the alarm type filter list and selected chips
- **Customers** — list card and details page title (via the shared `EntityDetailsPage` title path)

## Field selection

Follows the ticket's STR, which asks for the entity **name and label**. Web has two behaviours here and neither is "the" reference:

- entity list pages translate only the name, via `config.entityTitle` — `assets-table-config.resolver.ts:132`, `devices-table-config.resolver.ts:168`, `customers-table-config.resolver.ts:126`; the `type` and `label` columns have no cell function
- the entities/alarms table widgets run `customTranslation` over *every* cell — `entities-table-widget.component.ts:816`, `alarms-table-widget.component.ts:912` — which covers `label` and `type`

So `label` follows the table-widget behaviour, and `type` stays raw: web's entity lists render the `type` column without a cell function (`devices-table-config.resolver.ts:218`, `assets-table-config.resolver.ts:156`), and these cards correspond to that surface.

## Display-only invariant

`translate()` is applied at render time only. Raw values are deliberately preserved everywhere the backend consumes them:

- `textSearch` in `fetchEntities`
- alarm type filter values (`AlarmTypesSelectedEvent`)
- dashboard navigation params (`entityName`, `entityLabel`, `title`, `createDashboardEntityState`)

`translate(String?)` takes a nullable input and returns non-null (`''` for null or empty), returns the value untouched when it holds no marker, and leaves a marker in place when its key is missing from the translations.

## Known limitations (not addressed here)

- **Search vs. display** — list search is server-side over the raw value while rows render the translated one, so typing what you see returns no results. Web has the same limitation; changing it would diverge from the platform.
- **Bare `custom.<value>` keys** — web's `customTranslation()` also looks a marker-free value up as `custom.<value>` (`utils.service.ts:230`). This app does not. Adding it would mean every entity name gets a lookup, so an asset named `home` would silently render as whatever `custom.home` maps to; needs a product decision, tracked separately.
- **Language switch** — `load()` runs only at login, so switching language in-app leaves WL translations on the previously loaded locale, while web re-fetches the same endpoint on every change. Needs a locale-code decision first (the app ships bare `en`/`ar`/`zh` codes alongside `en_US`-style ones, and a failed load clears translations), tracked separately.

## Testing

- `flutter analyze` — 230 issues, unchanged from the base commit, none new in the touched files
- Manual verification per the ticket STR, with entity names and labels configured as `{i18n:...}` keys in Assets, Devices, Alarms and Customers
- No automated coverage: the repo has no `test/` directory, and `translate()` is not unit-testable as written (`_translations` is reachable only through `load()`, which needs `ITbClientService`). Standing up the first test suite is out of scope for a fix targeting a release branch.

